### PR TITLE
Add parentObj property to TaurusModel

### DIFF
--- a/lib/taurus/core/taurusmodel.py
+++ b/lib/taurus/core/taurusmodel.py
@@ -300,3 +300,5 @@ class TaurusModel(Logger):
     @property
     def fullname(self):
         return self._full_name
+
+    parentObj = property(fget=getParentObj)


### PR DESCRIPTION
Add a parentObj property with getPArentObj as getter to all TaurusModels.
This is useful in connection with fragments, since it allows one to refer to,
 e.g. "tango:a/b/c/d#parentObj.name"  to make a TaurusLabel show "a/b/c"