### PR TITLE
Add more verbosity to TangoAttribute.read

### DIFF
--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -479,6 +479,8 @@ class TangoAttribute(TaurusAttribute):
                 if self.__attr_value is not None:
                     return self.__attr_value
                 elif self.__attr_err is not None:
+                    self.debug("[Tango] read from cache failed (%s): %s",
+                               self.fullname, self.__attr_err)
                     raise self.__attr_err
 
         if not cache or (self.__subscription_state in (SubscriptionState.PendingSubscribe, SubscriptionState.Unsubscribed) and not self.isPollingActive()):


### PR DESCRIPTION
If TangoAttribute.read method fails when is using cache
it raises an exception that does not report any info of
the affected Tango attribute.

Add more verbosity during the exception.

Fix 474