### PR TITLE
Try again to work around race conditions in test suite

### DIFF
--- a/lib/taurus/qt/qtgui/display/test/test_tauruslabel.py
+++ b/lib/taurus/qt/qtgui/display/test/test_tauruslabel.py
@@ -160,7 +160,7 @@ class TaurusLabelTest2(TangoSchemeTestLauncher, BaseWidgetTestCase,
     def bgRole(self, model=None, expected=None, bgRole=None, maxdepr=0):
         '''Check that the label text'''
         self._widget.setModel(model)
-        self.processEvents(repetitions=10, sleep=.1)
+        self.processEvents(repetitions=30, sleep=.1)
         if bgRole is not None:
             self._widget.setBgRole(bgRole)
         p = self._widget.palette()


### PR DESCRIPTION
The automated tests are failing again lately, being the bgRole tests the
most likely to randomly fail. Increase processEvents repetitions for
bgRole test in an attempt to reduce the likelihood of these false
failures.

This is related to #261 and #366