### PR TITLE
Allow subscribing to events w/ or w/o first event - support-3.x

### DIFF
--- a/lib/taurus/core/util/event.py
+++ b/lib/taurus/core/util/event.py
@@ -170,14 +170,19 @@ class EventGenerator(Object):
         else:
             pass
 
-    def subscribeEvent(self, cb, data=None):
+    def subscribeEvent(self, cb, data=None, with_first_event=True):
         """Subscribes to the event
         
         :param cb: a callable object
         :type  cb: callable
         :param data: extra data to send each time an event is triggered on the
-                     given callback. Default is None
-        :type  data: object"""
+            given callback. Default is None.
+        :type  data: object
+        :param with_first_event: whether call the callback with the first event
+            value (the most recent value) during the subscription process.
+            Default is True.
+        :type data: boolean
+        """
         if not self.events_active:
             raise RuntimeError, ('%s does not have ' \
                                  'events/polling active' % self.event_name)
@@ -190,7 +195,8 @@ class EventGenerator(Object):
                 raise RuntimeError, ('Callback %s(%s) already reg. on %s' %
                                     (cb, data, self.event_name))
             self.cb_list.append((cb_ref, data))
-            cb(data, self.first_event_val)
+            if with_first_event:
+                cb(data, self.first_event_val)
         finally:
             self.unlock()
 


### PR DESCRIPTION
**This PR is an equivalent to #482 but for support-3.x branch.**

Emitting first event during the subscription process with the most recent
value may not be always desired.

This is the case of the TangoAttributeEG class in Sardana, a subclass of
the EventGenerator. It may work with the attribute which serves as a data
pipe for transferring scan results. It is not desired to receive an event
with the data corresponding to the previous scan while subscribing to events
of the new scan.

Allow control whether to emit the first event during the subscription process.