### PR TITLE
Fix regression in taurusgui --tango-host

### DIFF
--- a/lib/taurus/core/util/argparse/taurusargparse.py
+++ b/lib/taurus/core/util/argparse/taurusargparse.py
@@ -171,7 +171,11 @@ def init_taurus_args(parser=None, args=None, values=None):
     # initialize tango host
     if options.tango_host is not None:
         tango_factory = taurus.Factory("tango")
-        tango_factory.set_default_tango_host(options.tango_host)
+        tango_host = options.tango_host
+        # Translate the tango host to a valid taurus authority URI
+        if not "//" in tango_host:
+            tango_host = "//{0}".format(options.tango_host)
+        tango_factory.set_default_tango_host(tango_host)
 
     # initialize taurus polling period
     if options.taurus_polling_period is not None:

--- a/lib/taurus/core/util/argparse/taurusargparse.py
+++ b/lib/taurus/core/util/argparse/taurusargparse.py
@@ -103,7 +103,7 @@ def get_taurus_parser(parser=None):
 
         help_tauruslog = "taurus log level. Allowed values are (case insensitive): critical, "\
                          "error, warning/warn, info, debug, trace"
-        help_tangohost = "Tango host name"
+        help_tangohost = "Tango host name (either HOST:PORT or a Taurus URI, e.g. tango://foo:1234)"
         help_tauruspolling = "taurus global polling period in milliseconds"
         help_taurusserial = "taurus serialization mode. Allowed values are (case insensitive): "\
             "serial, concurrent (default)"
@@ -174,7 +174,7 @@ def init_taurus_args(parser=None, args=None, values=None):
         tango_host = options.tango_host
         # Translate the tango host to a valid taurus authority URI
         if not "//" in tango_host:
-            tango_host = "//{0}".format(options.tango_host)
+            tango_host = "tango://{0}".format(tango_host)
         tango_factory.set_default_tango_host(tango_host)
 
     # initialize taurus polling period


### PR DESCRIPTION
Taurusgui --tango-host=$TANGO_HOST raises a TaurusException:
"Invalid default Tango authority name" with taurus4. According
the documentation it should be work, and it is a regression introduced
in taurus4.

This happens due to the change of taurus4 to forze to use strict URIs.
Fix it, translating the given HOST_NAME to a taurus authority URI.