### PR TITLE
Refactor taurus.external.qt (Fix #411)

### DIFF
--- a/lib/taurus/external/qt/QtCore.py
+++ b/lib/taurus/external/qt/QtCore.py
@@ -25,9 +25,9 @@
 
 """This module exposes QtCore module"""
 
-from taurus.external.qt import getQtName
+from taurus.external.qt import API_NAME
 
-__backend = getQtName()
+__backend = API_NAME
 
 
 def __to_qvariant_1(pyobj=None):
@@ -196,4 +196,4 @@ elif __backend == 'PySide':
     if hasattr(__QtCore, "Property"):
         pyqtProperty = Property
 
-del getQtName
+del API_NAME

--- a/lib/taurus/external/qt/QtGui.py
+++ b/lib/taurus/external/qt/QtGui.py
@@ -25,13 +25,13 @@
 
 """This module exposes QtGui module"""
 
-from taurus.external.qt import getQtName, _updateQtSubModule
+from taurus.external.qt import API_NAME, _updateQtSubModule
 
-__backend = getQtName()
+__backend = API_NAME
 
 _updateQtSubModule(globals(), "QtGui")
 
 if __backend == 'PyQt5':
     _updateQtSubModule(globals(), "QtWidgets")
 
-del _updateQtSubModule, getQtName
+del _updateQtSubModule, API_NAME

--- a/lib/taurus/external/qt/__init__.py
+++ b/lib/taurus/external/qt/__init__.py
@@ -25,66 +25,118 @@
 
 """This module exposes PyQt4/PyQt5/PySide module"""
 
-__all__ = ["initialize", "getQtName", "getQt", "_updateQtSubModule", "requires"]
-
-
-from taurus import tauruscustomsettings as __config
-from taurus.core.util import log as __log
+__all__ = ["initialize", "API_NAME",
+           "getQtName", "getQt", "_updateQtSubModule", "requires"]
 
 import os
+from taurus.core.util import log as __log
+from taurus import tauruscustomsettings as __config
 
-__QT = None
-__QT_NAME = None
-__QT_KNOWN_APIS = "PyQt4", "PyQt5", "PySide"
-__QT_PREFERED_APIS = None
+# --------------------------------------------------------------------------
+# Deprecated (in Jul17) pending to be removed later on
 
-__QT_INIT = False
-__QT_LOG_INIT = False
-__QT_RES_INIT = False
-
-
-def __getPreferedAPIs():
-    return [__config.QT_AUTO_API] + \
-      [api for api in __QT_KNOWN_APIS if api != __config.QT_AUTO_API]
+def getQtName(name=None, strict=True):
+    __log.deprecated (dep='taurus.external.qt.getQtName',
+                      alt='taurus.external.qt.API_NAME', rel='4.0.4')
+    return API_NAME
 
 
-def __assertQt(name, qt=None, strict=True):
-    qt = qt or __QT
-    if name is None or qt is None:
-        return
-    qt_name = qt.__name__
-    if qt_name != name:
-        msg = "Cannot use %s because %s already in use" % (name, qt_name)
-        if strict:
-            raise Exception(msg)
-        else:
-            __log.error(msg)
+def initialize(name=None, strict=True, logging=True,
+               resources=True, remove_inputhook=True):
+    __log.deprecated (dep='taurus.external.qt.initialize', rel='4.0.4')
+    return getQt()
 
 
-def __hasBinding(qt_name):
-    """Safely check for known qt apis without importing submodules"""
-    import imp
-    try:
-        _, pth, _ = imp.find_module(qt_name)
-        imp.find_module('QtCore', pth)
-        imp.find_module('QtGui', pth)
-    except ImportError:
-        return False
+def requires(origin=None, exc_class=ImportError, **kwargs):
+    __log.deprecated (dep='taurus.external.qt.requires', rel='4.0.4')
     return True
 
 
-def __import(name):
-    import sys
-    __import__(name)
-    return sys.modules[name]
+# Handle rename of DEFAULT_QT_AUTO_API -->  DEFAULT_QT_API
+if hasattr(__config, 'DEFAULT_QT_AUTO_API'):
+    __log.deprecated(dep='DEFAULT_QT_AUTO_API', alt='DEFAULT_QT_API',
+                     rel='4.0.4')
+    if not hasattr(__config, 'DEFAULT_QT_API'):
+        __config.DEFAULT_QT_API = __config.DEFAULT_QT_AUTO_API
+
+# --------------------------------------------------------------------------
+
+#: Qt API environment variable name
+QT_API = 'QT_API'
+#: names of the expected PyQt5 api
+PYQT5_API = ['pyqt5']
+#: names of the expected PyQt4 api
+PYQT4_API = [
+    'pyqt',  # name used in IPython.qt
+    'pyqt4'  # pyqode.qt original name
+]
+#: names of the expected PySide api
+PYSIDE_API = ['pyside']
+
+os.environ.setdefault(QT_API, getattr(__config, 'DEFAULT_QT_API', 'pyqt4'))
+API = os.environ[QT_API].lower()
+assert API in (PYQT5_API + PYQT4_API + PYSIDE_API)
+
+is_old_pyqt = is_pyqt46 = False
+PYQT5 = True
+PYQT4 = PYSIDE = False
 
 
-def __importQt(name):
-    return __import(getQtName() + "." + name)
+class PythonQtError(Exception):
+    """Error raise if no bindings could be selected"""
+    pass
+
+
+if API in PYQT5_API:
+    try:
+        from PyQt5.Qt import PYQT_VERSION_STR as PYQT_VERSION  # analysis:ignore
+        from PyQt5.Qt import QT_VERSION_STR as QT_VERSION  # analysis:ignore
+        PYSIDE_VERSION = None
+    except ImportError:
+        API = os.environ['QT_API'] = 'pyqt'
+
+if API in PYQT4_API:
+    try:
+        import sip
+        try:
+            sip.setapi('QString', 2)
+            sip.setapi('QVariant', 2)
+            sip.setapi('QDate', 2)
+            sip.setapi('QDateTime', 2)
+            sip.setapi('QTextStream', 2)
+            sip.setapi('QTime', 2)
+            sip.setapi('QUrl', 2)
+        except AttributeError:
+            # PyQt < v4.6
+            pass
+        from PyQt4.Qt import PYQT_VERSION_STR as PYQT_VERSION  # analysis:ignore
+        from PyQt4.Qt import QT_VERSION_STR as QT_VERSION  # analysis:ignore
+        PYSIDE_VERSION = None
+        PYQT5 = False
+        PYQT4 = True
+    except ImportError:
+        API = os.environ['QT_API'] = 'pyside'
+    else:
+        is_old_pyqt = PYQT_VERSION.startswith(('4.4', '4.5', '4.6', '4.7'))
+        is_pyqt46 = PYQT_VERSION.startswith('4.6')
+
+if API in PYSIDE_API:
+    try:
+        from PySide import __version__ as PYSIDE_VERSION  # analysis:ignore
+        from PySide.QtCore import __version__ as QT_VERSION  # analysis:ignore
+        PYQT_VERSION = None
+        PYQT5 = False
+        PYSIDE = True
+    except ImportError:
+        raise PythonQtError('No Qt bindings could be found')
+
+API_NAME = {'pyqt5': 'PyQt5', 'pyqt': 'PyQt4', 'pyqt4': 'PyQt4',
+            'pyside': 'PySide'}[API]
 
 
 def __initializeQtLogging():
-    QtCore = __importQt("QtCore")
+    # from . import QtCore
+    QtCore = __importQt ('QtCore')
 
     QT_LEVEL_MATCHER = {
         QtCore.QtDebugMsg:     __log.debug,
@@ -107,90 +159,11 @@ def __initializeQtLogging():
         QtCore.qInstallMsgHandler(taurusMsgHandler)
 
 
-def __getTheme():
-    QtGui = __importQt("QtGui")
-    return QtGui.QIcon.themeName()
-
-
-def __hasTheme():
-    return len(__getTheme()) > 0
-
-
-def __get_taurus_resource_path():
-    import os
-    this_dir = os.path.abspath(os.path.dirname(__file__))
-    taurus_dir = os.path.join(this_dir, os.path.pardir, os.path.pardir)
-    base_resource_dir = os.path.join(taurus_dir, "qt", "qtgui", "resource")
-    return os.path.realpath(base_resource_dir)
-
-
-def __get_taurus_tango_theme_path():
-    import os
-    return os.path.join(__get_taurus_resource_path(), "tango-icons")
-
-
-def __themeDirectories():
-    """Returns valid theme directories for the current theme
-    **Requires QApplication to be created**"""
-    import os
-    QtGui = __importQt("QtGui")
-    theme = __getTheme()
-    theme_paths = QtGui.QIcon.themeSearchPaths()
-    result = []
-    for theme_path in theme_paths:
-        theme_path = os.path.join(theme_path, theme)
-        if os.path.isdir(theme_path) and not theme_path in result:
-            result.append(theme_path)
-    return result
-
-
-def __initializeTheme():
-    """Currently not used"""
-    import os
-    QtGui = __importQt("QtGui")
-
-    # Can only resources if QApplication already exists
-    app = QtGui.QApplication.instance()
-    if app is None:
-        raise SystemError("QApplication object must exist before "
-                          "initializing Qt resources")
-
-    tango_theme_dir = __get_taurus_tango_theme_path()
-
-    # initialize theme if necessary
-    theme = __getTheme()
-    has_theme = len(theme) > 0
-    if not has_theme:
-        __log.info("No native theme support. Using local tango-theme-icons")
-        if os.path.isdir(tango_theme_dir):
-            # If themes are not supported (windows, for example), taurus
-            # initializes local Tango theme
-            theme_search_path = QtGui.QIcon.themeSearchPaths()
-            theme_search_path.append(tango_theme_dir)
-            QtGui.QIcon.setThemeSearchPaths(theme_search_path)
-            QtGui.QIcon.setThemeName("Tango")
-        else:
-            __log.warning("Local tango-theme-icons not found: Theme not initialized")
-
-
-def __initializeQtResources():
-    import os
-    QtCore = __importQt("QtCore")
-    base_resource_dir = __get_taurus_resource_path()
-
-    # add taurus resources
-    namespace = __config.NAMESPACE
-    search_paths = QtCore.QDir.searchPaths(namespace) or []
-    for elem in os.listdir(base_resource_dir):
-        abs_elem = os.path.join(base_resource_dir, elem)
-        if os.path.isdir(abs_elem) and not abs_elem in search_paths:
-            search_paths.append(abs_elem)
-    QtCore.QDir.setSearchPaths(namespace, search_paths)
-
 
 def __removePyQtInputHook():
     try:
-        __importQt("QtCore").pyqtRemoveInputHook()
+        from . import QtCore
+        QtCore.pyqtRemoveInputHook()
     except AttributeError:
         pass
 
@@ -198,227 +171,34 @@ def __removePyQtInputHook():
 def _updateQtSubModule(glob_dict, qt_sub_module_name):
     glob_dict.update(__importQt(qt_sub_module_name).__dict__)
 
-
-#------------------------------------------------------------------------------
-# PyQt4
-#------------------------------------------------------------------------------
-
-def __get_sip():
-    try:
-        import sip
-    except ImportError:
-        sip = None
-    return sip
-
-
-def __setPyQt4API(element, api_version=2):
-    sip = __get_sip()
-    try:
-        ver = sip.getapi(element)
-    except ValueError:
-        ver = -1
-
-    if ver < 0:
-        try:
-            sip.setapi(element, api_version)
-            __log.debug("%s API set to version %d",
-                      element, sip.getapi(element))
-        except ValueError:
-            __log.warning("Error setting %s API to version %s", element,
-                        api_version, exc_info=1)
-            return False
-    elif ver < api_version:
-        __log.info("%s API set to version %s (advised: version >= %s)",
-                 element, ver, api_version)
-    return True
-
-
-def __preparePyQt4():
+def __import(name):
     import sys
-
-    # In python 3 APIs are set to level 2 so nothing to do
-    if sys.version_info[0] > 2:
-        return __import("PyQt4")
-
-    sip = __get_sip()
-
-    # For PySide compatibility, use the new-style string API that
-    # automatically converts QStrings to Unicode Python strings. Also,
-    # automatically unpack QVariants to their underlying objects.
-    if sip is None:
-        __log.warning("Could not find sip")
-    elif sip.SIP_VERSION < 0x040900:
-        sip_ver = sip.SIP_VERSION_STR
-        __log.warning("Using old sip %s (advised >= 4.9)", sip_ver)
-    else:
-        for obj in ("QDate", "QDateTime", "QString", "QTextStream", "QTime",
-          "QUrl", "QVariant"):
-            __setPyQt4API(obj, 2)
-
-    return __import("PyQt4")
+    __import__(name)
+    return sys.modules[name]
 
 
-#------------------------------------------------------------------------------
-# PyQt5
-#------------------------------------------------------------------------------
+def __importQt(name):
+    return __import(API_NAME + "." + name)
 
-def __preparePyQt5():
-    return __import("PyQt5")
-
-
-#------------------------------------------------------------------------------
-# PySide
-#------------------------------------------------------------------------------
-
-def __preparePySide():
-    return __import("PySide")
-
-
-#------------------------------------------------------------------------------
-# Global
-#------------------------------------------------------------------------------
 
 def getQt(name=None, strict=True):
-    global __QT, __QT_NAME
-    if __QT:
-        __assertQt(name, qt=__QT, strict=strict)
-        return __QT
-
-    import sys
-
-    modules = sys.modules
-    for api_name in __QT_PREFERED_APIS:
-        api = modules.get(api_name)
-        if api:
-            __assertQt(name, qt=api, strict=strict)
-            __QT = api
-            __QT_NAME = name
-            return __QT
-
-    # no qt imported yet
-    if strict and name:
-        apis = [name]
+    __log.deprecated (dep='taurus.external.qt.getQt', rel='4.0.4')
+    if PYQT5:
+        import PyQt5 as _qt
+    elif PYQT4:
+        import PyQt4 as _qt
+    elif PYSIDE:
+        import PySide as _qt
     else:
-        apis = list(__QT_PREFERED_APIS)
-        if name:
-            apis.remove(name)
-            apis.insert(0, name)
-    for api_name in apis:
-        f = globals()["__prepare" + api_name]
-        try:
-            __QT = f()
-            __QT_NAME = api_name
-            return __QT
-        except ImportError:
-            continue
-    raise ImportError("No suitable Qt found")
+        raise ImportError("No suitable Qt found")
+    return _qt
 
 
-def getQtName(name=None, strict=True):
-    # force initialization of Qt
-    getQt(name=name, strict=strict)
-    return __QT_NAME
+if getattr(__config, 'QT_AUTO_INIT_LOG', True):
+    __initializeQtLogging()
+
+if getattr(__config, 'QT_AUTO_REMOVE_INPUTHOOK', True):
+    __removePyQtInputHook()
 
 
-def initialize(name=None, strict=True, logging=True,
-               resources=True, remove_inputhook=True):
-    global __QT_INIT
-
-    if __QT_INIT:
-        return getQt()
-
-    if not __config.QT_AUTO_API in __QT_KNOWN_APIS:
-        raise ImportError("Invalid QT_AUTO_API '%s'. Valid APIs are %s" % \
-                          (__config.QT_AUTO_API,
-                          ", ".join(__QT_KNOWN_APIS)))
-
-    global __QT_PREFERED_APIS
-    __QT_PREFERED_APIS = __getPreferedAPIs()
-
-    qt = getQt(name=name, strict=strict)
-    if logging:
-        __initializeQtLogging()
-    if resources:
-        __initializeQtResources()
-    if remove_inputhook:
-        __removePyQtInputHook()
-
-    __QT_INIT = True
-
-    QT_API = os.environ.get('QT_API')
-    if QT_API is None:
-        global __QT_NAME
-        if __QT_NAME == 'PySide':
-            QT_API = 'pyside'
-        else:
-            QT_API = 'pyqt'
-
-    os.environ['QT_API'] = QT_API
-
-    return qt
-
-
-def requires(origin=None, exc_class=ImportError, **kwargs):
-    """
-    Determines if the Qt component fulfills the minimum specified.
-    Can take one of the following keyword arguments: Qt, PyQt, PySide.
-    Any of these arguments maybe a string in the loose version format
-    (see :class:`distutils.version.LooseVersion`)
-
-    If present, *Qt* keyword stands for the minimum Qt C++ version.
-    If present, *PyQt* keyword stands for the minimum PyQt version.
-    If present, *PySide* keyword stands for the minimum PySide version.
-
-    If a keyword is not present, it means it accepts any version. So, if, for
-    example, you are running taurus with PySide and you call requires with
-    `requires(PyQt='4.10')` it will **not** fail.
-
-    :param Qt:
-    """
-    from distutils.version import LooseVersion as V
-    QtName = getQtName()
-    QtCore = __importQt("QtCore")
-
-    if origin is None:
-        msg_prefix = "Required"
-    else:
-        msg_prefix = origin + " requires"
-
-    # check C++ Qt minimum version
-    req_cpp_qt_v_str = kwargs.pop("Qt", None)
-    if req_cpp_qt_v_str is not None:
-        cpp_qt_v_str = QtCore.QT_VERSION_STR
-        if V(req_cpp_qt_v_str) > V(cpp_qt_v_str):
-            if exc_class:
-                msg = "{0} C++ Qt >= {1}. Installed C++ Qt is {2}".format(
-                    msg_prefix, req_cpp_qt_v_str, cpp_qt_v_str)
-                raise exc_class(msg)
-            else:
-                return False
-
-    if QtName.startswith('PyQt'):
-        req_v_str = kwargs.get('PyQt', "0")
-        qt_v_str = QtCore.PYQT_VERSION_STR
-    elif QtName == 'PySide':
-        req_v_str = kwargs.get('PySide', "0")
-        qt_v_str = QtCore.PYSIDE_VERSION_STR
-
-    if req_v_str:
-        if V(req_v_str) > V(qt_v_str):
-            if exc_class:
-                msg = "{0} {1} >= {2}. Installed {1} is {3}",format(
-                    msg_prefix, QtName, req_v_str, qt_v_str)
-                raise exc_class(msg)
-            else:
-                return False
-    return True
-
-
-if __config.QT_AUTO_INIT:
-    initialize(name=__config.QT_AUTO_API,
-               strict=__config.QT_AUTO_STRICT,
-               logging=__config.QT_AUTO_INIT_LOG,
-               resources=__config.QT_AUTO_INIT_RES,
-               remove_inputhook=__config.QT_AUTO_REMOVE_INPUTHOOK)
-
-    __log.info('Using "%s" for Qt', __QT_NAME)
+__log.info('Using "%s" for Qt', API_NAME)

--- a/lib/taurus/external/qt/uic.py
+++ b/lib/taurus/external/qt/uic.py
@@ -26,9 +26,9 @@
 """This module exposes PyQt4/PSide uic module"""
 
 from taurus.core.util import log
-from taurus.external.qt import getQt
+from taurus.external.qt import API_NAME
 
-__backend = getQt().__name__
+__backend = API_NAME
 
 if __backend == 'PyQt4':
     from PyQt4.uic import *
@@ -133,4 +133,4 @@ elif __backend == 'PySide':
 
         return None
 
-del getQt
+del API_NAME

--- a/lib/taurus/external/test/test_qt.py
+++ b/lib/taurus/external/test/test_qt.py
@@ -57,11 +57,6 @@ class QtTestCase(unittest.TestCase):
         # store a "snapshot" of the currently loaded modules
         self._orig_mods = set(sys.modules.keys())
 
-        # auto initialize Qt by taurus using forcibly the self.QtAPI
-        tauruscustomsettings.QT_AUTO_INIT = True
-        tauruscustomsettings.QT_AUTO_API = self.QtAPI
-        tauruscustomsettings.QT_AUTO_STRICT = True
-
         # this import initializes Qt in case it is not loaded
         from taurus.external.qt import Qt
         self.__qt = Qt
@@ -72,9 +67,9 @@ class QtTestCase(unittest.TestCase):
         other_apis = set(_QtAPIs)
         other_apis.remove(self.QtAPI)
 
-        from taurus.external.qt import getQtName
+        from taurus.external.qt import API_NAME
 
-        self.assertEquals(getQtName(), self.QtAPI)
+        self.assertEquals(API_NAME, self.QtAPI)
 
         for other_api in other_apis:
             self.assertFalse(other_api in mods, other_api + " loaded in " + self.QtAPI + " test")

--- a/lib/taurus/tauruscustomsettings.py
+++ b/lib/taurus/tauruscustomsettings.py
@@ -86,48 +86,23 @@ NAMESPACE = 'taurus'
 # Qt configuration
 # ----------------------------------------------------------------------------
 
-#: Auto initialize Qt
-DEFAULT_QT_AUTO_INIT = True
-
 #: Set preffered API if not is already loaded
-DEFAULT_QT_AUTO_API = 'PyQt4'
-
-#: Whether or not should be strict in choosing Qt API
-DEFAULT_QT_AUTO_STRICT = False
+DEFAULT_QT_API = 'PyQt4'
 
 #: Auto initialize Qt logging to python logging
-DEFAULT_QT_AUTO_INIT_LOG = True
-
-#: Auto initialize taurus resources (icons)
-DEFAULT_QT_AUTO_INIT_RES = True
+QT_AUTO_INIT_LOG = True
 
 #: Remove input hook (only valid for PyQt4)
-DEFAULT_QT_AUTO_REMOVE_INPUTHOOK = True
-
-#: Auto initialize Qt
-QT_AUTO_INIT = DEFAULT_QT_AUTO_INIT
-
-#: Set preffered API if not is already loaded
-QT_AUTO_API = DEFAULT_QT_AUTO_API
-
-#: Whether or not should be strict in choosing Qt API
-QT_AUTO_STRICT = DEFAULT_QT_AUTO_STRICT
-
-#: Auto initialize Qt logging to python logging
-QT_AUTO_INIT_LOG = DEFAULT_QT_AUTO_INIT_LOG
-
-#: Auto initialize taurus resources (icons)
-QT_AUTO_INIT_RES = DEFAULT_QT_AUTO_INIT_RES
-
-#: Remove input hook (only valid for PyQt4)
-QT_AUTO_REMOVE_INPUTHOOK = DEFAULT_QT_AUTO_REMOVE_INPUTHOOK
+QT_AUTO_REMOVE_INPUTHOOK = True
 
 #: Select the theme to be used: set the theme dir  and the theme name.
 #: The path can be absolute or relative to the dir of taurus.qt.qtgui.icon
 #: If not set, the dir of taurus.qt.qtgui.icon will be used
 QT_THEME_DIR = ''
+
 #: The name of the icon theme (e.g. 'Tango', 'Oxygen', etc). Default='Tango'
 QT_THEME_NAME = 'Tango'
+
 #: In Linux the QT_THEME_NAME is not applied (to respect the system theme)
 #: setting QT_THEME_FORCE_ON_LINUX=True overrides this.
 QT_THEME_FORCE_ON_LINUX = True


### PR DESCRIPTION
-Simplify taurus.external.qt and bring it closer to what qtpy does.
-Deprecate "getQtName", "getQt", "initialize" and "requires".
-Add taurus.external.qt.API_NAME
-Remove the following Qt options in tauruscustomsettings:
    - DEFAULT_QT_AUTO_INIT
    - DEFAULT_QT_AUTO_API (changed to DEFAULT_QT_API)
    - DEFAULT_QT_AUTO_STRICT
    - DEFAULT_QT_AUTO_INIT_LOG
    - DEFAULT_QT_AUTO_INIT_RES
    - DEFAULT_QT_AUTO_REMOVE_INPUTHOOK
    - QT_AUTO_INIT
    - QT_AUTO_API
    - QT_AUTO_STRICT
    - QT_AUTO_INIT_RES

Fixes #411