### PR TITLE
Ignore harmless exception in AutoScrollTool

### DIFF
--- a/lib/taurus/qt/qtgui/extra_guiqwt/tools.py
+++ b/lib/taurus/qt/qtgui/extra_guiqwt/tools.py
@@ -244,7 +244,10 @@ class AutoScrollTool(ToggleTool, BaseConfigurableClass):
             if checked:
                 item.scrollRequested.connect(self.onScrollRequested)
             else:
-                item.scrollRequested.disconnect(self.onScrollRequested)
+                try:
+                    item.scrollRequested.disconnect(self.onScrollRequested)
+                except:
+                    pass
 
     def getScrollItems(self, plot):
         return [item for item in plot.get_items()


### PR DESCRIPTION
A harmless exception is thrown every time that the AutoScrollTool is
loaded. It is related to an attempt to disconnect a not connected
signal. Handle the exception to ignore it.