### PR TITLE
 Fix #382 TangoFactory ignores the default_tango_host variable

### DIFF
--- a/lib/taurus/core/tango/tangofactory.py
+++ b/lib/taurus/core/tango/tangofactory.py
@@ -162,10 +162,11 @@ class TangoFactory(Singleton, TaurusFactory, Logger):
         return dict(self.tango_db)
 
     def set_default_tango_host(self, tango_host):
-        """Sets the new default tango host.
+        """Sets the new default tango host. The method will transform the given
+        name to an Authority URI.
 
-        :param tango_host: (str) the new tango host or None to use the defined
-        by $TANGO_HOST env. var
+        :param tango_host: (str) the new tango host. It accepts any valid Tango
+        authority name or None to use the defined by $TANGO_HOST env. var.
         """
         # Translate to Authority URI
         if tango_host and "//" not in tango_host:

--- a/lib/taurus/core/tango/tangofactory.py
+++ b/lib/taurus/core/tango/tangofactory.py
@@ -166,9 +166,16 @@ class TangoFactory(Singleton, TaurusFactory, Logger):
 
         :param tango_host: (str) the new tango host
         """
+        # Translate to Authority URI
+        if "//" not in tango_host:
+            tango_host = "//{0}".format(tango_host)
         self._default_tango_host = tango_host
         self.dft_db = None
 
+    def get_default_tango_host(self):
+        """Retruns the current default tango host
+        """
+        return self._default_tango_host
     def registerAttributeClass(self, attr_name, attr_klass):
         """Registers a new attribute class for the attribute name.
 

--- a/lib/taurus/core/tango/tangofactory.py
+++ b/lib/taurus/core/tango/tangofactory.py
@@ -170,7 +170,8 @@ class TangoFactory(Singleton, TaurusFactory, Logger):
         # Translate to Authority URI
         if tango_host and "//" not in tango_host:
             tango_host = "//{0}".format(tango_host)
-        self._default_tango_host = tango_host
+        v = self.getAuthorityNameValidator()
+        self._default_tango_host = v.getUriGroups(tango_host)["authority"]
         self.tango_alias_devs.clear()
         self.dft_db = None
 

--- a/lib/taurus/core/tango/tangofactory.py
+++ b/lib/taurus/core/tango/tangofactory.py
@@ -171,6 +171,7 @@ class TangoFactory(Singleton, TaurusFactory, Logger):
         if tango_host and "//" not in tango_host:
             tango_host = "//{0}".format(tango_host)
         self._default_tango_host = tango_host
+        self.tango_alias_devs.clear()
         self.dft_db = None
 
     def get_default_tango_host(self):
@@ -288,20 +289,17 @@ class TangoFactory(Singleton, TaurusFactory, Logger):
            :raise: (taurus.core.taurusexception.TaurusException) if the given
                    dev_name is invalid.
         """
+        d = self.tango_devs.get(dev_name)
+        if d is None:
+            d = self.tango_alias_devs.get(dev_name)
+        if d is not None:
+            return d
+
         validator = _Device.getNameValidator()
         groups = validator.getUriGroups(dev_name)
 
         if groups is None:
             raise TaurusException("Invalid Tango device name '%s'" % dev_name)
-
-        d = self.tango_devs.get(dev_name)
-        if d is None:
-            d = self.tango_alias_devs.get(dev_name)
-            if d is not None:
-                auth = validator.getUriGroups(d.getFullName()).get('authority')
-                # Check is the alias belongs to the same authority
-                if auth == groups.get('authority'):
-                    return d
 
         full_dev_name, _, _ = validator.getNames(dev_name)
 

--- a/lib/taurus/core/tango/tangofactory.py
+++ b/lib/taurus/core/tango/tangofactory.py
@@ -164,6 +164,8 @@ class TangoFactory(Singleton, TaurusFactory, Logger):
     def set_default_tango_host(self, tango_host):
         """Sets the new default tango host. The method will transform the given
         name to an Authority URI.
+        
+        .. note:: Calling this method also clears the device alias cache.
 
         :param tango_host: (str) the new tango host. It accepts any valid Tango
         authority name or None to use the defined by $TANGO_HOST env. var.

--- a/lib/taurus/core/tango/tangofactory.py
+++ b/lib/taurus/core/tango/tangofactory.py
@@ -164,10 +164,11 @@ class TangoFactory(Singleton, TaurusFactory, Logger):
     def set_default_tango_host(self, tango_host):
         """Sets the new default tango host.
 
-        :param tango_host: (str) the new tango host
+        :param tango_host: (str) the new tango host or None to use the defined
+        by $TANGO_HOST env. var
         """
         # Translate to Authority URI
-        if "//" not in tango_host:
+        if tango_host and "//" not in tango_host:
             tango_host = "//{0}".format(tango_host)
         self._default_tango_host = tango_host
         self.dft_db = None

--- a/lib/taurus/core/tango/tangovalidator.py
+++ b/lib/taurus/core/tango/tangovalidator.py
@@ -102,7 +102,7 @@ class TangoDeviceNameValidator(TaurusDeviceNameValidator):
 
         authority = groups.get('authority')
         if authority is None:
-            groups['authority'] = authority = format(default_authority)
+            groups['authority'] = authority = default_authority
 
         db = None
         if queryAuth:

--- a/lib/taurus/core/tango/tangovalidator.py
+++ b/lib/taurus/core/tango/tangovalidator.py
@@ -90,19 +90,22 @@ class TangoDeviceNameValidator(TaurusDeviceNameValidator):
         if groups is None:
             return None
 
-        import PyTango
-        default_authority = '//' + PyTango.ApiUtil.get_env_var('TANGO_HOST')
+        default_authority = None
+        if factory is None:
+            from taurus import Factory
+            factory = Factory(scheme=self.scheme)
+        default_authority = factory.get_default_tango_host()
+
+        if default_authority is None:
+            import PyTango
+            default_authority = "//" + PyTango.ApiUtil.get_env_var('TANGO_HOST')
 
         authority = groups.get('authority')
         if authority is None:
-            groups['authority'] = authority = default_authority
+            groups['authority'] = authority = format(default_authority)
 
         db = None
         if queryAuth:
-            # attempt to get an Authority object
-            if factory is None:
-                from taurus import Factory
-                factory = Factory(scheme=self.scheme)
             try:
                 db = factory.getAuthority('tango:%s' % authority)
             except:

--- a/lib/taurus/core/util/argparse/taurusargparse.py
+++ b/lib/taurus/core/util/argparse/taurusargparse.py
@@ -172,9 +172,6 @@ def init_taurus_args(parser=None, args=None, values=None):
     if options.tango_host is not None:
         tango_factory = taurus.Factory("tango")
         tango_host = options.tango_host
-        # Translate the tango host to a valid taurus authority URI
-        if not "//" in tango_host:
-            tango_host = "tango://{0}".format(tango_host)
         tango_factory.set_default_tango_host(tango_host)
 
     # initialize taurus polling period


### PR DESCRIPTION
TangoFactory ignores the set default_value, when you ask for a
Device without define the authority part. It uses the value defined
by the TANGO_HOST env. var. instead of the set _default_tango_host
variable.

The main problem comes from the TangoDevice validator that does not
ask for the set TangoFactory._default_tango_host variable.

Fixes #382 
