### PR TITLE
Fix #361 Taurus widget shows blank label

### DIFF
--- a/lib/taurus/core/tango/util/tango_taurus.py
+++ b/lib/taurus/core/tango/util/tango_taurus.py
@@ -118,7 +118,7 @@ def unit_from_tango(unit):
         unit = None
     try:
         return UR.parse_units(unit)
-    except UndefinedUnitError:
+    except (UndefinedUnitError, UnicodeDecodeError):
         # TODO: Maybe we could dynamically register the unit in the UR
         from taurus import warning
         warning('Unknown unit "%s (will be treated as dimensionless)"', unit)


### PR DESCRIPTION
Taurus widget shows blank label instead of the attribute
representation when it has defined an invalid units
(for pint library).

An UnicodeDecodeError is raising when pint try to decode
the unit. Taurus should return dimensionless unit in these cases.

Fix it, handling the exception and return dimensionless unit when
taurus could not get a valid unit.