### PR TITLE
TaurusValue bckcomp of label configs

### DIFF
--- a/lib/taurus/core/tango/test/res/TangoSchemeTest
+++ b/lib/taurus/core/tango/test/res/TangoSchemeTest
@@ -142,6 +142,7 @@ class TangoSchemeTest(Device):
              'uchar_image': dict(unit=default_unit["int"],
                                  dtype=[(numpy.uint8,)],
                                  max_dim_x=MAXDIMX, max_dim_y=MAXDIMY),
+             'MIXEDcase': dict(dtype=str)
              }
 
     extra_cfg = {'short_scalar': dict(min_value=default_ranges['int'][0],
@@ -201,6 +202,8 @@ class TangoSchemeTest(Device):
                                **attrs['float_image'])
     string_image_ro = attribute(access=AttrWriteType.READ,
                                 **attrs['string_image'])
+    MIXEDcase = attribute(access=AttrWriteType.READ,
+                              **attrs['MIXEDcase'])
 
     # READ/WRITE ATTRIBUTES
     # SCALARS
@@ -308,6 +311,9 @@ class TangoSchemeTest(Device):
 
     def read_uchar_image_ro(self):
         return [[self.default_rvalue['uchar']] * self.DIMX] * self.DIMY
+
+    def read_MIXEDcase(self):
+        return "MIXEDcase"
 
     # READ/WRITE METHODS
     # SCALARS

--- a/lib/taurus/qt/qtgui/display/tauruslabel.py
+++ b/lib/taurus/qt/qtgui/display/tauruslabel.py
@@ -231,6 +231,7 @@ class TaurusLabel(Qt.QLabel, TaurusBaseWidget):
     def __init__(self, parent=None, designMode=False):
         self._prefix = self.DefaultPrefix
         self._suffix = self.DefaultSuffix
+        self._permanentText = None
         self._bgRole = self.DefaultBgRole
         self._fgRole = self.DefaultFgRole
         self._modelIndex = self.DefaultModelIndex
@@ -398,6 +399,10 @@ class TaurusLabel(Qt.QLabel, TaurusBaseWidget):
     def resetSuffixText(self):
         self.setSuffixText(self.DefaultSuffix)
 
+    def setPermanentText(self, text):
+        self.setText(text)
+        self._permanentText = text
+
     def setAutoTrim(self, trim):
         self._autoTrim = trim
         self.controllerUpdate()
@@ -422,6 +427,11 @@ class TaurusLabel(Qt.QLabel, TaurusBaseWidget):
 
     def resetAutoTrim(self):
         self.setAutoTrim(self.DefaultAutoTrim)
+
+    def displayValue(self, v):
+        if self._permanentText is not None:
+            return self._permanentText
+        return TaurusBaseWidget.displayValue(self, v)
 
     @classmethod
     def getQtDesignerPluginInfo(cls):

--- a/lib/taurus/qt/qtgui/display/tauruslabel.py
+++ b/lib/taurus/qt/qtgui/display/tauruslabel.py
@@ -252,6 +252,11 @@ class TaurusLabel(Qt.QLabel, TaurusBaseWidget):
         if self._designMode:
             self.controllerUpdate()
 
+        # register configurable properties
+        self.registerConfigProperty(
+            self.getPermanentText, self.setPermanentText, "permanentText"
+            )
+
     def _calculate_controller_class(self):
         ctrl_map = _CONTROLLER_MAP
         if self._designMode:
@@ -398,6 +403,9 @@ class TaurusLabel(Qt.QLabel, TaurusBaseWidget):
 
     def resetSuffixText(self):
         self.setSuffixText(self.DefaultSuffix)
+
+    def getPermanentText(self):
+        return self._permanentText
 
     def setPermanentText(self, text):
         self.setText(text)

--- a/lib/taurus/qt/qtgui/panel/taurusvalue.py
+++ b/lib/taurus/qt/qtgui/panel/taurusvalue.py
@@ -1216,6 +1216,20 @@ class TaurusValue(Qt.QWidget, TaurusBaseWidget):
 
     @Qt.pyqtSlot('QString')
     def setLabelConfig(self, config):
+        """Sets fragment configuration to the label widget.
+
+        :param config: fragment
+        :type config: str
+        """
+        # backwards compatibility: this method used to work for setting
+        # an arbitrary text to the label widget
+        try:
+            self.getModelFragmentObj(config)
+        except Exception:
+            msg = "Use setLabelText for setting an arbitrary label text"
+            self.deprecated(msg)
+            self.setLabelText(config)
+            return
         self._labelConfig = config
         self.updateLabelWidget()
 

--- a/lib/taurus/qt/qtgui/panel/taurusvalue.py
+++ b/lib/taurus/qt/qtgui/panel/taurusvalue.py
@@ -106,11 +106,11 @@ class DefaultLabelWidget(TaurusLabel):
             TaurusLabel.setModel(self, None)
             self.setText(devName)
 
-    _BCK_COMPAT_TAGS = {'<attr_name>': '{attr.name}',
-                        '<attr_fullname>': '{attr.fullname}',
-                        '<dev_alias>': '{dev.name}',
-                        '<dev_name>': '{dev_name}',
-                        '<dev_fullname>': '{dev.fullname}',
+    _BCK_COMPAT_TAGS = {'<attr_name>': 'name',
+                        '<attr_fullname>': 'fullname',
+                        '<dev_alias>': 'parentObj.name',
+                        '<dev_name>': 'parentObj.name',
+                        '<dev_fullname>': 'parentObj.fullname',
                         }
 
     def getDisplayValue(self, cache=True, fragmentName=None):
@@ -121,9 +121,7 @@ class DefaultLabelWidget(TaurusLabel):
             new = self._BCK_COMPAT_TAGS.get(old, '{attr.%s}' % old)
             self.deprecated(dep=old, alt=new)
             fragmentName = fragmentName.replace(old, new)
-        attr = self.getModelObj()
-        dev = attr.getParent()
-        return fragmentName.format(dev=dev, attr=attr)
+        return TaurusLabel.getDisplayValue(self, cache, fragmentName)
 
     def sizeHint(self):
         return Qt.QSize(Qt.QLabel.sizeHint(self).width(), 18)
@@ -346,7 +344,7 @@ class TaurusValue(Qt.QWidget, TaurusBaseWidget):
 
         self._allowWrite = True
         self._minimumHeight = None
-        self._labelConfig = '{attr.label}'
+        self._labelConfig = 'label'
         self.setModifiableByUser(False)
 
         if parent is not None:

--- a/lib/taurus/qt/qtgui/panel/taurusvalue.py
+++ b/lib/taurus/qt/qtgui/panel/taurusvalue.py
@@ -353,6 +353,8 @@ class TaurusValue(Qt.QWidget, TaurusBaseWidget):
 
         self.registerConfigProperty(
             self.getLabelConfig, self.setLabelConfig, 'labelConfig')
+        self.registerConfigProperty(
+            self.getLabelText, self.setLabelText, 'labelText')
         self.registerConfigProperty(self.isCompact, self.setCompact, 'compact')
 
     def setVisible(self, visible):
@@ -1236,6 +1238,9 @@ class TaurusValue(Qt.QWidget, TaurusBaseWidget):
     def resetLabelConfig(self):
         self._labelConfig = 'label'
         self.updateLabelWidget()
+
+    def getLabelText(self):
+        return self._labelText
 
     def setLabelText(self, text):
         self._labelText = text

--- a/lib/taurus/qt/qtgui/panel/taurusvalue.py
+++ b/lib/taurus/qt/qtgui/panel/taurusvalue.py
@@ -1216,7 +1216,7 @@ class TaurusValue(Qt.QWidget, TaurusBaseWidget):
         self.updateLabelWidget()
 
     def resetLabelConfig(self):
-        self._labelConfig = '{attr.label}'
+        self._labelConfig = 'label'
         self.updateLabelWidget()
 
     def getSwitcherClass(self):

--- a/lib/taurus/qt/qtgui/panel/taurusvalue.py
+++ b/lib/taurus/qt/qtgui/panel/taurusvalue.py
@@ -345,6 +345,7 @@ class TaurusValue(Qt.QWidget, TaurusBaseWidget):
         self._allowWrite = True
         self._minimumHeight = None
         self._labelConfig = 'label'
+        self._labelText = None
         self.setModifiableByUser(False)
 
         if parent is not None:
@@ -797,6 +798,9 @@ class TaurusValue(Qt.QWidget, TaurusBaseWidget):
             if hasattr(self._labelWidget, 'setModel'):
                 self._labelWidget.setModel(self.getFullModelName())
 
+            if self._labelText is not None:
+                self._labelWidget.setPermanentText(self._labelText)
+
     def updateReadWidget(self):
         # get the class for the widget and replace it if necessary
         try:
@@ -1218,6 +1222,10 @@ class TaurusValue(Qt.QWidget, TaurusBaseWidget):
     def resetLabelConfig(self):
         self._labelConfig = 'label'
         self.updateLabelWidget()
+
+    def setLabelText(self, text):
+        self._labelText = text
+        self._labelWidget.setPermanentText(text)
 
     def getSwitcherClass(self):
         '''Returns the TaurusValue switcher class (used in compact mode).

--- a/lib/taurus/qt/qtgui/panel/test/test_taurusvalue.py
+++ b/lib/taurus/qt/qtgui/panel/test/test_taurusvalue.py
@@ -34,35 +34,35 @@ from taurus.core.tango.test import TangoSchemeTestLauncher
 DEV_NAME = TangoSchemeTestLauncher.DEV_NAME
 
 
-@insertTest(helper_name='texts',
-            model='tango:' + DEV_NAME + '/double_scalar',
-            expected=('double_scalar', '1.23', '0.00 mm', 'mm'),
-            # expected=('double_scalar', '1.23', '0.0', 'mm'),
+@insertTest(helper_name="texts",
+            model="tango:" + DEV_NAME + "/double_scalar",
+            expected=("double_scalar", "1.23", "0.00 mm", "mm"),
+            # expected=("double_scalar", "1.23", "0.0", "mm"),
             # TODO: change taurusvalue's line edit to hide units
             )
 class TaurusValueTest(TangoSchemeTestLauncher, BaseWidgetTestCase,
                       unittest.TestCase):
-    '''
+    """
     Specific tests for TaurusValue
-    '''
+    """
     _klass = TaurusValue
 
     def test_bug126(self):
-        '''Verify that case is not lost when customizing a label (bug#126)'''
+        """Verify that case is not lost when customizing a label (bug#126)"""
         w = self._widget
-        # self._widget.setModel('eval:1')
-        self._widget.setModel('tango:' + DEV_NAME + '/double_scalar')
-        label = 'MIXEDcase'
+        # self._widget.setModel("eval:1")
+        self._widget.setModel("tango:" + DEV_NAME + "/double_scalar")
+        label = "MIXEDcase"
         w.setLabelConfig(label)
         self.processEvents(repetitions=10, sleep=.1)
         shownLabel = str(w.labelWidget().text())
-        msg = 'Shown label ("%s") differs from set label ("%s")' % (shownLabel,
+        msg = "Shown label ("%s") differs from set label ("%s")" % (shownLabel,
                                                                     label)
         self.assertEqual(label, shownLabel, msg)
         self.assertMaxDeprecations(1)
 
     def texts(self, model=None, expected=None, fgRole=None, maxdepr=0):
-        '''Checks the texts for scalar attributes'''
+        """Checks the texts for scalar attributes"""
         self._widget.setModel(model)
         if fgRole is not None:
             self._widget.setFgRole(fgRole)
@@ -72,7 +72,7 @@ class TaurusValueTest(TangoSchemeTestLauncher, BaseWidgetTestCase,
                str(self._widget.writeWidget().displayText()),
                str(self._widget.unitsWidget().text()),
                )
-        msg = ('wrong text for "%s":\n expected: %s\n got: %s' %
+        msg = ("wrong text for "%s":\n expected: %s\n got: %s" %
                (model, expected, got))
         self.assertEqual(got, expected, msg)
         self.assertMaxDeprecations(maxdepr)
@@ -80,9 +80,9 @@ class TaurusValueTest(TangoSchemeTestLauncher, BaseWidgetTestCase,
     def test_labelCaseSensitivity(self):
         """Verify that case is respected of in the label widget"""
         w = self._widget
-        # self._widget.setModel('eval:1')
-        self._widget.setModel('tango:' + DEV_NAME + '/MIXEDcase')
-        label = 'MIXEDcase'
+        # self._widget.setModel("eval:1")
+        self._widget.setModel("tango:" + DEV_NAME + "/MIXEDcase")
+        label = "MIXEDcase"
         self.processEvents(repetitions=10, sleep=.1)
         shownLabel = str(w.labelWidget().text())
         msg = 'Shown label ("%s") differs from set label ("%s")' % (shownLabel,
@@ -91,10 +91,10 @@ class TaurusValueTest(TangoSchemeTestLauncher, BaseWidgetTestCase,
         self.assertMaxDeprecations(0)
 
     def tearDown(self):
-        '''Set Model to None'''
+        """Set Model to None"""
         self._widget.setModel(None)
         TangoSchemeTestLauncher.tearDown(self)
         unittest.TestCase.tearDown(self)
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     pass

--- a/lib/taurus/qt/qtgui/panel/test/test_taurusvalue.py
+++ b/lib/taurus/qt/qtgui/panel/test/test_taurusvalue.py
@@ -78,8 +78,7 @@ class TaurusValueTest(TangoSchemeTestLauncher, BaseWidgetTestCase,
         self.assertMaxDeprecations(maxdepr)
 
     def test_labelCaseSensitivity(self):
-        '''Verify that case is respected of in the label widget'''
-        '''Verify that case is not lost when customizing a label (bug#126)'''
+        """Verify that case is respected of in the label widget"""
         w = self._widget
         # self._widget.setModel('eval:1')
         self._widget.setModel('tango:' + DEV_NAME + '/MIXEDcase')

--- a/lib/taurus/qt/qtgui/panel/test/test_taurusvalue.py
+++ b/lib/taurus/qt/qtgui/panel/test/test_taurusvalue.py
@@ -77,6 +77,20 @@ class TaurusValueTest(TangoSchemeTestLauncher, BaseWidgetTestCase,
         self.assertEqual(got, expected, msg)
         self.assertMaxDeprecations(maxdepr)
 
+    def test_labelCaseSensitivity(self):
+        '''Verify that case is respected of in the label widget'''
+        '''Verify that case is not lost when customizing a label (bug#126)'''
+        w = self._widget
+        # self._widget.setModel('eval:1')
+        self._widget.setModel('tango:' + DEV_NAME + '/MIXEDcase')
+        label = 'MIXEDcase'
+        self.processEvents(repetitions=10, sleep=.1)
+        shownLabel = str(w.labelWidget().text())
+        msg = 'Shown label ("%s") differs from set label ("%s")' % (shownLabel,
+                                                                    label)
+        self.assertEqual(label, shownLabel, msg)
+        self.assertMaxDeprecations(0)
+
     def tearDown(self):
         '''Set Model to None'''
         self._widget.setModel(None)

--- a/lib/taurus/qt/qtgui/panel/test/test_taurusvalue.py
+++ b/lib/taurus/qt/qtgui/panel/test/test_taurusvalue.py
@@ -51,9 +51,8 @@ class TaurusValueTest(TangoSchemeTestLauncher, BaseWidgetTestCase,
         '''Verify that case is not lost when customizing a label (bug#126)'''
         w = self._widget
         # self._widget.setModel('eval:1')
-        self._widget.setModel('tango:' + DEV_NAME + '/double_scalar')
+        self._widget.setModel('tango:' + DEV_NAME + '/MIXEDcase')
         label = 'MIXEDcase'
-        w.setLabelConfig(label)
         self.processEvents(repetitions=10, sleep=.1)
         shownLabel = str(w.labelWidget().text())
         msg = 'Shown label ("%s") differs from set label ("%s")' % (shownLabel,

--- a/lib/taurus/qt/qtgui/panel/test/test_taurusvalue.py
+++ b/lib/taurus/qt/qtgui/panel/test/test_taurusvalue.py
@@ -56,7 +56,7 @@ class TaurusValueTest(TangoSchemeTestLauncher, BaseWidgetTestCase,
         w.setLabelConfig(label)
         self.processEvents(repetitions=10, sleep=.1)
         shownLabel = str(w.labelWidget().text())
-        msg = "Shown label ("%s") differs from set label ("%s")" % (shownLabel,
+        msg = 'Shown label ("%s") differs from set label ("%s")' % (shownLabel,
                                                                     label)
         self.assertEqual(label, shownLabel, msg)
         self.assertMaxDeprecations(1)
@@ -72,7 +72,7 @@ class TaurusValueTest(TangoSchemeTestLauncher, BaseWidgetTestCase,
                str(self._widget.writeWidget().displayText()),
                str(self._widget.unitsWidget().text()),
                )
-        msg = ("wrong text for "%s":\n expected: %s\n got: %s" %
+        msg = ('wrong text for "%s":\n expected: %s\n got: %s' %
                (model, expected, got))
         self.assertEqual(got, expected, msg)
         self.assertMaxDeprecations(maxdepr)
@@ -80,7 +80,6 @@ class TaurusValueTest(TangoSchemeTestLauncher, BaseWidgetTestCase,
     def test_labelCaseSensitivity(self):
         """Verify that case is respected of in the label widget"""
         w = self._widget
-        # self._widget.setModel("eval:1")
         self._widget.setModel("tango:" + DEV_NAME + "/MIXEDcase")
         label = "MIXEDcase"
         self.processEvents(repetitions=10, sleep=.1)

--- a/lib/taurus/qt/qtgui/panel/test/test_taurusvalue.py
+++ b/lib/taurus/qt/qtgui/panel/test/test_taurusvalue.py
@@ -51,14 +51,15 @@ class TaurusValueTest(TangoSchemeTestLauncher, BaseWidgetTestCase,
         '''Verify that case is not lost when customizing a label (bug#126)'''
         w = self._widget
         # self._widget.setModel('eval:1')
-        self._widget.setModel('tango:' + DEV_NAME + '/MIXEDcase')
+        self._widget.setModel('tango:' + DEV_NAME + '/double_scalar')
         label = 'MIXEDcase'
+        w.setLabelConfig(label)
         self.processEvents(repetitions=10, sleep=.1)
         shownLabel = str(w.labelWidget().text())
         msg = 'Shown label ("%s") differs from set label ("%s")' % (shownLabel,
                                                                     label)
         self.assertEqual(label, shownLabel, msg)
-        self.assertMaxDeprecations(0)
+        self.assertMaxDeprecations(1)
 
     def texts(self, model=None, expected=None, fgRole=None, maxdepr=0):
         '''Checks the texts for scalar attributes'''


### PR DESCRIPTION
This PR aims to fix the backwards compatibility of the TaurusValue label configs.
The old-style label configs are now correctly translated to the new-style fragments e.g. <attr_name> -> name,  <dev_fullname>: parentObj.fullname.

**Note**: `TaurusValue.setLabelConfig` used with a simple string was previously setting a label text to this string. IMHO this was working just by coincidence. For me the `setLabelConfig` method should not be used to achieve this kind of behavior. That's why this PR does not maintain the backwards compatibility here.