### PR TITLE
Initialize X with thread-safety when using TaurusApplication.

### DIFF
--- a/lib/taurus/qt/qtgui/application/taurusapplication.py
+++ b/lib/taurus/qt/qtgui/application/taurusapplication.py
@@ -196,6 +196,17 @@ class TaurusApplication(Qt.QApplication, Logger):
         if 'cmd_line_parser' in kwargs:
             parser = kwargs.pop('cmd_line_parser')
 
+        #######################################################################
+        # Workaround for XInitThreads-related crash.
+        # Sometimes (e.g. running `taurusgui example01`) one gets the following:
+        # [xcb] Unknown request in queue while dequeuing
+        # [xcb] Most likely this is a multi-threaded client and XInitThreads has not been called
+        # [xcb] Aborting, sorry about that.
+        #
+        # According to http://stackoverflow.com/a/31967769 , it is fixed by:
+        Qt.QCoreApplication.setAttribute(Qt.Qt.AA_X11InitThreads)
+        ######################################################################
+
         try:
             Qt.QApplication.__init__(self, *args, **kwargs)
         except TypeError:


### PR DESCRIPTION
Sometimes (e.g. running `taurusgui example01`) one gets the following:
 [xcb] Unknown request in queue while dequeuing
 [xcb] Most likely this is a multi-threaded client and XInitThreads has
       not been called
 [xcb] Aborting, sorry about that.

 Fix according to http://stackoverflow.com/a/31967769 , by setting:
 `Qt.QCoreApplication.setAttribute(Qt.Qt.AA_X11InitThreads)`