### PR TITLE
Fix Attribute errors when use eval as default scheme

### DIFF
--- a/lib/taurus/qt/qtgui/panel/taurusform.py
+++ b/lib/taurus/qt/qtgui/panel/taurusform.py
@@ -36,6 +36,7 @@ import PyTango
 
 import taurus.core
 from taurus.core import TaurusDevState
+from taurus import tauruscustomsettings
 
 from taurus.qt.qtcore.mimetypes import (TAURUS_ATTR_MIME_TYPE, TAURUS_DEV_MIME_TYPE,
                                         TAURUS_MODEL_LIST_MIME_TYPE, TAURUS_MODEL_MIME_TYPE)
@@ -195,6 +196,9 @@ class TaurusForm(TaurusWidget):
 
     def chooseModels(self):
         '''launches a model chooser dialog to modify the contents of the form'''
+        default_scheme = getattr(tauruscustomsettings, "DEFAULT_SCHEME", "None")
+        if default_scheme is not "tango":
+            return
         if self.__modelChooserDlg is None:
             self.__modelChooserDlg = Qt.QDialog(self)
             self.__modelChooserDlg.setWindowTitle(

--- a/lib/taurus/qt/qtgui/panel/taurusform.py
+++ b/lib/taurus/qt/qtgui/panel/taurusform.py
@@ -232,7 +232,7 @@ class TaurusForm(TaurusWidget):
 
     def chooseAttrs(self):
         self.info(
-            'TaurusForm.chooseAttrs() ahs been deprecated. Use TaurusForm.chooseModels() instead')
+            'TaurusForm.chooseAttrs() has been deprecated. Use TaurusForm.chooseModels() instead')
         self.chooseModels()
 
     def sizeHint(self):

--- a/lib/taurus/qt/qtgui/plot/taurusplot.py
+++ b/lib/taurus/qt/qtgui/plot/taurusplot.py
@@ -41,6 +41,7 @@ import taurus.core
 from taurus.core.taurusmanager import getSchemeFromName
 from taurus.core.taurusbasetypes import DataFormat
 # TODO: Tango-centric
+from taurus import tauruscustomsettings
 from taurus.core.util.containers import LoopList, CaselessDict, CaselessList
 from taurus.core.util.safeeval import SafeEvaluator
 from taurus.qt.qtcore.util.signal import baseSignal
@@ -2780,6 +2781,10 @@ class TaurusPlot(Qwt5.QwtPlot, TaurusBaseWidget):
         :class:`TaurusModelChooser`) and also to generate raw data or import it
         from files
         '''
+        # It is tango-centric; Check if the default scheme is tango before launching the TaurusModelChooser
+        default_scheme = getattr(tauruscustomsettings, "DEFAULT_SCHEME", "None")
+        if default_scheme is not "tango":
+            return
         if self.DataImportDlg is None:
             from taurus.qt.qtgui.panel import TaurusModelChooser
             self.DataImportDlg = Qt.QDialog(self)


### PR DESCRIPTION
TaurusModelChooser is still Tango-Centric, but it is showed when a model is not given in taurusplot, or taurusform.

Avoid to launch it when tango is not the default scheme.

Fix bug #255.