### PR TITLE
Fix #387 UnboundLocalError in TangoAttrValue

### DIFF
--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -96,7 +96,8 @@ class TangoAttrValue(TaurusAttrValue):
         if p.has_failed:
             self.error = PyTango.DevFailed(*p.get_err_stack())
         else:
-            if p.is_empty:  # spectra and images can be empty without failing
+            # spectra and images can be empty without failing
+            if p.is_empty and self._attrRef.data_format != DataFormat._0D:
                 dtype = FROM_TANGO_TO_NUMPY_TYPE.get(
                     self._attrRef._tango_data_type)
                 if self._attrRef.data_format == DataFormat._1D:

--- a/lib/taurus/core/tango/test/res/TangoSchemeTest
+++ b/lib/taurus/core/tango/test/res/TangoSchemeTest
@@ -23,8 +23,9 @@
 ##
 #############################################################################
 import numpy
+from time import time
 
-from PyTango import DeviceProxy, AttrWriteType, DevState
+from PyTango import DeviceProxy, AttrWriteType, DevState, AttrQuality
 from PyTango.server import Device, DeviceMeta, attribute, run, command
 
 
@@ -256,7 +257,7 @@ class TangoSchemeTest(Device):
         return self.default_rvalue['bool']
 
     def read_short_scalar_ro(self):
-        return self.default_rvalue['int']
+        return self.default_rvalue['int'], time(), self._quality
 
     def read_short_scalar_ro_nu(self):
         return self.default_rvalue['int']
@@ -444,6 +445,17 @@ class TangoSchemeTest(Device):
         # To setUp the state
         Device.init_device(self)
         self.set_state(DevState.ON)
+        self._quality = AttrQuality.ATTR_VALID
+
+    @command(dtype_in=str)
+    def ChangeShortScalarROQuality(self, quality):
+        quality_states = {"valid": AttrQuality.ATTR_VALID,
+                          "invalid": AttrQuality.ATTR_INVALID,
+                          "changing": AttrQuality.ATTR_CHANGING,
+                          "alarm": AttrQuality.ATTR_ALARM,
+                          "warning": AttrQuality.ATTR_WARNING
+                          }
+        self._quality = quality_states.get(quality) or AttrQuality.ATTR_VALID
 
     @command
     def Reset(self):
@@ -454,6 +466,7 @@ class TangoSchemeTest(Device):
         # so is not possible to use the PyTango.Device API
         dev = DeviceProxy(self.get_name())
         attr_list = list(dev.get_attribute_list())
+        self._quality = AttrQuality.ATTR_VALID
         for attr in attr_list:
             attrInfoex = dev.get_attribute_config(attr)
             if attr.startswith('string') or attr.startswith('boolean') or \


### PR DESCRIPTION
PyTango.DeviceAttribute.isempty returns True with scalar values
and Taurus trusts in this value without check the data_type.
 