### PR TITLE
Fix bug#394 AssertionError in TangoAttribute methods

### DIFF
--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -811,7 +811,11 @@ class TangoAttribute(TaurusAttribute):
             limits = limits[0]
         low, high = limits
         low = Quantity(low)
+        if low.dimensionless:
+            low = Quantity(low, self._units)
         high = Quantity(high)
+        if high.dimensionless:
+            high = Quantity(high, self._units)
         TaurusAttribute.setRange(self, [low, high])
         infoex = self._pytango_attrinfoex
         if low.magnitude != float('-inf'):
@@ -829,7 +833,11 @@ class TangoAttribute(TaurusAttribute):
             limits = limits[0]
         low, high = limits
         low = Quantity(low)
+        if low.dimensionless:
+            low = Quantity(low, self._units)
         high = Quantity(high)
+        if high.dimensionless:
+            high = Quantity(high, self._units)
         TaurusAttribute.setWarnings(self, [low, high])
         infoex = self._pytango_attrinfoex
         if low.magnitude != float('-inf'):
@@ -847,7 +855,11 @@ class TangoAttribute(TaurusAttribute):
             limits = limits[0]
         low, high = limits
         low = Quantity(low)
+        if low.dimensionless:
+            low = Quantity(low, self._units)
         high = Quantity(high)
+        if high.dimensionless:
+            high = Quantity(high, self._units)
         TaurusAttribute.setAlarms(self, [low, high])
         infoex = self._pytango_attrinfoex
         if low.magnitude != float('-inf'):

--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -812,10 +812,10 @@ class TangoAttribute(TaurusAttribute):
         low, high = limits
         low = Quantity(low)
         if low.dimensionless:
-            low = Quantity(low, self._units)
+            low = Quantity(low.magnitude, self._units)
         high = Quantity(high)
         if high.dimensionless:
-            high = Quantity(high, self._units)
+            high = Quantity(high.magnitude, self._units)
         TaurusAttribute.setRange(self, [low, high])
         infoex = self._pytango_attrinfoex
         if low.magnitude != float('-inf'):
@@ -834,10 +834,10 @@ class TangoAttribute(TaurusAttribute):
         low, high = limits
         low = Quantity(low)
         if low.dimensionless:
-            low = Quantity(low, self._units)
+            low = Quantity(low.magnitude, self._units)
         high = Quantity(high)
         if high.dimensionless:
-            high = Quantity(high, self._units)
+            high = Quantity(high.magnitude, self._units)
         TaurusAttribute.setWarnings(self, [low, high])
         infoex = self._pytango_attrinfoex
         if low.magnitude != float('-inf'):
@@ -856,10 +856,10 @@ class TangoAttribute(TaurusAttribute):
         low, high = limits
         low = Quantity(low)
         if low.dimensionless:
-            low = Quantity(low, self._units)
+            low = Quantity(low.magnitude, self._units)
         high = Quantity(high)
         if high.dimensionless:
-            high = Quantity(high, self._units)
+            high = Quantity(high.magnitude, self._units)
         TaurusAttribute.setAlarms(self, [low, high])
         infoex = self._pytango_attrinfoex
         if low.magnitude != float('-inf'):


### PR DESCRIPTION
The TangoAttribute setRange, setAlarms, and setWarnings methods
raise an AssertionError when the attribute has non dimensionless unit
and any of the input parameter does not define the unit. This a
breakup of the back. comp.

Fix it, setting the attribute unit to the dimensionless input.