### PR TITLE
Make Project page point to the repo, not issues

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -38,7 +38,7 @@ Projects related to Taurus
     :hidden:
 
     Home Page <http://www.taurus-scada.org>
-    Project Page <https://github.com/taurus-org/taurus/issues>
+    Project Page <https://github.com/taurus-org/taurus>
     Download from PyPI <http://pypi.python.org/pypi/taurus>
     docs
 


### PR DESCRIPTION
The Project Page link in the doc index (only visible on the left bar in RTD)
points to the issues page. It should poit to the root repo page instead.
Change it
