### PR TITLE
Fix Taurustrend: force reading period not working

### DIFF
--- a/lib/taurus/qt/qtgui/plot/taurustrend.py
+++ b/lib/taurus/qt/qtgui/plot/taurustrend.py
@@ -36,6 +36,7 @@ import gc
 from taurus.external.qt import Qt, Qwt5
 
 import taurus.core
+from taurus.core.taurusattribute import TaurusAttribute
 from taurus.core.util.containers import CaselessDict, CaselessList, ArrayBuffer
 from taurus.qt.qtgui.base import TaurusBaseComponent
 from taurus.qt.qtgui.plot import TaurusPlot
@@ -269,7 +270,7 @@ class TaurusTrendsSet(Qt.QObject, TaurusBaseComponent):
 
     def getModelClass(self):
         '''see :meth:`TaurusBaseComponent.getModelClass`'''
-        return taurus.core.taurusattribute.TaurusAttribute
+        return TaurusAttribute
 
     def registerDataChanged(self, listener, meth):
         '''see :meth:`TaurusBaseComponent.registerDataChanged`'''
@@ -398,7 +399,10 @@ class TaurusTrendsSet(Qt.QObject, TaurusBaseComponent):
             # (it overwrites custom titles!)
             return
         else:
-            model = evt_src if evt_src is not None else self.getModelObj()
+            if isinstance(evt_src, TaurusAttribute):
+                model = evt_src
+            else:
+                model = self.getModelObj()
             if evt_type == taurus.core.taurusbasetypes.TaurusEventType.Error:
                 self._onDroppedEvent(reason='Error event')
                 if not self.parent().getUseArchiving():


### PR DESCRIPTION
The "force reading period" option from taurustrend context
menu has no effect; attributes are still updated only on
event received.

Fix exception in TaurusTrendsSet handleEvent method.

Fix #475