### PR TITLE
Use full name when checking if a DB is mysql

### DIFF
--- a/lib/taurus/core/tango/tangodatabase.py
+++ b/lib/taurus/core/tango/tangodatabase.py
@@ -317,8 +317,8 @@ class TangoDatabaseCache(object):
 
     def refresh(self):
         db = self.db
-
-        if hasattr(Device(db.dev_name()), 'DbMySqlSelect'):
+        db_dev_name = '/'.join((db.getFullName(), db.dev_name()))
+        if hasattr(Device(db_dev_name), 'DbMySqlSelect'):
             # optimization in case the db exposes a MySQL select API
             query = ("SELECT name, alias, exported, host, server, class " +
                      "FROM device")


### PR DESCRIPTION
The cache refresh does a check to see if a mysql optimization can be done.
This is done by checking the tango DB device, which is obtained using a call 
to `TangoAuthority.dev_name`. The` dev_name` method is exposed from the 
Tango API and returns a tango URI **without the authority component**. 
In the current implementation this may lead to checking the wrong device in some 
special cases. Avoid it by prefixing the tango URI with the authority full name.