### PR TITLE
Extend eval scheme to allow usage of arbitrary modules

### DIFF
--- a/doc/source/devel/core_tutorial.rst
+++ b/doc/source/devel/core_tutorial.rst
@@ -98,9 +98,14 @@ Or one that adds noise to a tango image attribute:
     
 ``eval:img={tango:sys/tg_test/1/short_image_ro};img+10*rand(*img.shape)``
 
+And, by using custom evaluators, one can easily access virtually anything
+available from a python module. For example, using the datetime module
+to get today's date as a Taurus attribute:
+
+``eval:@datetime.*/date.today().isoformat()``
+
 See :mod:`taurus.core.evaluation` for a more exhaustive description and some 
-tricks with the Evaluation scheme (e.g. creating custom evaluators to run 
-arbitrary python code).
+tricks with the Evaluation scheme and the custom evaluators.
 
 Now an example for the :mod:`taurus.core.epics` scheme. The model name for the 
 EPICS process variable (PV) "my:example.RBV" is:

--- a/lib/taurus/core/evaluation/__init__.py
+++ b/lib/taurus/core/evaluation/__init__.py
@@ -77,10 +77,13 @@ where:
           - `<modulename>` is a python module name and
 
           - `<classname>` is the name of a class in `<modulename>` that derives
-            from :class:`EvaluationDevice`
+            from :class:`EvaluationDevice`. In the special case that <classname>
+            is "*", an EvaluationDevice will be used, but all symbols from
+            the module <modulename> will be available in it
 
       See :file:`<taurus>/core/evaluation/dev_example.py` for an example of a
-      custom Evaluator
+      custom Evaluator. Also see examples below for usage of the `@foo.*`
+      feature.
 
     - The optional `<subst>` segment is used to provide substitution symbols.
       `<subst>` is a semicolon-separated string of `<key>=<value>` strings.
@@ -108,6 +111,14 @@ Some examples of valid evaluation models are:
     - An attribute that adds noise to a tango image attribute:
 
         `eval:img={tango:sys/tg_test/1/short_image_ro};img+10*rand(*img.shape)`
+
+    - An attribute that accesses a method from a given module (os.path.exists):
+
+        `eval:@os.*/path.exists("/some/file")`
+
+    - Same as before, for getting today's date as an attribute:
+
+        'eval:@datetime.*/date.today().isoformat()'
 
     - A default evaluator device named `foo`:
 

--- a/lib/taurus/core/evaluation/evalvalidator.py
+++ b/lib/taurus/core/evaluation/evalvalidator.py
@@ -148,7 +148,8 @@ class EvaluationDeviceNameValidator(TaurusDeviceNameValidator):
 
     scheme = 'eval'
     authority = EvaluationAuthorityNameValidator.authority
-    _evaluatorname = r'((?P<_evalname>[^/?#:\.=]+)|(?P<_evalclass>(\w+\.)+\w+))'
+    _evaluatorname = r'((?P<_evalname>[^/?#:\.=]+)|' + \
+                     r'(?P<_evalclass>(\w+\.)+(\w+|\*)))'
     devname = r'(?P<devname>@%s)' % _evaluatorname
     path = r'(?!//)/?%s' % devname
     query = '(?!)'

--- a/lib/taurus/core/evaluation/test/test_evalattribute.py
+++ b/lib/taurus/core/evaluation/test/test_evalattribute.py
@@ -233,6 +233,18 @@ from taurus.core.evaluation.evalattribute import EvaluationAttrValue
                                 ),
             expectedshape=(3, 3)
             )
+@insertTest(helper_name='read_attr',
+            attr_fullname='eval:@os.*/path.exists("%s")' % __file__,
+            expected=dict(rvalue=True,
+                          type=DataType.Boolean,
+                          label='path.exists("%s")' % __file__,
+                          writable=False,
+                          ),
+            expected_attrv=dict(rvalue=True,
+                                wvalue=None
+                                ),
+            expectedshape=None
+            )
 class EvalAttributeTestCase(unittest.TestCase):
 
     def read_attr(self, attr_fullname, expected={}, expected_attrv={},

--- a/lib/taurus/core/evaluation/test/test_evalvalidator.py
+++ b/lib/taurus/core/evaluation/test/test_evalvalidator.py
@@ -74,6 +74,8 @@ class EvaluationAuthValidatorTestCase(AbstractNameValidatorTestCase,
 @valid(name='eval:@foo')
 @valid(name='eval:@mymod.Myclass', groups={'devname': '@mymod.Myclass'})
 @valid(name='eval:@mymod.mysubmod.Myclass')
+@valid(name='eval:@mymod.mysubmod.*')
+@valid(name='eval:@mymod.*')
 @valid(name='eval:/@foo', groups={'devname': '@foo', 'path': '/@foo'})
 @valid(name='eval://localhost/@foo')
 @valid(name='eval:@ foo', groups={'devname': '@ foo'})
@@ -112,6 +114,8 @@ class EvaluationDevValidatorTestCase(AbstractNameValidatorTestCase,
 @valid(name='eval:@foo/1')
 @valid(name='eval:@mymod.Myclass/1.2',
        groups={'attrname': '1.2', 'devname': '@mymod.Myclass'})
+@valid(name='eval:@mymod.*/bar',
+       groups={'attrname': 'bar', 'devname': '@mymod.*'})
 @valid(name='eval://linspace(-1, 1, 256)',
        groups={'attrname': 'linspace(-1, 1, 256)',
                '_expr': 'linspace(-1, 1, 256)',


### PR DESCRIPTION
A little known (yet very powerful) feature of the eval scheme is that you can use custom evaluator devices.

The problem with the existing solution is that it forces you to create an ad-hoc class for the custom evaluator. This PR simplifies the creation of custom evaluators. In this new implementation, one can use the syntax `eval:@foo.*` to indicate that an evaluator device should be created which has all symbols from the `foo` module available for the evaluation.

For example, one could do a simple clock with:

```
taurusform 'eval:@datetime.*/datetime.now().isoformat()'
```

Notes:

- This facilitates enormously the access to many sources of data without having to create an specific scheme.
- one big limitation of this is that the attributes are read-only (you would need a proper dedicated scheme for writing)