### PR TITLE
Fix bugs of TaurusDevTree and TaurusDevicePropertyTable in Taurus4

### DIFF
--- a/lib/taurus/qt/qtgui/table/taurusdevicepropertytable.py
+++ b/lib/taurus/qt/qtgui/table/taurusdevicepropertytable.py
@@ -125,7 +125,9 @@ class TaurusPropTable(QtGui.QTableWidget, TaurusBaseWidget):
         elif self.db is None:
             self.warning('Model must be set before calling setTable')
             return
-        self.cellChanged.disconnect(self.valueChanged)
+        try: self.cellChanged.disconnect(self.valueChanged)
+        except: pass
+
         dev_name = str(dev_name)
         self.list_prop = list(self.db.get_device_property_list(dev_name, '*'))
         self.setRowCount(len(self.list_prop))

--- a/lib/taurus/qt/qtgui/table/taurusdevicepropertytable.py
+++ b/lib/taurus/qt/qtgui/table/taurusdevicepropertytable.py
@@ -125,8 +125,10 @@ class TaurusPropTable(QtGui.QTableWidget, TaurusBaseWidget):
         elif self.db is None:
             self.warning('Model must be set before calling setTable')
             return
-        try: self.cellChanged.disconnect(self.valueChanged)
-        except: pass
+        try: 
+            self.cellChanged.disconnect(self.valueChanged)
+        except: 
+            pass
 
         dev_name = str(dev_name)
         self.list_prop = list(self.db.get_device_property_list(dev_name, '*'))

--- a/lib/taurus/qt/qtgui/tree/taurusdevicetree.py
+++ b/lib/taurus/qt/qtgui/tree/taurusdevicetree.py
@@ -267,7 +267,7 @@ class TaurusTreeNodeContainer(object):
         import taurus.qt.qtgui.table
         device = self.getNodeText()
         nameclass = taurus.qt.qtgui.table.TaurusPropTable()
-        nameclass.setTable(device)
+        nameclass.setModel(device)
         nameclass.show()
         # Dialog is used to make new floating panels persistent
         PopupDialog(self, nameclass)
@@ -385,7 +385,7 @@ class TaurusDevTree(TaurusTreeNodeContainer, Qt.QTreeWidget, TaurusBaseWidget):
         self.initConfig()
 
         # Signal
-        self.itemclicked.connect(self.deviceClicked)
+        self.itemClicked.connect(self.deviceClicked)
         self.nodeFound.connect(self.expandNode)
         self.setDragDropMode(Qt.QAbstractItemView.DragDrop)
         self.setModifiableByUser(True)
@@ -963,7 +963,7 @@ class TaurusDevTree(TaurusTreeNodeContainer, Qt.QTreeWidget, TaurusBaseWidget):
                     nodes[0].setSelected(True)
                     self.setCurrentItem(nodes[0])
                     # Searches must not trigger events!
-                    self.deviceSelected(self.getNodeDeviceName(nodes[0]))
+                    self.emitSelected(self.getNodeDeviceName(nodes[0]))
                     self.debug('The selected node is %s' %
                                self.getNodeText(nodes[0]))
                 # Then proceed to expand/close the rest of nodes
@@ -1106,11 +1106,11 @@ class TaurusDevTree(TaurusTreeNodeContainer, Qt.QTreeWidget, TaurusBaseWidget):
 
     def deviceClicked(self, item, column):
         self.trace("In TaurusDevTree.deviceClicked(%s)" % item.text(column))
-        self.deviceSelected(self.getNodeDeviceName())
+        self.emitSelected(self.getNodeDeviceName())
 
-    def deviceSelected(self, device_name=''):
+    def emitSelected(self, device_name=''):
         '''QSIGNAL: this method is used to emit deviceSelected(QString) signal'''
-        self.trace("In TaurusDevTree.deviceSelected(%s)" % device_name)
+        self.trace("In TaurusDevTree.emitSelected(%s)" % device_name)
         try:
             #item = self.currentItem()
             device_name = device_name or self.getNodeDeviceName()  # item.text(0)


### PR DESCRIPTION
Fixed a couple of exceptions that didn't allowed to use TaurusDevTree.

The main issue was that the new deviceSelected signal had a conflict with an already existing deviceSelected method. I renamed the method to emitSelected() to avoid the conflict. 

In addition there was a typo on init method and a mistake on initializing the properties widget from the tree.

