### PR TITLE
Use unitless instead of dimensionless when handling implicit units

### DIFF
--- a/lib/taurus/core/tango/util/tango_taurus.py
+++ b/lib/taurus/core/tango/util/tango_taurus.py
@@ -121,7 +121,7 @@ def unit_from_tango(unit):
     except (UndefinedUnitError, UnicodeDecodeError):
         # TODO: Maybe we could dynamically register the unit in the UR
         from taurus import warning
-        warning('Unknown unit "%s (will be treated as dimensionless)"', unit)
+        warning('Unknown unit "%s (will be treated as unitless)"', unit)
         return UR.parse_units(None)
 
 

--- a/lib/taurus/core/taurusattribute.py
+++ b/lib/taurus/core/taurusattribute.py
@@ -296,12 +296,12 @@ class TaurusAttribute(TaurusModel):
             obj.append(('description', _descr))
 
         if isinstance(self.rvalue, Quantity):
-            idDimensionless = self.rvalue.dimensionless
+            _unitless = self.rvalue.unitless
             range = self._range
             alarm = self._alarm
             warning = self._warning
             if range != [None, None]:
-                if not idDimensionless:
+                if not _unitless:
                     low = range[0]
                     high = range[1]
                 else:
@@ -309,7 +309,7 @@ class TaurusAttribute(TaurusModel):
                     high = range[1].magnitude
                 obj.append(('range', "[%s, %s]" % (low, high)))
             if alarm != [None, None]:
-                if not idDimensionless:
+                if not _unitless:
                     low = alarm[0]
                     high = alarm[1]
                 else:
@@ -317,7 +317,7 @@ class TaurusAttribute(TaurusModel):
                     high = alarm[1].magnitude
                 obj.append(('alarm', "[%s, %s]" % (low, high)))
             if warning != [None, None]:
-                if not idDimensionless:
+                if not _unitless:
                     low = warning[0]
                     high = warning[1]
                 else:

--- a/lib/taurus/qt/qtgui/input/tauruslineedit.py
+++ b/lib/taurus/qt/qtgui/input/tauruslineedit.py
@@ -212,7 +212,7 @@ class TaurusValueLineEdit(Qt.QLineEdit, TaurusBaseWritableWidget):
                 try:
                     q = Quantity(text)
                     # allow implicit units (assume wvalue.units implicitly)
-                    if q.dimensionless:
+                    if q.unitless:
                         q = Quantity(q.magnitude, val.units)
                     return q
                 except:

--- a/lib/taurus/qt/qtgui/table/taurusvaluestable.py
+++ b/lib/taurus/qt/qtgui/table/taurusvaluestable.py
@@ -43,15 +43,15 @@ from taurus.core.util.enumeration import Enumeration
 
 def _value2Quantity(value, units):
     '''
-    Creates a Quantity from value and forces units if the vaule is dimensionless
+    Creates a Quantity from value and forces units if the vaule is unitless
 
     :param value: (int, float or str) a number or a string from which a quantity
                   can be created
-    :param units: (str or Pint units) Units to use if the value is dimensionless
+    :param units: (str or Pint units) Units to use if the value is unitless
     :return: (Quantity)
     '''
     q = Quantity(value)
-    if q.dimensionless:
+    if q.unitless:
         q = Quantity(q, units)
     return q
 

--- a/lib/taurus/qt/qtgui/util/validator.py
+++ b/lib/taurus/qt/qtgui/util/validator.py
@@ -64,7 +64,7 @@ class PintValidator(Qt.QValidator):
         the unit. They will also be used for dimensionality coherence checks.
 
         :param units: (pint.Unit or None). The implicit unit. If None, implicit
-                      dimension is "dimensionless" and no dimensionality checks
+                      dimension is "unitless" and no dimensionality checks
                       will be performed (other than those inherent to range
                       enforcement)
         """
@@ -97,7 +97,7 @@ class PintValidator(Qt.QValidator):
         except:
             return Qt.QValidator.Intermediate, input, pos
         if self._implicit_units is not None:
-            if q.dimensionless:
+            if q.unitless:
                 # "cast" to implicit units
                 q = Quantity(q.magnitude, self.units)
             # check coherence with implicit units


### PR DESCRIPTION
Several parts of taurus handle unitless quantities but check
using the .dimensionless attribute, which is not exactly the same:
e.g., Q_('1 rad') is dimensionless, but not unitless

Fix it by using the .unitless attribute instead.