### PR TITLE
Qt < 4.8 does not define AA_X11InitThreads

### DIFF
--- a/lib/taurus/qt/qtgui/application/taurusapplication.py
+++ b/lib/taurus/qt/qtgui/application/taurusapplication.py
@@ -204,7 +204,10 @@ class TaurusApplication(Qt.QApplication, Logger):
         # [xcb] Aborting, sorry about that.
         #
         # According to http://stackoverflow.com/a/31967769 , it is fixed by:
-        Qt.QCoreApplication.setAttribute(Qt.Qt.AA_X11InitThreads)
+        try:
+            Qt.QCoreApplication.setAttribute(Qt.Qt.AA_X11InitThreads)
+        except AttributeError:
+            pass  # Qt < 4.8 does not define AA_X11InitThreads
         ######################################################################
 
         try:


### PR DESCRIPTION
Apply a try except to avoid error in Taurus using
Qt < 4.8.

Qt < 4.8 does not define AA_X11InitThreads.