### PR TITLE
Fix bug #341 python2.7 setup.py test failed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -158,5 +158,5 @@ setup(name='taurus',
       provides=provides,
       requires=requires,
       extras_require=extras_require,
-      test_suite='taurus.test.testsuite.get_suite',
+      test_suite='taurus.test.testsuite.get_taurus_suite',
       )


### PR DESCRIPTION
get_suite method was renamed to get_taurus_suite when the filter
test feature was implemented. Changing it the python setup test
works again.