### PR TITLE
Deprecate TaurusAttribute.isState

### DIFF
--- a/lib/taurus/core/epics/epicsattribute.py
+++ b/lib/taurus/core/epics/epicsattribute.py
@@ -125,8 +125,6 @@ class EpicsAttribute(TaurusAttribute):
     # ~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-
     # Necessary to overwrite from TaurusAttribute
     # ~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-
-    def isState(self):
-        return False  # TODO implement generic
 
     def encode(self, value):
         """encodes the value passed to the write method into

--- a/lib/taurus/core/evaluation/evalattribute.py
+++ b/lib/taurus/core/evaluation/evalattribute.py
@@ -361,9 +361,6 @@ class EvaluationAttribute(TaurusAttribute):
     def isBoolean(self):
         return isinstance(self._value.rvalue, bool)
 
-    def isState(self):
-        return False
-
     def getDisplayValue(self, cache=True):
         return str(self.read(cache=cache).rvalue)
 

--- a/lib/taurus/core/taurusattribute.py
+++ b/lib/taurus/core/taurusattribute.py
@@ -32,7 +32,8 @@ __docformat__ = "restructuredtext"
 import weakref
 
 from .taurusmodel import TaurusModel
-from taurus.core.taurusbasetypes import TaurusElementType, DataType
+from taurus.core.taurusbasetypes import TaurusElementType
+from taurus.core.util.log import deprecation_decorator
 from taurus.external.pint import Quantity, UR
 
 
@@ -116,12 +117,13 @@ class TaurusAttribute(TaurusModel):
     def isNumeric(self):
         return self.type in [DataType.Float, DataType.Integer]
 
+    @deprecation_decorator(rel='>4.0.1', alt='.type==DataType.DevState')
+    def isState(self):
+        return False
+
     #-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-
     # Necessary to overwrite in subclass
     #-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-
-    def isState(self):
-        raise NotImplementedError("Not allowed to call AbstractClass" +
-                                  " TaurusAttribute.isState")
 
     def encode(self, value):
         raise NotImplementedError("Not allowed to call AbstractClass" +

--- a/lib/taurus/qt/qtgui/display/taurusled.py
+++ b/lib/taurus/qt/qtgui/display/taurusled.py
@@ -35,7 +35,7 @@ import operator
 
 from taurus.external.qt import Qt
 
-from taurus.core import DataFormat, AttrQuality
+from taurus.core import DataFormat, AttrQuality, DataType
 from taurus.core.tango import DevState
 
 from taurus.qt.qtgui.base import TaurusBaseWidget
@@ -225,7 +225,7 @@ class TaurusLed(QLed, TaurusBaseWidget):
             klass = _TaurusLedController
         elif model.isBoolean():
             klass = _TaurusLedControllerBool
-        elif model.isState():
+        elif model.type == DataType.DevState:
             klass = _TaurusLedControllerState
         return klass
 


### PR DESCRIPTION
TaurusAttribute declares isState as an abstract method, but it is
tango-centric. All other schemes implement it to return False.
Remove implementations from other schemes and substitute the abstract
method by a (deprecated) base implementation returning False.