### PR TITLE
Fix bug #398 taurus.qt.qtgui fails to import

### DIFF
--- a/lib/taurus/qt/qtgui/util/tauruscolor.py
+++ b/lib/taurus/qt/qtgui/util/tauruscolor.py
@@ -37,7 +37,6 @@ from taurus.external.qt import Qt
 from taurus.core.util.colors import ColorPalette, \
     DEVICE_STATE_DATA, ATTRIBUTE_QUALITY_DATA
 from taurus.core.taurusbasetypes import AttrQuality
-from taurus.core.tango import DevState  # TODO: Tango-centric
 
 
 class QtColorPalette(ColorPalette):
@@ -96,6 +95,13 @@ class QtColorPalette(ColorPalette):
         return (b[name], f[name])
 
 
-QT_DEVICE_STATE_PALETTE = QtColorPalette(DEVICE_STATE_DATA, DevState)
+
 QT_ATTRIBUTE_QUALITY_PALETTE = QtColorPalette(ATTRIBUTE_QUALITY_DATA,
                                               AttrQuality)
+
+try:
+    # TODO: Tango-centric
+    from taurus.core.tango import DevState
+    QT_DEVICE_STATE_PALETTE = QtColorPalette(DEVICE_STATE_DATA, DevState)
+except ImportError:
+    QT_DEVICE_STATE_PALETTE = QtColorPalette(DEVICE_STATE_DATA, {})


### PR DESCRIPTION
taurus.qt.qtgui fails to import if PyTango is not installed.

Since taurus.qt.qtgui core is still not Tango independent,
as a workarround the exception is catching to avoid the ImportError

Fixes: #398 