### PR TITLE
Fix bug #421 TarurusTrend does no work with boolean_scalar

### DIFF
--- a/lib/taurus/qt/qtgui/extra_guiqwt/curve.py
+++ b/lib/taurus/qt/qtgui/extra_guiqwt/curve.py
@@ -94,7 +94,10 @@ class TaurusCurveItem(CurveItem, TaurusBaseComponent):
     def onCurveDataChanged(self):
         # TODO: Take units into account for displaying curves, axis, etc.
         try:
-            yvalue = self._ycomp.read().rvalue.magnitude
+            if self._ycomp.isNumeric():
+                yvalue = self._ycomp.read().rvalue.magnitude
+            else:
+                yvalue = self._ycomp.read().rvalue
         except:
             yvalue = None
 
@@ -103,7 +106,10 @@ class TaurusCurveItem(CurveItem, TaurusBaseComponent):
 
         # TODO: Take units into account for displaying curves, axis, etc.
         try:
-            xvalue = self._xcomp.read().rvalue.magnitude
+            if self._xcomp.isNumeric():
+                xvalue = self._xcomp.read().rvalue.magnitude
+            else:
+                xvalue = self._xcomp.read().rvalue
         except:
             xvalue = None
 
@@ -225,7 +231,10 @@ class TaurusTrendItem(CurveItem, TaurusBaseComponent):
 
         # update y
         # TODO: Take units into account for displaying curves, axis, etc.
-        self.__yBuffer.append(evt_value.rvalue.magnitude)
+        if self.__yBuffer.isNumeric():
+            self.__yBuffer.append(evt_value.rvalue.magnitude)
+        else:
+            self.__yBuffer.append(evt_value.rvalue)
 
         # update the plot data
         x, y = self.__xBuffer.contents(), self.__yBuffer.contents()

--- a/lib/taurus/qt/qtgui/plot/taurusplot.py
+++ b/lib/taurus/qt/qtgui/plot/taurusplot.py
@@ -650,7 +650,10 @@ class TaurusCurve(Qwt5.QwtPlotCurve, TaurusBaseComponent):
         if attr.data_format == DataFormat._1D:
             # TODO: Adapt all values to be plotted to the same Unit
             if value:
-                self._yValues = numpy.array(value.rvalue.magnitude)
+                if attr.isNumeric():
+                    self._yValues = numpy.array(value.rvalue.magnitude)
+                else:
+                    self._yValues = numpy.array(value.rvalue)
             else:
                 self._yValues = numpy.zeros(0)
             self._xValues = self.getXValues()


### PR DESCRIPTION
Taurus plotting widgets can not plot boolean attributes since
API changes in Taurus 4. They expected numeric values (Quantities).

Fix it, allowing also boolean attributes.

Fixes #421