### PR TITLE
Add TangoAttribute.getAttributeProxy

### DIFF
--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -503,7 +503,12 @@ class TangoAttribute(TaurusAttribute):
         if self.__attr_err is not None:
             raise self.__attr_err
         return self.__attr_value
-
+    
+    def getAttributeProxy(self):
+        """Convenience method that creates and returns a PyTango.AttributeProxy
+        object"""
+        return PyTango.AttributeProxy(self.getFullName())
+    
     #-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-
     # API for listeners
     #-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-


### PR DESCRIPTION
Add convenience function that returns a PyTango.AttributeProxy of the
given attribute.

Solves #447