### PR TITLE
Fix  bug  #440 TaurusForm: drag & drop fails

### DIFF
--- a/lib/taurus/qt/qtgui/base/taurusbase.py
+++ b/lib/taurus/qt/qtgui/base/taurusbase.py
@@ -1528,9 +1528,9 @@ class TaurusBaseWidget(TaurusBaseComponent):
             modelclass = self.getModelClass()
         except:
             modelclass = None
-        if issubclass(modelclass, TaurusDevice):
+        if modelclass and issubclass(modelclass, TaurusDevice):
             mimeData.setData(TAURUS_DEV_MIME_TYPE, modelname)
-        elif issubclass(modelclass, TaurusAttribute):
+        elif modelclass and issubclass(modelclass, TaurusAttribute):
             mimeData.setData(TAURUS_ATTR_MIME_TYPE, modelname)
         return mimeData
 


### PR DESCRIPTION
TaurusForm raises  a TypeError if you try to drag & drop a
taurusdevice model in itself. 

Fix it, avoiding to check issubclass when modelclass is None