### PR TITLE
Fix  Bug 392: Wrong formatting of Tango attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ develop branch)  won't be reflected in this file.
 
 ## Unreleased
 
+### Added
+- Formatting API in TaurusBaseComponent (#444)
+- TangoAttribute.format_spec and taurus.core.util.tangoFormatter
+
+### Deprecated
+- TangoAttribute.format
+
+### Fixed
+- Taurus4 does not follow Tango format (#392)
 
 ## [4.0.3] - 2017-01-16
 [Jan17 milestone](https://github.com/taurus-org/taurus/milestone/1)

--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -30,6 +30,7 @@ __all__ = ["TangoAttribute", "TangoAttributeEventListener", "TangoAttrValue"]
 __docformat__ = "restructuredtext"
 
 # -*- coding: utf-8 -*-
+import re
 import time
 import threading
 import weakref
@@ -921,6 +922,9 @@ class TangoAttribute(TaurusAttribute):
             ###############################################################
             self.format = standard_display_format_from_tango(i.data_type,
                                                              i.format)
+            match = re.search("[^\.]*\.(?P<precision>[0-9]+)[eEfFgG%]", self.format)
+            if match:
+                self.precision = int(match.group(1))
             # self._units and self._display_format is to be used by
             # TangoAttrValue for performance reasons. Do not rely on it in other
             # code

--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -48,7 +48,8 @@ from taurus.core.taurusbasetypes import (TaurusEventType,
                                          DataFormat, DataType)
 from taurus.core.taurusoperation import WriteAttrOperation
 from taurus.core.util.event import EventListener
-from taurus.core.util.log import debug, taurus4_deprecation
+from taurus.core.util.log import (debug, taurus4_deprecation,
+                                  deprecation_decorator)
 
 from taurus.core.tango.enums import (EVENT_TO_POLLING_EXCEPTIONS,
                                      FROM_TANGO_TO_NUMPY_TYPE,
@@ -920,16 +921,21 @@ class TangoAttribute(TaurusAttribute):
             self.tango_writable = i.writable
             self.max_dim = i.max_dim_x, i.max_dim_y
             ###############################################################
-            self.format = standard_display_format_from_tango(i.data_type,
-                                                             i.format)
-            self.format_spec = self.format.lstrip('%')  # format specifier
-            match = re.search("[^\.]*\.(?P<precision>[0-9]+)[eEfFgG%]", self.format)
+            fmt = standard_display_format_from_tango(i.data_type, i.format)
+            self.format_spec = fmt.lstrip('%')  # format specifier
+            match = re.search("[^\.]*\.(?P<precision>[0-9]+)[eEfFgG%]", fmt)
             if match:
                 self.precision = int(match.group(1))
             # self._units and self._display_format is to be used by
             # TangoAttrValue for performance reasons. Do not rely on it in other
             # code
             self._units = units
+
+    @property
+    @deprecation_decorator(alt='format_spec or precision', rel='4.0.4')
+    def format(self):
+        i = self._pytango_attrinfoex
+        return standard_display_format_from_tango(i.data_type, i.format)
 
     @property
     def _tango_data_type(self):

--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -922,6 +922,7 @@ class TangoAttribute(TaurusAttribute):
             ###############################################################
             self.format = standard_display_format_from_tango(i.data_type,
                                                              i.format)
+            self.format_spec = self.format.lstrip('%')  # format specifier
             match = re.search("[^\.]*\.(?P<precision>[0-9]+)[eEfFgG%]", self.format)
             if match:
                 self.precision = int(match.group(1))

--- a/lib/taurus/core/tango/util/__init__.py
+++ b/lib/taurus/core/tango/util/__init__.py
@@ -27,4 +27,4 @@
 
 __docformat__ = 'restructuredtext'
 
-from formatter import *
+from formatter import tangoFormatter

--- a/lib/taurus/core/tango/util/__init__.py
+++ b/lib/taurus/core/tango/util/__init__.py
@@ -26,3 +26,5 @@
 """The sardana package. It contains specific part of sardana"""
 
 __docformat__ = 'restructuredtext'
+
+from formatter import *

--- a/lib/taurus/core/tango/util/formatter.py
+++ b/lib/taurus/core/tango/util/formatter.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+
+##############################################################################
+##
+# This file is part of Taurus, a Tango User Interface Library
+##
+# http://www.tango-controls.org/static/taurus/latest/doc/html/index.html
+##
+# Copyright 2011 CELLS / ALBA Synchrotron, Bellaterra, Spain
+##
+# Taurus is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+##
+# Taurus is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+##
+# You should have received a copy of the GNU Lesser General Public License
+# along with Taurus.  If not, see <http://www.gnu.org/licenses/>.
+##
+##############################################################################
+
+__all__ = ["tangoFormatter"]
+
+def tangoFormatter(dtype=None, basecomponent=None, **kwargs):
+    """
+    The tango formatter callable. Returns the string formatting base on
+    the Tango Attribute configuration `format` (Display.Format in Tango DB)
+
+    :param dtype: (object) data type
+    :param basecomponent: widget
+    :param kwargs: other keyword arguments
+
+    :return: the string formatting
+    """
+    fmt = "{0}"
+    if basecomponent is not None:
+        # get the TangoAttribute Spec format
+        spec_format = basecomponent.modelObj.format[1:]
+        if dtype is Quantity:
+            fmt = "{{:~{spec_format}}}".format(tformat=spec_format)
+        else:
+            fmt = "{{:{spec_format}}}".format(tformat=spec_format)
+
+    return fmt

--- a/lib/taurus/core/tango/util/formatter.py
+++ b/lib/taurus/core/tango/util/formatter.py
@@ -27,12 +27,12 @@ __all__ = ["tangoFormatter"]
 
 def tangoFormatter(dtype=None, basecomponent=None, **kwargs):
     """
-    The tango formatter callable. Returns the string formatting base on
-    the Tango Attribute configuration `format` (Display.Format in Tango DB)
+    The tango formatter callable. Returns a format string based on
+    the `format` Tango Attribute configuration (Display.Format in Tango DB)
 
-    :param dtype: (object) data type
-    :param basecomponent: widget
-    :param kwargs: other keyword arguments
+    :param dtype: (type) type of the value object
+    :param basecomponent: the widget whose display is to be formatted
+    :param kwargs: other keyword arguments (ignored)
 
     :return: the string formatting
     """

--- a/lib/taurus/core/tango/util/formatter.py
+++ b/lib/taurus/core/tango/util/formatter.py
@@ -25,24 +25,20 @@
 
 __all__ = ["tangoFormatter"]
 
-def tangoFormatter(dtype=None, basecomponent=None, **kwargs):
+from taurus.external.pint import Quantity
+
+def tangoFormatter(dtype=None, **kwargs):
     """
     The tango formatter callable. Returns a format string based on
     the `format` Tango Attribute configuration (Display.Format in Tango DB)
 
     :param dtype: (type) type of the value object
-    :param basecomponent: the widget whose display is to be formatted
     :param kwargs: other keyword arguments (ignored)
 
     :return: the string formatting
     """
-    fmt = "{0}"
-    if basecomponent is not None:
-        # get the TangoAttribute Spec format
-        spec_format = basecomponent.modelObj.format[1:]
-        if dtype is Quantity:
-            fmt = "{{:~{spec_format}}}".format(tformat=spec_format)
-        else:
-            fmt = "{{:{spec_format}}}".format(tformat=spec_format)
-
+    if dtype is Quantity:
+        fmt = "{:~{bc.modelObj.format_spec}}"
+    else:
+        fmt = "{:{bc.modelObj.format_spec}}"
     return fmt

--- a/lib/taurus/core/tango/util/tango_taurus.py
+++ b/lib/taurus/core/tango/util/tango_taurus.py
@@ -181,3 +181,26 @@ def standard_display_format_from_tango(dtype, fmt):
 def display_format_from_tango(dtype, fmt):
     fmt = standard_display_format_from_tango(dtype, fmt)
     return fmt.replace('%s', '!s').replace('%r', '!r').replace('%', '')
+
+
+def tangoFormatter(dtype=None, basecomponent=None, **kwargs):
+    """
+    The tango formatter callable. Returns the string formatting base on
+    the Tango Attribute configuration `format` (Display.Format in Tango DB)
+
+    :param dtype: (object) data type
+    :param basecomponent: widget
+    :param kwargs: other keyword arguments
+
+    :return: the string formatting
+    """
+    fmt = "{0}"
+    if basecomponent is not None:
+        # get the TangoAttribute Spec format
+        spec_format = basecomponent.modelObj.format[1:]
+        if dtype is Quantity:
+            fmt = "{{:~{spec_format}}}".format(tformat=spec_format)
+        else:
+            fmt = "{{:{spec_format}}}".format(tformat=spec_format)
+
+    return fmt

--- a/lib/taurus/core/tango/util/tango_taurus.py
+++ b/lib/taurus/core/tango/util/tango_taurus.py
@@ -183,24 +183,3 @@ def display_format_from_tango(dtype, fmt):
     return fmt.replace('%s', '!s').replace('%r', '!r').replace('%', '')
 
 
-def tangoFormatter(dtype=None, basecomponent=None, **kwargs):
-    """
-    The tango formatter callable. Returns the string formatting base on
-    the Tango Attribute configuration `format` (Display.Format in Tango DB)
-
-    :param dtype: (object) data type
-    :param basecomponent: widget
-    :param kwargs: other keyword arguments
-
-    :return: the string formatting
-    """
-    fmt = "{0}"
-    if basecomponent is not None:
-        # get the TangoAttribute Spec format
-        spec_format = basecomponent.modelObj.format[1:]
-        if dtype is Quantity:
-            fmt = "{{:~{spec_format}}}".format(tformat=spec_format)
-        else:
-            fmt = "{{:{spec_format}}}".format(tformat=spec_format)
-
-    return fmt

--- a/lib/taurus/core/taurusattribute.py
+++ b/lib/taurus/core/taurusattribute.py
@@ -75,7 +75,7 @@ class TaurusAttribute(TaurusModel):
         self._range = [None, None]
         self._alarm = [None, None]
         self._warning = [None, None]
-        self._precision = None
+        self.precision = None
 
     def cleanUp(self):
         self.trace("[TaurusAttribute] cleanUp")
@@ -402,12 +402,6 @@ class TaurusAttribute(TaurusModel):
         v = self.read(cache)
         return isinstance(v.rvalue, bool)
 
-    def setPrecision(self, value):
-        self._precision = value
-
-    def getPrecision(self):
-        return self._precision
-
     @property
     def description(self):
         return self._description
@@ -456,4 +450,3 @@ class TaurusAttribute(TaurusModel):
     range = property(getRange, setRange)
     warnings = property(getWarnings, setWarnings)
     alarms = property(getAlarms, setAlarms)
-    precision = property(getPrecision, setPrecision)

--- a/lib/taurus/core/taurusattribute.py
+++ b/lib/taurus/core/taurusattribute.py
@@ -75,6 +75,7 @@ class TaurusAttribute(TaurusModel):
         self._range = [None, None]
         self._alarm = [None, None]
         self._warning = [None, None]
+        self._precision = None
 
     def cleanUp(self):
         self.trace("[TaurusAttribute] cleanUp")
@@ -401,6 +402,12 @@ class TaurusAttribute(TaurusModel):
         v = self.read(cache)
         return isinstance(v.rvalue, bool)
 
+    def setPrecision(self, value):
+        self._precision = value
+
+    def getPrecision(self):
+        return self._precision
+
     @property
     def description(self):
         return self._description
@@ -449,3 +456,4 @@ class TaurusAttribute(TaurusModel):
     range = property(getRange, setRange)
     warnings = property(getWarnings, setWarnings)
     alarms = property(getAlarms, setAlarms)
+    precision = property(getPrecision, setPrecision)

--- a/lib/taurus/qt/qtgui/base/taurusbase.py
+++ b/lib/taurus/qt/qtgui/base/taurusbase.py
@@ -733,7 +733,7 @@ class TaurusBaseComponent(TaurusListener, BaseConfigurableClass):
         :param dtype: (object) data type
         :param kwargs: other keyword arguments
         """
-        if not isinstance(self.FORMAT, str):
+        if not isinstance(self.FORMAT, basestring):
             # unbound method to callable
             if isinstance(self.FORMAT, MethodType):
                 self.FORMAT = self.FORMAT.__func__

--- a/lib/taurus/qt/qtgui/base/taurusbase.py
+++ b/lib/taurus/qt/qtgui/base/taurusbase.py
@@ -128,6 +128,7 @@ class TaurusBaseComponent(TaurusListener, BaseConfigurableClass):
 
     # Dictionary with the default sting formatting  codifications
     defaultFormatDict = {float: "{:.{precision}f}",
+                         Enum: "{0.name}",
                          Quantity: "{:~.{precision}f}"
                          }
 
@@ -695,20 +696,6 @@ class TaurusBaseComponent(TaurusListener, BaseConfigurableClass):
         :param v: (object) the value to be translated to string
 
         :return: (str) a string representing the given value
-        """
-        if isinstance(v, Enum):
-            v = v.name
-        return self._applyFormat(v)
-
-
-    def _applyFormat(self, v):
-        """Returns a string formatting of the given value.
-        If the string format can not be applied to the given value (raise an exception)
-        the string format of the attribute will be applied.
-
-        :param v: (object) the reference value to calculate its type
-
-        :return: (str) a string formatting of the given value
         """
         if self._format is None:
             self._updateFormat(type(v))

--- a/lib/taurus/qt/qtgui/base/taurusbase.py
+++ b/lib/taurus/qt/qtgui/base/taurusbase.py
@@ -546,7 +546,6 @@ class TaurusBaseComponent(TaurusListener, BaseConfigurableClass):
                 modelName = modelClass.buildModelName(parent_model, modelName)
         self._detach()
         self.modelName = modelName
-        self.resetFormat()
         # update modelFragmentName
         try:
             scheme = self.getTaurusManager().getScheme(modelName)
@@ -1046,6 +1045,7 @@ class TaurusBaseComponent(TaurusListener, BaseConfigurableClass):
 
         :param model: (str) the new model name"""
         self.setModelCheck(model)
+        self.resetFormat()
         self.updateStyle()
 
     def setModelCheck(self, model, check=True):

--- a/lib/taurus/qt/qtgui/base/taurusbase.py
+++ b/lib/taurus/qt/qtgui/base/taurusbase.py
@@ -73,6 +73,8 @@ def defaultFormatter(dtype=None, basecomponent=None, **kwargs):
     :return: (str) The string formatting codified in the `basecomponent.defaultFormats` dict
     according the given type or the string formatting.
     """
+    if issubclass(dtype, Enum):
+        dtype = Enum
     return basecomponent.defaultFormatDict.get(dtype, "{0}")
 
 

--- a/lib/taurus/qt/qtgui/base/taurusbase.py
+++ b/lib/taurus/qt/qtgui/base/taurusbase.py
@@ -98,9 +98,9 @@ class TaurusBaseComponent(TaurusListener, BaseConfigurableClass):
     FORMAT = defaultFormatter
 
     # Dictionary mapping dtypes to format strings
-    defaultFormatDict = {float: "{:.{precision}f}",
+    defaultFormatDict = {float: "{:.{bc.modelObj.precision}f}",
                          Enum: "{0.name}",
-                         Quantity: "{:~.{precision}f}"
+                         Quantity: "{:~.{bc.modelObj.precision}f}"
                          }
 
     taurusEvent = baseSignal('taurusEvent', object, object, object)
@@ -706,16 +706,16 @@ class TaurusBaseComponent(TaurusListener, BaseConfigurableClass):
         :return: (str) a string representing the given value
         """
         if self._format is None:
-            self._updateFormat(type(v))
-
-        if self.modelObj is not None:
-            precision = self.modelObj.precision
-        else:
-            precision = None
-
+            try:
+                self._updateFormat(type(v))
+            except Exception, e:
+                self.warning(('Cannot update format. Reverting to default.' +
+                              ' Reason: %r'), e)
+                self.setFormat(defaultFormatter)
         try:
-            fmt_v = self._format.format(v, precision=precision)
+            fmt_v = self._format.format(v, bc=self)
         except Exception:
+            self.debug("Invalid format %r for %r. Using '{0}'", self._format, v)
             fmt_v = "{0}".format(v)
 
         return fmt_v

--- a/lib/taurus/qt/qtgui/display/test/test_tauruslabel.py
+++ b/lib/taurus/qt/qtgui/display/test/test_tauruslabel.py
@@ -171,6 +171,94 @@ class TaurusLabelTest2(TangoSchemeTestLauncher, BaseWidgetTestCase,
         self.assertMaxDeprecations(maxdepr)
 
 
+def baseFormatter1(dtype, **kwargs):
+    return "{:~.1f}"
+
+
+def baseFormatter2(dtype, **kwargs):
+    return dtype.__name__
+
+
+@insertTest(helper_name='checkFormat',
+            model='eval:Q(5)#rvalue.magnitude',
+            formatter=baseFormatter2,
+            expected="int",
+            test_skip="Skipped test due to bug #433")
+@insertTest(helper_name='checkFormat',
+            model='eval:Q("5m")#rvalue.units',
+            formatter=baseFormatter2,
+            expected="Unit")
+@insertTest(helper_name='checkFormat',
+            model='eval:1.2345',
+            formatter=baseFormatter1,
+            expected="1.2")
+@insertTest(helper_name='checkFormat',
+            model='eval:"hello"',
+            formatter=baseFormatter1,
+            expected="hello")
+@insertTest(helper_name='checkFormat',
+            model='eval:"hello"',
+            formatter=baseFormatter2,
+            expected="str")
+@insertTest(helper_name='checkFormat',
+            model='eval:"hello"',
+            formatter=None,
+            expected="hello")
+@insertTest(helper_name='checkFormat',
+            model='eval:1.2345',
+            formatter='{:~.3f}',
+            expected="1.234")
+@insertTest(helper_name='checkFormat',
+            model='eval:1.2345',
+            formatter='{:.3f}',
+            expected="1.234 dimensionless")
+class TaurusLabelFormat(BaseWidgetTestCase, unittest.TestCase):
+    '''
+    Specific tests for testing the Formatting API with TaurusLabel
+    instances
+    '''
+
+    _klass = TaurusLabel
+
+    def checkFormat(self, model, formatter, expected):
+        if formatter is not None:
+            self._widget.setFormat(formatter)
+            # self._widget.FORMAT = formatter
+            # self._widget.updateFormat()
+        self._widget.setModel(model)
+        self.processEvents(repetitions=50, sleep=.1)
+
+        got = self._widget.text()
+        msg = ('wrong text for "%s":\n expected: %s\n got: %s' %
+               (model, expected, got))
+        self.assertEqual(got, expected, msg)
+
+
+
+@insertTest(helper_name='checkFormat',
+            model='eval:1.2345',
+            formatter='{:.3f}',
+            expected="1.234 dimensionless")
+@insertTest(helper_name='checkFormat',
+            model='eval:1.2345',
+            formatter=None,
+            expected="1.2")
+class TaurusLabelFormatClass(TaurusLabelFormat):
+    '''
+    Specific tests for testing the Formatting API with TaurusLabel
+    '''
+
+    _klass = TaurusLabel
+
+    def setUp(self):
+        TaurusLabelFormat.setUp(self)
+        self._defaultFormatter = TaurusLabel.FORMAT
+        TaurusLabel.FORMAT = baseFormatter1
+
+    def tearDown(self):
+        TaurusLabel.FORMAT = self._defaultFormatter
+
+
 #
 # if __name__ == "__main__":
 #     unittest.main()

--- a/lib/taurus/qt/qtgui/display/test/test_tauruslabel.py
+++ b/lib/taurus/qt/qtgui/display/test/test_tauruslabel.py
@@ -212,11 +212,11 @@ def baseFormatter2(dtype, **kwargs):
             model='eval:1.2345',
             formatter='{:.3f}',
             expected="1.234 dimensionless")
-class TaurusLabelFormat(BaseWidgetTestCase, unittest.TestCase):
-    '''
+class TaurusLabelFormatTest(BaseWidgetTestCase, unittest.TestCase):
+    """
     Specific tests for testing the Formatting API with TaurusLabel
     instances
-    '''
+    """
 
     _klass = TaurusLabel
 
@@ -243,15 +243,15 @@ class TaurusLabelFormat(BaseWidgetTestCase, unittest.TestCase):
             model='eval:1.2345',
             formatter=None,
             expected="1.2")
-class TaurusLabelFormatClass(TaurusLabelFormat):
-    '''
+class TaurusLabelFormatClassTest(TaurusLabelFormatTest):
+    """
     Specific tests for testing the Formatting API with TaurusLabel
-    '''
+    """
 
     _klass = TaurusLabel
 
     def setUp(self):
-        TaurusLabelFormat.setUp(self)
+        TaurusLabelFormatTest.setUp(self)
         self._defaultFormatter = TaurusLabel.FORMAT
         TaurusLabel.FORMAT = baseFormatter1
 

--- a/lib/taurus/qt/qtgui/display/test/test_tauruslabel.py
+++ b/lib/taurus/qt/qtgui/display/test/test_tauruslabel.py
@@ -95,7 +95,7 @@ testOldFgroles = functools.partial(insertTest, helper_name='text', maxdepr=1,
 
 
 @testOldFgroles(fgRole='value', expected='1.23 mm')
-@testOldFgroles(fgRole='w_value', expected='0.0 mm')
+@testOldFgroles(fgRole='w_value', expected='0.00 mm')
 @testOldFgroles(fgRole='state', expected='Ready')
 @testOldFgroles(fgRole='quality', expected='ATTR_VALID')
 @testOldFgroles(fgRole='none', expected='')

--- a/lib/taurus/qt/qtgui/panel/taurusvalue.py
+++ b/lib/taurus/qt/qtgui/panel/taurusvalue.py
@@ -192,6 +192,8 @@ class DefaultReadWidgetLabel(ExpandingLabel):
             return
         if model_obj.getType() in (DataType.Integer, DataType.Float):
             fgrole += '.magnitude'
+            # Force to recalculate the (display) format
+            self.resetFormat()
         self.setFgRole(fgrole)
 
 

--- a/lib/taurus/qt/qtgui/panel/taurusvalue.py
+++ b/lib/taurus/qt/qtgui/panel/taurusvalue.py
@@ -192,8 +192,6 @@ class DefaultReadWidgetLabel(ExpandingLabel):
             return
         if model_obj.getType() in (DataType.Integer, DataType.Float):
             fgrole += '.magnitude'
-            # Force to recalculate the (display) format
-            self.resetFormat()
         self.setFgRole(fgrole)
 
 

--- a/lib/taurus/qt/qtgui/panel/test/test_taurusvalue.py
+++ b/lib/taurus/qt/qtgui/panel/test/test_taurusvalue.py
@@ -36,7 +36,7 @@ DEV_NAME = TangoSchemeTestLauncher.DEV_NAME
 
 @insertTest(helper_name='texts',
             model='tango:' + DEV_NAME + '/double_scalar',
-            expected=('double_scalar', '1.23', '0.0 mm', 'mm'),
+            expected=('double_scalar', '1.23', '0.00 mm', 'mm'),
             # expected=('double_scalar', '1.23', '0.0', 'mm'),
             # TODO: change taurusvalue's line edit to hide units
             )


### PR DESCRIPTION
According the discussion in the ticket #392:
- We add a "precision" attribute to the TaurusAttribute class with the same meaning as in pyEpics ("number of decimal places of precision for floating point values")
- We encode/decode it for each scheme (e.g. for tango, we would have: format="%6.2f" <--> precision=2 )
- We make the display widgets use this precision as a hint for display
- We add an API to set a formatter in TaurusBaseComponent (allowing python str format or callable)
