### PR TITLE
Improve Appveyor builds

### DIFF
--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -10,10 +10,12 @@ environment:
         # Python 2.7 (64)
         - PYTHON_DIR: "C:\\Python27-x64"
           QT_BINDINGS: "PyQt4"
+          TEST_SCRIPT: "ci\\win-test.bat"
 
-#        # Python 2.7
-#        - PYTHON_DIR: "C:\\Python27"
-#          QT_BINDINGS: "PyQt4"
+        # Python 2.7
+        - PYTHON_DIR: "C:\\Python27"
+          QT_BINDINGS: "PyQt4"
+          TEST_SCRIPT: "ci\\win-test.bat"
 
 
 install:
@@ -51,40 +53,8 @@ test_script:
     - "virtualenv --clear %VENV_TEST_DIR%"
     - "%VENV_TEST_DIR%\\Scripts\\activate.bat"
 
-    # Install numpy
-    - "pip install --trusted-host www.silx.org --find-links http://www.silx.org/pub/wheelhouse/ --upgrade numpy"
-
-    # Install Qt binding
-    # Install PyQt4 from www.silx.org and PyQt5/PySide from pypi
-    - "pip install --pre --trusted-host www.silx.org --find-links http://www.silx.org/pub/wheelhouse/ %QT_BINDINGS%"
-
-    # Install lxml
-    - "pip install --pre --trusted-host www.silx.org --find-links http://www.silx.org/pub/wheelhouse/ lxml==3.7.0"
-
-    # Install h5py 
-    - "pip install --pre --trusted-host www.silx.org --find-links http://www.silx.org/pub/wheelhouse/ h5py"
-
-    # Install scipy 
-    - "pip install --pre --trusted-host www.silx.org --find-links http://www.silx.org/pub/wheelhouse/ scipy"
-
-    # Install guiqwt 
-    # TODO, install guiqwt from pypi
-    # - "pip install --upgrade guiqwt"
-
-    # Install the generated taurus wheel package to test it
-    # Make sure it does not come from cache or pypi
-    # At this point all install_requires dependencies MUST be installed
-    # as this is installing only from dist/
-    - "pip install --pre --find-links dist/ --no-cache-dir --no-index taurus"
-
-    # Print Python info
-    - "pip list"
-    
-    # launch tests (for now only a trivial import, since the testsuite
-    # would fail due to missing tango and epics)
-    - "python -c \"import taurus\""
-    # TODO: run testsuite
-    #- "taurustestsuite"
+    # Run the test script
+    - "%TEST_SCRIPT%"
 
     # Leave test virtualenv
     - "%VENV_TEST_DIR%\\Scripts\\deactivate.bat"

--- a/ci/win-test.bat
+++ b/ci/win-test.bat
@@ -1,0 +1,34 @@
+:: Install numpy
+pip install --trusted-host www.silx.org --find-links http://www.silx.org/pub/wheelhouse/ --upgrade numpy
+
+:: Install Qt binding
+:: Install PyQt4 from www.silx.org and PyQt5/PySide from pypi
+pip install --pre --trusted-host www.silx.org --find-links http://www.silx.org/pub/wheelhouse/ %QT_BINDINGS%
+
+:: Install lxml
+pip install --pre --trusted-host www.silx.org --find-links http://www.silx.org/pub/wheelhouse/ lxml==3.7.0
+
+:: Install h5py 
+pip install --pre --trusted-host www.silx.org --find-links http://www.silx.org/pub/wheelhouse/ h5py
+
+:: Install scipy 
+pip install --pre --trusted-host www.silx.org --find-links http://www.silx.org/pub/wheelhouse/ scipy
+
+:: Install guiqwt 
+:: TODO, install guiqwt from pypi
+:: pip install --upgrade guiqwt
+
+:: Install the generated taurus wheel package to test it
+:: Make sure it does not come from cache or pypi
+:: At this point all install_requires dependencies MUST be installed
+:: as this is installing only from dist/
+pip install --pre --find-links dist/ --no-cache-dir --no-index taurus
+
+:: Print Python info
+pip list
+
+:: launch tests (for now only a trivial import, since the testsuite
+:: would fail due to missing tango and epics)
+python -c "import taurus"
+:: TODO: run testsuite
+::taurustestsuite


### PR DESCRIPTION
- Currently appveyor is only building for amd64. Add a build for win32
as well.
- Make the appveyor configuration more modular by calling external batch scripts