### PR TITLE
Fix MSI creation

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,7 +3,7 @@ commit = True
 message = Bump version {current_version} to {new_version}
 tag = False
 tag_name = {new_version}
-current_version = 4.0.2-dev
+current_version = 4.0.3-alpha
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?
 serialize = 
 	{major}.{minor}.{patch}-{release}
@@ -16,6 +16,6 @@ replace = version = '{new_version}'
 [bumpversion:part:release]
 optional_value = gamma
 values = 
-	dev
+	alpha
 	gamma
 

--- a/lib/taurus/core/release.py
+++ b/lib/taurus/core/release.py
@@ -48,7 +48,7 @@ name = 'taurus'
 
 # we use semantic versioning (http://semver.org/) and we update it using the
 # bumpversion script (https://github.com/peritus/bumpversion)
-version = '4.0.2-dev'
+version = '4.0.3-alpha'
 
 # generate version_info and revision (**deprecated** since version 4.0.2-dev).
 if '-' in version:

--- a/setup.py
+++ b/setup.py
@@ -137,9 +137,15 @@ classifiers = [
     'Topic :: Software Development :: Widget Sets',
 ]
 
+# Unfortunately, distutils.version.StrictVersion does not support semantic
+# versioning (www.semver.org) for pre-releases. This breaks, e.g,  bdist_msi
+# As a workaround, we normalize the version to be acceptable for StrictVersion
+# Note that the normalized version is identical to the semver except for
+# pre-releases (where '-dev' is replaced by 'a0').
+_version = release.version.replace('-dev', 'a0')
 
 setup(name='taurus',
-      version=release.version,
+      version=_version,
       description=release.description,
       long_description=release.long_description,
       author=release.authors['Tiago_et_al'][0],

--- a/setup.py
+++ b/setup.py
@@ -137,15 +137,9 @@ classifiers = [
     'Topic :: Software Development :: Widget Sets',
 ]
 
-# Unfortunately, distutils.version.StrictVersion does not support semantic
-# versioning (www.semver.org) for pre-releases. This breaks, e.g,  bdist_msi
-# As a workaround, we normalize the version to be acceptable for StrictVersion
-# Note that the normalized version is identical to the semver except for
-# pre-releases (where '-dev' is replaced by 'a0').
-_version = release.version.replace('-dev', 'a0')
 
 setup(name='taurus',
-      version=_version,
+      version=release.version,
       description=release.description,
       long_description=release.long_description,
       author=release.authors['Tiago_et_al'][0],


### PR DESCRIPTION
The introduction of proper semver support with bumpversion (#347)
broke the creation of MSI packages (see #352). The reason is that
distutils.version.StrictVersion does not support semantic versioning
for pre-releases. As a workaround, normalize the version to be
acceptable for StrictVersion. This Fixes #352.

Note that the normalized version is identical to the semver except for
pre-releases (where '-dev' is replaced by 'a0').

UPDATE: a different approach was finally selected after this suggestion (https://github.com/taurus-org/taurus/pull/356#discussion_r92418123) by @reszelaz