### PR TITLE
Fix Bug #433 Unexpected rvalue type in eval attribute (with quantities)

### DIFF
--- a/lib/taurus/core/evaluation/evalattribute.py
+++ b/lib/taurus/core/evaluation/evalattribute.py
@@ -334,7 +334,10 @@ class EvaluationAttribute(TaurusAttribute):
         try:
             evaluator = self.getParentObj()
             rvalue = evaluator.eval(self._transformation)
-            value_dimension = len(numpy.shape(rvalue))
+            if hasattr(rvalue, "magnitude"):
+                value_dimension = len(numpy.shape(rvalue.magnitude))
+            else:
+                value_dimension = len(numpy.shape(rvalue))
             value_dformat = DataFormat(value_dimension)
             self.data_format = value_dformat
             self.type = self._encodeType(rvalue, value_dformat)

--- a/lib/taurus/core/evaluation/evalattribute.py
+++ b/lib/taurus/core/evaluation/evalattribute.py
@@ -334,14 +334,16 @@ class EvaluationAttribute(TaurusAttribute):
         try:
             evaluator = self.getParentObj()
             rvalue = evaluator.eval(self._transformation)
-            # TODO: Workarround for pint issue #509
-            # https://github.com/hgrecco/pint/issues/509
+            # --------------------------------------------------------- 
+            # Workaround for https://github.com/hgrecco/pint/issues/509
             # The numpy.shape method over a Quantity mutates
             # the type of its magnitude.
+            # TODO: remove "if" when the bug is solved in pint
             if hasattr(rvalue, "magnitude"):
                 value_dimension = len(numpy.shape(rvalue.magnitude))
             else:
                 value_dimension = len(numpy.shape(rvalue))
+            # ---------------------------------------------------------
             value_dformat = DataFormat(value_dimension)
             self.data_format = value_dformat
             self.type = self._encodeType(rvalue, value_dformat)

--- a/lib/taurus/core/evaluation/evalattribute.py
+++ b/lib/taurus/core/evaluation/evalattribute.py
@@ -334,6 +334,10 @@ class EvaluationAttribute(TaurusAttribute):
         try:
             evaluator = self.getParentObj()
             rvalue = evaluator.eval(self._transformation)
+            # TODO: Workarround for pint issue #509
+            # https://github.com/hgrecco/pint/issues/509
+            # The numpy.shape method over a Quantity mutates
+            # the type of its magnitude.
             if hasattr(rvalue, "magnitude"):
                 value_dimension = len(numpy.shape(rvalue.magnitude))
             else:

--- a/lib/taurus/qt/qtgui/display/test/test_tauruslabel.py
+++ b/lib/taurus/qt/qtgui/display/test/test_tauruslabel.py
@@ -182,8 +182,7 @@ def baseFormatter2(dtype, **kwargs):
 @insertTest(helper_name='checkFormat',
             model='eval:Q(5)#rvalue.magnitude',
             formatter=baseFormatter2,
-            expected="int",
-            test_skip="Skipped test due to bug #433")
+            expected="int")
 @insertTest(helper_name='checkFormat',
             model='eval:Q("5m")#rvalue.units',
             formatter=baseFormatter2,


### PR DESCRIPTION
The evalAttribute rvalue type returns a numpy.ndarray instead of
scalar (int/float) when the URI explicit defines a Quantity.

e.g. "eval:Q('1m')"

Apply numpy.shape method over a Quantity mutates the
magnitude type.