### PR TITLE
Add API_PollObjNotFound as EVENT_TO_POLLING_EXCEPTIONS

### DIFF
--- a/lib/taurus/core/tango/enums.py
+++ b/lib/taurus/core/tango/enums.py
@@ -64,6 +64,7 @@ EVENT_TO_POLLING_EXCEPTIONS = ('API_AttributePollingNotStarted',
                                'API_EventTimeout',
                                'API_EventPropertiesNotSet',
                                'API_CommandNotFound',
+                               'API_PollObjNotFound',
 )
 #                                   'API_BadConfigurationProperty')    
 


### PR DESCRIPTION
This is a cherry-pick from develop

When disabling server polling on Tango device servers, Taurus
is not switching to client polling automatically.

Add API_PollObjNotFound to the EVENT_TO_POLLING_EXCEPTIONS enum to
handle the source of this problem.