### PR TITLE
Update & refactor dependencies (Fix #376, #406, #407)

### DIFF
--- a/doc/source/users/getting_started.rst
+++ b/doc/source/users/getting_started.rst
@@ -141,7 +141,7 @@ installation method:
 
       pip install taurus[NAME_OF_EXTRA]
 
-- The conda Conda_ package management system may also be used to install
+- The Conda_ package management system may also be used to install
   most of the required dependencies.
 
 - The `taurus-test Docker container`_ provides a Docker container (based

--- a/doc/source/users/getting_started.rst
+++ b/doc/source/users/getting_started.rst
@@ -22,8 +22,9 @@ You can test the installation by running::
 
        python -c "import taurus; print taurus.Release.version"
 
-
 Note: pip is already included in python>2.7.9
+
+Note: some "extra" features of taurus have additional dependencies_.
 
 Installing from sources manually (platform-independent)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -34,11 +35,13 @@ You may alternatively install from a downloaded release package:
 #. Extract the downloaded source into a temporary directory and change to it
 #. run::
 
-       python setup.py install
+       pip install .
 
 #. test the installation::
 
        python -c "import taurus; print taurus.Release.version"
+
+Note: some "extra" features of taurus have additional dependencies_.
 
 Linux (Debian-based)
 ~~~~~~~~~~~~~~~~~~~~
@@ -71,72 +74,35 @@ Working from Git source directly (in develop mode)
 
 If you intend to do changes to Taurus itself, or want to try the latest
 developments, it is convenient to work directly from the git source in
-"develop" mode, so that you do not need to re-install on each change.
+"develop" (aka "editable") mode, so that you do not need to re-install
+on each change.
 
 You can clone taurus from our main git repository::
 
     git clone https://github.com/taurus-org/taurus.git taurus
 
-Then, to work on develop mode, just do::
+Then, to work in develop mode, just do::
 
-    cd taurus
-    python setup.py develop
+    pip install -e ./taurus
+
 
 .. _dependencies:
 
 Dependencies
 ------------
 
-.. graphviz::
+Strictly speaking, Taurus only depends on numpy, but that will leave
+out most of the features normally expected of Taurus (which are
+considered "extras"). For example:
 
-    digraph dependencies {
-        size="8,3";
-        Taurus      [shape=box,label="taurus 4.0"];
-        Python      [shape=box,label="Python >=2.7"];
-        numpy       [shape=box,label="numpy >=1.1.0"];
-        lxml        [shape=box,label="lxml >=2.1"];
-        PyTango     [shape=box,label="PyTango >=7.1.0"];
-        pyepics     [shape=box,label="pyepics >=3.2.4"];
-        PyQt        [shape=box,label="PyQt >=4.8"];
-        PyQwt       [shape=box,label="PyQwt >=5.2.0"];
-        guiqwt      [shape=box,label="guiqwt >=2.3.0"];
-        PyMca5      [shape=box,label="PyMca5 >=5.1.2"];
-        ply         [shape=box,label="PLY >=2.3"];
+- Interacting with a Tango controls system requires PyTango_.
 
-        Taurus -> Python;
-        Taurus -> numpy;
-        Taurus -> lxml;
-        Taurus -> PyTango      [style=dotted, label="only for using Tango"];
-        Taurus -> pyepics      [style=dotted, label="only for using EPICS"];
-        Taurus -> PyQt         [style=dotted, label="taurus.qt only"];
-        Taurus -> PyQwt        [style=dotted, label="taurus.qt only"];
-        Taurus -> guiqwt       [style=dotted, label="taurus.qt.qtgui.extra_guiqwt only"];
-        Taurus -> PyMca5       [style=dotted, label="taurus.qt.qtgui.extra_nexus only"];
-        Taurus -> ply          [style=dotted, label="taurus.qt.qtgui.graphic.jdraw only"];
-    }
+- Interacting with an Epics controls system requires pyepics_.
 
-Taurus has dependencies on some python libraries. After you install taurus you
-can check the state of the dependencies by doing::
+- Using the taurus Qt widgets, requires PyQt_ 4.x (4.8 <= v < 5).
+  (PyQt5 support coming soon).
 
-    import taurus
-    taurus.check_dependencies()
-    
-- If you want to interact with a Tango controls system, you need PyTango_ 7 or later
-  installed. You can check by doing::
-
-    python -c 'import PyTango; print PyTango.Release.version'
-    
-- If you want to interact with an EPICS controls system,you need pyepics_
-
-- For using the taurus Qt widgets, you will need PyQt_ 4.8 or later 
-  (PyQt5 support comming soon). You can check by doing::
-
-    python -c 'import PyQt4.Qt; print PyQt4.Qt.QT_VERSION_STR'
-
-- The :mod:`taurus.qt.qtgui.plot` module requires PyQwt_ 5.2.0 or later.
-  (this dependency will be dropped soon). You can check it by doing::
-
-      python -c 'import PyQt4.Qwt5; print PyQt4.Qwt5.QWT_VERSION_STR'
+- The :mod:`taurus.qt.qtgui.plot` module requires PyQwt_.
 
 - The image widgets require the guiqwt_ library.
 
@@ -144,27 +110,61 @@ can check the state of the dependencies by doing::
 
 - The NeXus browser widget requires PyMca5_.
 
+- The TaurusEditor widget requires spyder_.
 
-.. note:: For Windows users: many of these dependencies are already satisfied
-          by installing the `Python(x,y)`_ bundle. Also, most can be installed
-          from PyPI_ (e.g. using pip). For some versions, PyPI may not provide
-          pre-built windows binaries, so pip may try to compile from sources,
-          which takes long and may not succeed without some further work. In
-          those cases, one may use windows binaries from other versions and/or
-          wheel packages from the Silx_WheelHouse_.
+- The TaurusGui module requires lxml_.
+
+
+For a complete list of "extra" features and their corresponding
+requirements, execute the following command::
+
+    python -c 'import taurus; taurus.check_dependencies()'
+
+
+How you install the required dependencies depends on your preferred
+installation method:
+
+- For GNU/Linux, it is in general better to install the dependencies from
+  your distribution repositories if available.
+
+- For Windows users: many of these dependencies are already satisfied
+  by installing the `Python(x,y)`_ bundle. Also, most can be installed
+  from PyPI_ (e.g. using pip). For some versions, PyPI may not provide
+  pre-built windows binaries, so pip may try to compile from sources,
+  which takes long and may not succeed without some further work. In
+  those cases, one may use windows binaries from other versions and/or
+  wheel packages from the Silx_WheelHouse_.
+
+- In general, you can use pip to install dependencies for a given
+  extra feature (if they are in PyPI or in one of your configured
+  indexes). Use::
+
+      pip install taurus[NAME_OF_EXTRA]
+
+- The conda Conda_ package management system may also be used to install
+  most of the required dependencies.
+
+- The `taurus-test Docker container`_ provides a Docker container (based
+  on Debian) with all the dependencies pre-installed (including Tango and
+  Epics running environments) on which you can install taurus straight
+  away.
 
 
 .. _numpy: http://numpy.org/
 .. _PLY: http://www.dabeaz.com/ply/
 .. _Python(x,y): http://python-xy.github.io/
 .. _Tango: http://www.tango-controls.org/
-.. _PyTango: http://packages.python.org/PyTango/
+.. _PyTango: http://pytango.readthedocs.io
 .. _Qt: http://qt.nokia.com/products/
 .. _PyQt: http://www.riverbankcomputing.co.uk/software/pyqt/
 .. _PyQwt: http://pyqwt.sourceforge.net/
 .. _guiqwt: https://pypi.python.org/pypi/guiqtw
-.. _IPython: http://ipython.or/g
+.. _IPython: http://ipython.org
 .. _PyMca5: http://pymca.sourceforge.net/
 .. _pyepics: http://pypi.python.org/pypi/pyepics
+.. _spyder: http://pythonhosted.org/spyder
+.. _lxml: http://lxml.de
 .. _Silx_WheelHouse: http://www.silx.org/pub/wheelhouse/
-.. _PyPI: https://pypi.python.org/pypi
+.. _PyPI: http://pypi.python.org/pypi
+.. _Conda: http://conda.io/docs/
+.. _taurus-test Docker container: http://hub.docker.com/r/cpascual/taurus-test/

--- a/lib/taurus/core/taurushelper.py
+++ b/lib/taurus/core/taurushelper.py
@@ -47,313 +47,68 @@ from .util.log import taurus4_deprecation
 # regexp for finding the scheme
 __SCHEME_RE = re.compile(r'([^:/?#]+):.*')
 
-
-def __translate_version_str2int(version_str):
-    """Translates a version string in format x[.y[.z[...]]] into a 000000 number"""
-    import math
-    parts = version_str.split('.')
-    i, v, l = 0, 0, len(parts)
-    if not l:
-        return v
-    while i < 3:
-        try:
-            v += int(parts[i]) * int(math.pow(10, (2 - i) * 2))
-            l -= 1
-            i += 1
-        except ValueError, ve:
-            return v
-        if not l:
-            return v
-    return v
-
-    try:
-        v += 10000 * int(parts[0])
-        l -= 1
-    except ValueError, ve:
-        return v
-    if not l:
-        return v
-
-    try:
-        v += 100 * int(parts[1])
-        l -= 1
-    except ValueError, ve:
-        return v
-    if not l:
-        return v
-
-    try:
-        v += int(parts[0])
-        l -= 1
-    except ValueError:
-        return v
-    if not l:
-        return v
+def __check_pyqt(req='4.8'):
+    import PyQt4.Qt
+    from pkg_resources import parse_version
+    assert(parse_version(PyQt4.Qt.PYQT_VERSION_STR) >= parse_version(req))
 
 
-def __get_python_version():
-    return '.'.join(map(str, sys.version_info[:3]))
-
-
-def __get_python_version_number():
-    pyver_str = __get_python_version()
-    if pyver_str is None:
-        return None
-    return __translate_version_str2int(pyver_str)
-
-
-def __get_pytango_version():
-    try:
-        import PyTango
-    except:
-        return None
-    try:
-        return PyTango.Release.version
-    except:
-        return '0.0.0'
-
-
-def __get_pytango_version_number():
-    tgver_str = __get_pytango_version()
-    if tgver_str is None:
-        return None
-    return __translate_version_str2int(tgver_str)
-
-
-def __get_pyqt_version():
-    try:
-        import PyQt4.Qt
-        return PyQt4.Qt.PYQT_VERSION_STR
-    except:
-        return None
-
-
-def __get_pyqt_version_number():
-    pyqtver_str = __get_pyqt_version()
-    if pyqtver_str is None:
-        return None
-    return __translate_version_str2int(pyqtver_str)
-
-
-def __get_pyqwt_version():
-    try:
-        import PyQt4.Qwt5
-        return PyQt4.Qwt5.QWT_VERSION_STR
-    except:
-        pass
-
-
-def __get_pyqwt_version_number():
-    pyqwtver_str = __get_pyqwt_version()
-    if pyqwtver_str is None:
-        return None
-    return __translate_version_str2int(pyqwtver_str)
-
-
-def __get_qub_version():
-    try:
-        import Qub4
-        return "1.0.0"
-    except:
-        try:
-            import Qub
-            return "1.0.0"
-        except:
-            pass
-
-
-def __get_qub_version_number():
-    qubver_str = __get_qub_version()
-    if qubver_str is None:
-        return None
-    return __translate_version_str2int(qubver_str)
-
-
-def __get_qtcontrols_version():
-    try:
-        import qtcontrols
-        return "1.0.0"
-    except:
-        pass
-
-
-def __get_qtcontrols_version_number():
-    qtcontrols_str = __get_qtcontrols_version()
-    if qtcontrols_str is None:
-        return None
-    return __translate_version_str2int(qtcontrols_str)
-
-
-def __get_spyder_version():
-    try:
-        import spyder
-        return spyder.__version__
-    except:
-            pass
-
-
-def __get_spyder_version_number():
-    spyderver_str = __get_spyder_version()
-    if spyderver_str is None:
-        return None
-    return __translate_version_str2int(spyderver_str)
-
-
-def __w(msg):
-    sys.stdout.write(msg)
-    sys.stdout.flush()
-
-
-def __wn(msg):
-    __w(msg + '\n')
+def __check_pyqwt5(req='5.2'):
+    import PyQt4.Qwt5
+    from pkg_resources import parse_version
+    assert(parse_version(PyQt4.Qwt5.QWT_VERSION_STR) >= parse_version(req))
 
 
 def check_dependencies():
-    for msg in _check_dependencies(forlog=False):
-        m = msg[1]
-        if msg[0] != -1:
-            m = '\t%s' % m
-        print m
+    """ 
+    Prints a check-list of requirements and marks those that are fulfilled
+    """
+
+    # non_pypi is a dictionary with extra:req_list and req_list is a list of
+    # (reqname, check) tuples where reqname is the name of a requirement and
+    # check is a function that raises an exception if the requirement is not
+    # fulfilled
+    non_pypi = {'taurus-qt': [('PyQt4>=4.8', __check_pyqt),
+                              ('PyQt4.Qwt5>=5.2', __check_pyqwt5),
+                              ]
+                }
+    import pkg_resources
+    d = pkg_resources.get_distribution('taurus')
+    print "Dependencies for %s:" % d
+    # minimum requirements (without extras)
+    for r in d.requires():
+        try:
+            pkg_resources.require(str(r))
+            print '\t[*]',
+        except Exception:
+            print '\t[ ]',
+        print '%s' % r
+    # requirements for the extras
+    print '\nExtras:'
+    for extra in sorted(d.extras):
+        print "Dependencies for taurus[%s]:" % extra
+        # requirements from PyPI
+        for r in d.requires(extras=[extra]):
+            try:
+                pkg_resources.require(str(r))
+                print '\t[*]',
+            except Exception:
+                print '\t[ ]',
+            print '%s' % r
+        # requirements outside PyPI
+        for r, check in non_pypi.get(extra, ()):
+            try:
+                check()
+                print '\t[*]',
+            except Exception:
+                print '\t[ ]',
+            print '%s (not in PyPI)' % r
 
 
 def log_dependencies():
-    from taurus.core.util.log import Logger
-    l = Logger("taurus")
-    for msg in _check_dependencies(forlog=True):
-        if msg[0] != -1:
-            l.info(msg[1])
-
-
-def _check_dependencies(forlog=False):
-    """Checks for the required and optional packages of taurus"""
-
-    # TODO: Checking dependencies should be taken care by setuptools. Remove
-
-    if forlog:
-        MSG = {'OK': '[OK]', 'ERR': '[ERROR]', 'WARN': '[WARNING]'}
-    else:
-        MSG = {
-            'OK': "[\033[0;32mOK\033[0m]",
-            'ERR': "[\033[0;31mERROR\033[0m]",
-            'WARN': "[\033[0;33mWARNING\033[0m]"}
-
-    core_requirements = {
-        #    module       minimum  recommended
-        "Python": ("2.6.0", "2.6.0"),
-    }
-
-    core_optional_requirements = {
-        #    module       minimum  recommended
-        "PyTango": ("7.1.0", "7.1.0"),
-    }
-
-    widget_requirements = {
-        #    module       minimum  recommended
-        "PyTango": ("7.1.0", "7.1.0"),
-        "PyQt": ("4.4.0", "4.4.0"),
-        "PyQwt": ("5.2.0", "5.2.0"),
-    }
-
-    widget_optional_requirements = {
-        #    module       minimum  recommended
-        "Qub": ("1.0.0", "1.0.0"),
-        "qtcontrols": ("1.0.0", "1.0.0"),
-        "spyder": ("3.0.0", "3.0.0"),
-    }
-
-    yield -1, "Checking required dependencies of taurus.core..."
-    r = core_requirements
-
-    m = "Checking for Python >=%s..." % r["Python"][0]
-    minPython, recPython = map(__translate_version_str2int, r["Python"])
-    currPython, currPythonStr = __get_python_version_number(), __get_python_version()
-    if currPython is None:
-        yield 2, "{msg} {ERR} (Not found])".format(msg=m, **MSG)
-    elif currPython < minPython:
-        yield 1, "{msg} {WARN} (Found {fnd}. Recommended >={rec})".format(msg=m, fnd=currPythonStr, rec=r['Python'][1], **MSG)
-    else:
-        yield 0, "{msg} {OK} (Found {fnd})".format(msg=m, fnd=currPythonStr, **MSG)
-
-    yield -1, "Checking OPTIONAL dependencies of taurus.core..."
-    r = core_optional_requirements
-
-    m = "Checking for PyTango >=%s..." % r["PyTango"][0]
-    minPyTango, recPyTango = map(__translate_version_str2int, r["PyTango"])
-    currPyTango, currPyTangoStr = __get_pytango_version_number(), __get_pytango_version()
-    if currPyTango is None:
-        yield 2, "{msg} {ERR} (Not found])".format(msg=m, **MSG)
-    elif currPyTango < minPyTango:
-        yield 1, "{msg} {WARN} (Found {fnd}. Recommended >={rec})".format(msg=m, fnd=currPyTangoStr, rec=r['PyTango'][1], **MSG)
-    else:
-        yield 0, "{msg} {OK} (Found {fnd})".format(msg=m, fnd=currPyTangoStr, **MSG)
-
-    yield -1, "Checking required dependencies of taurus.qt..."
-    r = widget_requirements
-
-    m = "Checking for PyTango >=%s..." % r["PyTango"][0]
-    if currPyTango is None:
-        yield 2, "{msg} {ERR} (Not found])".format(msg=m, **MSG)
-    elif currPyTango < minPyTango:
-        yield 1, "{msg} {WARN} (Found {fnd}. Recommended >={rec})".format(msg=m, fnd=currPyTangoStr, rec=r['PyTango'][1], **MSG)
-    else:
-        yield 0, "{msg} {OK} (Found {fnd})".format(msg=m, fnd=currPyTangoStr, **MSG)
-
-    m = "Checking for PyQt >=%s..." % r["PyQt"][0]
-    minPyQt, recPyQt = map(__translate_version_str2int, r["PyQt"])
-    currPyQt, currPyQtStr = __get_pyqt_version_number(), __get_pyqt_version()
-    if currPyQt is None:
-        yield 2, "{msg} {ERR} (Not found])".format(msg=m, **MSG)
-    elif currPyQt < minPyQt:
-        yield 1, "{msg} {WARN} (Found {fnd}. Recommended >={rec})".format(msg=m, fnd=currPyQtStr, rec=r['PyQt'][1], **MSG)
-    else:
-        yield 0, "{msg} {OK} (Found {fnd})".format(msg=m, fnd=currPyQtStr, **MSG)
-
-    m = "Checking for PyQwt >=%s..." % r["PyQwt"][0]
-    minPyQwt, recPyQwt = map(__translate_version_str2int, r["PyQwt"])
-    currPyQwt, currPyQwtStr = __get_pyqwt_version_number(), __get_pyqwt_version()
-    if currPyQwt is None:
-        yield 1, "{msg} {ERR} (Not found])".format(msg=m, **MSG)
-    elif currPyQwt < minPyQwt:
-        yield 1, "{msg} {WARN} (Found {fnd}. Recommended >={rec})".format(msg=m, fnd=currPyQwtStr, rec=r['PyQwt'][1], **MSG)
-    else:
-        yield 0, "{msg} {OK} (Found {fnd})".format(msg=m, fnd=currPyQwtStr, **MSG)
-
-    yield -1, "Checking OPTIONAL dependencies of taurus.qt..."
-    r = widget_optional_requirements
-
-    m = "Checking for Qub >=%s..." % r["Qub"][0]
-    minQub, recQub = map(__translate_version_str2int, r["Qub"])
-    currQub, currQubStr = __get_qub_version_number(), __get_qub_version()
-    if currQub is None:
-        yield 1, "{msg} {WARN} (Not found])".format(msg=m, **MSG)
-    elif currQub < minQub:
-        yield 1, "{msg} {WARN} (Found {fnd}. Recommended >={rec})".format(msg=m, fnd=currQubStr, rec=r['Qub'][1], **MSG)
-    else:
-        yield 0, "{msg} {OK} (Found {fnd})".format(msg=m, fnd=currQubStr, **MSG)
-
-    m = "Checking for spyder >=%s..." % r["spyder"][0]
-    minspyder, recspyder = map(
-        __translate_version_str2int, r["spyder"])
-    currspyder, currspyderStr = __get_spyder_version_number(
-    ), __get_spyder_version()
-    if currspyder is None:
-        yield 1, "{msg} {WARN} (Not found])".format(msg=m, **MSG)
-    elif currspyder < minspyder:
-        yield 1, "{msg} {WARN} (Found {fnd}. Recommended >={rec})".format(msg=m, fnd=currspyderStr, rec=r['spyder'][1], **MSG)
-    else:
-        yield 0, "{msg} {OK} (Found {fnd})".format(msg=m, fnd=currspyderStr, **MSG)
-
-    m = "Checking for qtcontrols >=%s..." % r["qtcontrols"][0]
-    minqtcontrols, recqtcontrols = map(
-        __translate_version_str2int, r["qtcontrols"])
-    currqtcontrols, currqtcontrolsStr = __get_qtcontrols_version_number(
-    ), __get_qtcontrols_version()
-    if currqtcontrols is None:
-        yield 1, "{msg} {WARN} (Not found])".format(msg=m, **MSG)
-    elif currqtcontrols < minqtcontrols:
-        yield 1, "{msg} {WARN} (Found {fnd}. Recommended >={rec})".format(msg=m, fnd=currqtcontrolsStr, rec=r['qtcontrols'][1], **MSG)
-    else:
-        yield 0, "{msg} {OK} (Found {fnd})".format(msg=m, fnd=currqtcontrolsStr, **MSG)
+    """deprecated since '4.0.4'"""
+    from taurus import deprecated
+    deprecated(dep='taurus.log_dependencies', rel='4.0.4')
 
 
 def getSchemeFromName(name, implicit=True):

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ extras_require = {
                      ],
     'taurus-epics': ['pyepics >=3.2.4',
                      ],
-    'taurus-h5file': ['taurus_h5file',
+    'taurus-h5file': ['h5file',
                       ],
 }
 

--- a/setup.py
+++ b/setup.py
@@ -50,9 +50,9 @@ provides = [
     # 'Taurus-Qt',  # [Taurus-Qt]
     # 'Taurus-Qt-PyQwt',  # [Taurus-Qt-Plot]
     # 'Taurus-Qt-Synoptic',  # [Taurus-Qt-Synoptic]
-    # 'Taurus-Qt-TaurusGUI',  # [Taurus-TaurusGUI]
-    # 'Taurus-Qt-Editor',  # [Taurus-Editor] --> or maybe move it to sardana
-    # 'Taurus-Qt-Guiqwt',
+    # 'Taurus-Qt-TaurusGUI',  # [Taurus-Qt-TaurusGUI]
+    # 'Taurus-Qt-Editor',  # [Taurus-Qt-Editor] --> or maybe move it to sardana
+    # 'Taurus-Qt-Guiqwt',  # [Taurus-Qt-Guiqwt]
 ]
 
 install_requires = [
@@ -63,7 +63,7 @@ extras_require = {
     'taurus-qt': ['qtpy',
                   # 'PyQt4 >=4.8',
                   # 'PyQt4.Qwt5 >=5.2.0',  # [Taurus-Qt-Plot]
-                  'ply >=2.3', # [Taurus-Qt-Synoptic]
+                  'ply >=2.3',  # [Taurus-Qt-Synoptic]
                   'lxml >=2.1',  # [Taurus-Qt-TaurusGUI]
                   'spyder >=3.0',  # [Taurus-Qt-Editor]
                   'guiqwt >=2.3.1',  # [Taurus-Qt-Guiqwt]
@@ -73,7 +73,7 @@ extras_require = {
     'taurus-epics': ['pyepics >=3.2.4',
                      ],
     'taurus-h5file': ['taurus_h5file',
-                    ],
+                      ],
 }
 
 console_scripts = [
@@ -98,9 +98,9 @@ gui_scripts = [
     'taurusdemo = taurus.qt.qtgui.panel.taurusdemo:main [Taurus-Qt]',
 ]
 
-entry_points={'console_scripts': console_scripts,
-              'gui_scripts': gui_scripts,
-              }
+entry_points = {'console_scripts': console_scripts,
+                'gui_scripts': gui_scripts,
+                }
 
 classifiers = [
     'Development Status :: 3 - Alpha',

--- a/setup.py
+++ b/setup.py
@@ -50,31 +50,30 @@ provides = [
     # 'Taurus-Qt',  # [Taurus-Qt]
     # 'Taurus-Qt-PyQwt',  # [Taurus-Qt-Plot]
     # 'Taurus-Qt-Synoptic',  # [Taurus-Qt-Synoptic]
-    # 'Taurus-TaurusGUI',  # [Taurus-TaurusGUI]
-    # 'Taurus-Editor',  # [Taurus-Editor] --> or maybe move it to sardana
+    # 'Taurus-Qt-TaurusGUI',  # [Taurus-TaurusGUI]
+    # 'Taurus-Qt-Editor',  # [Taurus-Editor] --> or maybe move it to sardana
     # 'Taurus-Qt-Guiqwt',
 ]
 
-requires = [
-    'numpy (>=1.1)',
-    'PyTango (>=7.1)',  # [Taurus-Tango]
-    'PyQt4 (>=4.8)',  # [Taurus-Qt]
-    'PyQt4.Qwt5 (>=5.2.0)',  # [Taurus-Qt-Plot]
-    'ply (>=2.3)',  # [Taurus-Qt-Synoptic]
-    'lxml (>=2.1)',  # [Taurus-TaurusGUI]
-    'spyder (>=2.2)',  # [Taurus-Editor] --> or maybe move it to sardana
-    'guiqwt (==2.3.1)',
+install_requires = [
+    'numpy>=1.1',
 ]
 
 extras_require = {
-    # 'Taurus-Tango': ['PyTango>=7.1'],  # [Taurus-Tango]
-    # 'Taurus-Qt': ['PyQt4>=4.8'],  # [Taurus-Qt]
-    # 'Taurus-Qt-PyQwt': ['PyQt4.Qwt5>=5.2.0'],  # [Taurus-Qt-Plot]
-    # 'Taurus-Qt-Synoptic': ['ply>=2.3'],  # [Taurus-Qt-Synoptic]
-    # 'Taurus-TaurusGUI': ['lxml>=2.1'],  # [Taurus-TaurusGUI]
-    # 'Taurus-Editor': ['spyder>=2.2'],  # [Taurus-Editor] --> or maybe move it to sardana
-    # 'Taurus-Qt-Guiqwt': ['guiqwt==2.3.1','guidata==1.6.1'],
-    # 'Taurus-Nexus': ['PyMca<5'],
+    'taurus-qt': ['qtpy',
+                  # 'PyQt4 >=4.8',
+                  # 'PyQt4.Qwt5 >=5.2.0',  # [Taurus-Qt-Plot]
+                  'ply >=2.3', # [Taurus-Qt-Synoptic]
+                  'lxml >=2.1',  # [Taurus-Qt-TaurusGUI]
+                  'spyder >=3.0',  # [Taurus-Qt-Editor]
+                  'guiqwt >=2.3.1',  # [Taurus-Qt-Guiqwt]
+                  ],
+    'taurus-tango': ['PyTango >=7.1',
+                     ],
+    'taurus-epics': ['pyepics >=3.2.4',
+                     ],
+    'taurus-h5file': ['taurus_h5file',
+                    ],
 }
 
 console_scripts = [
@@ -83,33 +82,20 @@ console_scripts = [
 ]
 
 gui_scripts = [
-    'taurusconfigbrowser = taurus.qt.qtgui.panel.taurusconfigeditor:main',
-    'taurusplot = taurus.qt.qtgui.plot.taurusplot:main',
-    'taurustrend = taurus.qt.qtgui.plot.taurustrend:main',
-    'taurusform = taurus.qt.qtgui.panel.taurusform:taurusFormMain',
-    'tauruspanel = taurus.qt.qtgui.panel.taurusdevicepanel:TaurusPanelMain',
-    'taurusdevicepanel = taurus.qt.qtgui.panel.taurusdevicepanel:TaurusDevicePanelMain',
-    'taurusgui = taurus.qt.qtgui.taurusgui.taurusgui:main',
-    'taurusdesigner = taurus.qt.qtdesigner.taurusdesigner:main',
-    'tauruscurve = taurus.qt.qtgui.extra_guiqwt.plot:taurusCurveDlgMain',
-    'taurustrend1d = taurus.qt.qtgui.extra_guiqwt.plot:taurusTrendDlgMain',
-    'taurusimage = taurus.qt.qtgui.extra_guiqwt.plot:taurusImageDlgMain',
-    'taurustrend2d = taurus.qt.qtgui.extra_guiqwt.taurustrend2d:taurusTrend2DMain',
-    'taurusiconcatalog = taurus.qt.qtgui.icon.catalog:main',
-    'taurusdemo = taurus.qt.qtgui.panel.taurusdemo:main',
-    # 'taurusconfigbrowser = taurus.qt.qtgui.panel.taurusconfigeditor:main [Taurus-Qt]',
-    # 'taurusplot = taurus.qt.qtgui.plot.taurusplot:main [Taurus-Qt-Plot]',
-    # 'taurustrend = taurus.qt.qtgui.plot.taurustrend:main [Taurus-Qt-Plot]',
-    # 'taurusform = taurus.qt.qtgui.panel.taurusform:taurusFormMain [Taurus-Qt]',
-    # 'tauruspanel = taurus.qt.qtgui.panel.taurusdevicepanel:TaurusPanelMain [Taurus-Qt]',
-    # 'taurusdevicepanel = taurus.qt.qtgui.panel.taurusdevicepanel:TaurusDevicePanelMain [Taurus-Qt-Plot]',
-    # 'taurusgui = taurus.qt.qtgui.taurusgui.taurusgui:main [Taurus-Qt-Plot,Taurus-Qt-Synoptic]',
-    # 'taurusdesigner = taurus.qt.qtdesigner.taurusdesigner:main [Taurus-Qt]',
-    # 'tauruscurve = taurus.qt.qtgui.extra_guiqwt.plot:taurusCurveDlgMain [Taurus-Qt-Guiqwt]',
-    # 'taurustrend1d = taurus.qt.qtgui.extra_guiqwt.plot:taurusTrendDlgMain [Taurus-Qt-Guiqwt]',
-    # 'taurusimage = taurus.qt.qtgui.extra_guiqwt.plot:taurusImageDlgMain [Taurus-Qt-Guiqwt]',
-    # 'taurustrend2d = taurus.qt.qtgui.extra_guiqwt.taurustrend2d:taurusTrend2DMain [Taurus-Qt-Guiqwt]',
-    # TODO: taurusremotelogmonitor
+    'taurusconfigbrowser = taurus.qt.qtgui.panel.taurusconfigeditor:main [Taurus-Qt]',
+    'taurusplot = taurus.qt.qtgui.plot.taurusplot:main [Taurus-Qt]',
+    'taurustrend = taurus.qt.qtgui.plot.taurustrend:main [Taurus-Qt]',
+    'taurusform = taurus.qt.qtgui.panel.taurusform:taurusFormMain [Taurus-Qt]',
+    'tauruspanel = taurus.qt.qtgui.panel.taurusdevicepanel:TaurusPanelMain [Taurus-Qt]',
+    'taurusdevicepanel = taurus.qt.qtgui.panel.taurusdevicepanel:TaurusDevicePanelMain [Taurus-Qt]',
+    'taurusgui = taurus.qt.qtgui.taurusgui.taurusgui:main [Taurus-Qt]',
+    'taurusdesigner = taurus.qt.qtdesigner.taurusdesigner:main [Taurus-Qt]',
+    'tauruscurve = taurus.qt.qtgui.extra_guiqwt.plot:taurusCurveDlgMain [Taurus-Qt]',
+    'taurustrend1d = taurus.qt.qtgui.extra_guiqwt.plot:taurusTrendDlgMain [Taurus-Qt]',
+    'taurusimage = taurus.qt.qtgui.extra_guiqwt.plot:taurusImageDlgMain [Taurus-Qt]',
+    'taurustrend2d = taurus.qt.qtgui.extra_guiqwt.taurustrend2d:taurusTrend2DMain [Taurus-Qt]',
+    'taurusiconcatalog = taurus.qt.qtgui.icon.catalog:main [Taurus-Qt]',
+    'taurusdemo = taurus.qt.qtgui.panel.taurusdemo:main [Taurus-Qt]',
 ]
 
 entry_points={'console_scripts': console_scripts,
@@ -156,7 +142,7 @@ setup(name='taurus',
       include_package_data=True,
       entry_points=entry_points,
       provides=provides,
-      requires=requires,
+      install_requires=install_requires,
       extras_require=extras_require,
       test_suite='taurus.test.testsuite.get_taurus_suite',
       )


### PR DESCRIPTION
- Update requirements (fixes #376)
- Use setuptool's "install_requires" instead of distutil's "requires"
  in order to fix #407 (pip does not install taurus dependencies)
- make most dependencies optional and associate each with an "extra"
  feature in Taurus.
- Refactor check_dependencies() (implemented in taurushelper.py) to
  make use of the dependencies declared in setup.py (fixes #406 )
- Change getting started documentation to facilitate maintenance
  of dependencies documentation.
- Deprecate log_dependencies()
- Clean unused private functions in `taurushelper.py`