### PR TITLE
Fix taurusgui main

### DIFF
--- a/lib/taurus/qt/qtgui/display/tauruslabel.py
+++ b/lib/taurus/qt/qtgui/display/tauruslabel.py
@@ -592,12 +592,10 @@ def main():
     if len(args) == 0:
         w = demo()
     else:
-        models = map(str.lower, args)
-
         w = Qt.QWidget()
         layout = Qt.QGridLayout()
         w.setLayout(layout)
-        for model in models:
+        for model in args:
             label = TaurusLabel()
             label.model = model
             layout.addWidget(label)


### PR DESCRIPTION
The tauruslabel example set to lowercase the model.
This breaks the case-sensitive URIs.

Avoid to do it.