### PR TITLE
Use displayValue to format the datainspector label

### DIFF
--- a/lib/taurus/qt/qtgui/plot/taurusplot.py
+++ b/lib/taurus/qt/qtgui/plot/taurusplot.py
@@ -2975,6 +2975,8 @@ class TaurusPlot(Qwt5.QwtPlot, TaurusBaseWidget):
                             pickedCurveName = name
                             pickedIndex = i
                             pickedAxes = curve.xAxis(), curve.yAxis()
+                            _displayValue = getattr(curve, 'owner', curve
+                                                    ).displayValue
         finally:
             self.curves_lock.release()
 
@@ -2988,12 +2990,14 @@ class TaurusPlot(Qwt5.QwtPlot, TaurusBaseWidget):
             pickedCurveTitle = self.getCurveTitle(pickedCurveName)
             self.replot()
             label = self._pickedMarker.label()
+            display_y = _displayValue(picked.y())
             if self.getXIsTime():
-                infotxt = "'%s'[%i]:\n\t (t=%s, y=%.5g)" % (
-                    pickedCurveTitle, pickedIndex, datetime.fromtimestamp(picked.x()).ctime(), picked.y())
+                infotxt = "'%s'[%i]:\n\t (t=%s, y=%s)" % (
+                    pickedCurveTitle, pickedIndex,
+                    datetime.fromtimestamp(picked.x()).ctime(), display_y )
             else:
-                infotxt = "'%s'[%i]:\n\t (x=%.5g, y=%.5g)" % (
-                    pickedCurveTitle, pickedIndex, picked.x(), picked.y())
+                infotxt = "'%s'[%i]:\n\t (x=%.5g, y=%s)" % (
+                    pickedCurveTitle, pickedIndex, picked.x(), display_y )
             label.setText(infotxt)
             fits = label.textSize().width() < self.size().width()
             if fits:

--- a/lib/taurus/qt/qtgui/plot/taurustrend.py
+++ b/lib/taurus/qt/qtgui/plot/taurustrend.py
@@ -33,6 +33,7 @@ import time
 import numpy
 import re
 import gc
+import weakref
 from taurus.external.qt import Qt, Qwt5
 
 import taurus.core
@@ -247,6 +248,8 @@ class TaurusTrendsSet(Qt.QObject, TaurusBaseComponent):
         :param name: (str) the name of the curve
         :param curve: (TaurusCurve) the curve object to be added
         '''
+        # provide the curve with a weakref to the trendset (the owner)
+        curve.owner = weakref.proxy(self)
         self._curves[name] = curve
         self._orderedCurveNames.append(name)
 


### PR DESCRIPTION
DataInspector mode in TaurusPlot  uses a hardcoded format for 
displaying the Y value.
This causes issues when more precisionis required (see
https://github.com/taurus-org/taurus/issues/181 )
Fix it by delegating the formatting to `displayValue()` (this requires
to have access to the associated trendset from the curve when 
working on a TaurusTrend)

Fixes #181 

Known limitations: 
- The inspector does not react to changes in format while it is running (but new instances of the plot/trend will use the correct format)
- The x value is not treated like the Y. This is a consequence of the X model being a "second-class citizen" (there is no TaurusBaseComponent associated to it and corespondingly no `displayValue()` method)