### PR TITLE
Add bumpversion support (and bump version to 4.0.2-dev)

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,21 @@
+[bumpversion]
+commit = True
+message = Bump version {current_version} to {new_version}
+tag = False
+tag_name = {new_version}
+current_version = 4.0.2-dev
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?
+serialize = 
+	{major}.{minor}.{patch}-{release}
+	{major}.{minor}.{patch}
+
+[bumpversion:file:lib/taurus/core/release.py]
+search = version = '{current_version}'
+replace = version = '{new_version}'
+
+[bumpversion:part:release]
+optional_value = gamma
+values = 
+	dev
+	gamma
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ develop branch)  won't be reflected in this file.
 
 ## [Unreleased]
 
+### Added
+- bumpversion support
+
+### Changed
+
+### Deprecated
+- `taurus.Release.version_info` and `taurus.Release.revision` variables
+
+### Removed
+
+### Fixed
+
 
 ## [4.0.1] - 2016-07-19
 Jul16 milestone. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,15 +12,9 @@ develop branch)  won't be reflected in this file.
 ### Added
 - bumpversion support
 
-### Changed
 
 ### Deprecated
 - `taurus.Release.version_info` and `taurus.Release.revision` variables
-
-### Removed
-
-### Fixed
-
 
 ## [4.0.1] - 2016-07-19
 Jul16 milestone. 

--- a/lib/taurus/core/release.py
+++ b/lib/taurus/core/release.py
@@ -46,21 +46,25 @@ Release data for the taurus project. It contains the following members:
 # the tarballs and RPMs made by distutils, so it's best to lowercase it.
 name = 'taurus'
 
-# For versions with substrings (like 0.6.16.svn), use an extra . to separate
-# the new substring.  We have to avoid using either dashes or underscores,
-# because bdist_rpm does not accept dashes (an RPM) convention, and
-# bdist_deb does not accept underscores (a Debian convention).
+# we use semantic versioning (http://semver.org/) and we update it using the
+# bumpversion script (https://github.com/peritus/bumpversion)
+version = '4.0.2-dev'
 
+# generate version_info and revision (**deprecated** since version 4.0.2-dev).
+if '-' in version:
+    _v, _rel = version.split('-')
+else:
+    _v, _rel = version, ''
+_v = tuple([int(n) for n in _v.split('.')])
+version_info = _v + (_rel, 0)   # deprecated, do not use
+revision = str(version_info[4])  # deprecated, do not use
 
-version_info = (4, 0, 1, '', 0)
-version = '.'.join(map(str, version_info[:3]))
-revision = str(version_info[4])
 
 description = "A framework for scientific/industrial CLIs and GUIs"
 
 long_description = """Taurus is a python framework for control and data
 acquisition CLIs and GUIs in scientific/industrial environments.
-It supports multiple control systems or data sources: Tango, EPICS, spec...
+It supports multiple control systems or data sources: Tango, EPICS,...
 New control system libraries can be integrated through plugins."""
 
 license = 'LGPL'


### PR DESCRIPTION
Add [bumpversion](https://github.com/peritus/bumpversion) support to taurus. This allows us to keep a consistent version scheme.

With this, the release process would be as follows (it can be done manually or eventually be automated in the Continuous Delivery process):

- We start in develop, with an unreleased version (i.e., with "-dev" suffix). For example, say "4.0.2-dev"
- start release branch with: 
    ```
    git checkout -b release-`bumpversion --dry-run --list release | grep new_version= | sed -r s,"^.*=",,` develop
    ```
   (the branch will be called  "release-4.0.2")

- call `bumpversion release` (version in the release branch will now be "4.0.2")
- work on release branch and commit (if needed)
- edit CHANGELOG.md (if needed)
- merge release branch into master and tag with:
  ```
  git tag `bumpversion --dry-run --list release | grep current_version= | sed -r s,"^.*=",,`
  ```
- merge release branch into develop and bump patch version with `bumpversion patch`(version in develop will now be "4.0.3-dev")
- During the coming development process, any change that adds a new feature should call `bumpversion minor` and any change that produces backwards incompatibility should call `bumpversion major`. Bug fixes do not need to bump the version since we already did just after the release.

