### PR TITLE
Add deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ develop branch) won't be reflected in this file.
 ### Deprecated
 - TangoAttribute.format
 - taurus.qt.qtgui.console (#385)
+- taurustrend1d (#514)
+- tauruscurve (#514)
 
 ### Removed
 - `taurus.external.ordereddict` (#223)

--- a/lib/taurus/qt/qtgui/extra_guiqwt/plot.py
+++ b/lib/taurus/qt/qtgui/extra_guiqwt/plot.py
@@ -57,6 +57,8 @@ class TaurusCurveDialog(CurveDialog, TaurusBaseWidget):
         '''see :class:`guiqwt.plot.CurveDialog` for other valid initialization parameters'''
         CurveDialog.__init__(self, parent=parent, toolbar=toolbar, **kwargs)
         TaurusBaseWidget.__init__(self, 'TaurusCurveDialog')
+        self.info("\n\nDEPRECATION WARNING: This widget is deprecated. "
+            "Use taurustrend instead\n\n")
         self.setWindowFlags(Qt.Qt.Widget)
         self._designMode = designMode
         self._modelNames = CaselessList()
@@ -203,6 +205,8 @@ class TaurusTrendDialog(CurveDialog, TaurusBaseWidget):
         '''see :class:`guiqwt.plot.CurveDialog` for other valid initialization parameters'''
         CurveDialog.__init__(self, parent=parent, toolbar=toolbar, **kwargs)
         TaurusBaseWidget.__init__(self, 'TaurusTrendDialog')
+        self.info("\n\nDEPRECATION WARNING: This widget is deprecated. "
+            "Use taurustrend instead\n\n")
         self.setWindowFlags(Qt.Qt.Widget)
         self._designMode = designMode
         self._modelNames = CaselessList()

--- a/lib/taurus/qt/qtgui/extra_guiqwt/plot.py
+++ b/lib/taurus/qt/qtgui/extra_guiqwt/plot.py
@@ -57,7 +57,7 @@ class TaurusCurveDialog(CurveDialog, TaurusBaseWidget):
         '''see :class:`guiqwt.plot.CurveDialog` for other valid initialization parameters'''
         CurveDialog.__init__(self, parent=parent, toolbar=toolbar, **kwargs)
         TaurusBaseWidget.__init__(self, 'TaurusCurveDialog')
-        self.deprecated(rel='4.1', dep='tauruscurve', alt='taurusplot')
+        self.deprecated(rel='4.1', dep='TaurusCurveDialog', alt='TaurusPlot / taurusplot launcher')
         self.setWindowFlags(Qt.Qt.Widget)
         self._designMode = designMode
         self._modelNames = CaselessList()
@@ -204,7 +204,7 @@ class TaurusTrendDialog(CurveDialog, TaurusBaseWidget):
         '''see :class:`guiqwt.plot.CurveDialog` for other valid initialization parameters'''
         CurveDialog.__init__(self, parent=parent, toolbar=toolbar, **kwargs)
         TaurusBaseWidget.__init__(self, 'TaurusTrendDialog')
-        self.deprecated(rel='4.1', dep='taurustrend1d', alt='taurustrend')
+        self.deprecated(rel='4.1', dep='TaurusTrendDialog', alt='TaurusTrend / taurustrend launcher')
         self.setWindowFlags(Qt.Qt.Widget)
         self._designMode = designMode
         self._modelNames = CaselessList()

--- a/lib/taurus/qt/qtgui/extra_guiqwt/plot.py
+++ b/lib/taurus/qt/qtgui/extra_guiqwt/plot.py
@@ -57,7 +57,7 @@ class TaurusCurveDialog(CurveDialog, TaurusBaseWidget):
         '''see :class:`guiqwt.plot.CurveDialog` for other valid initialization parameters'''
         CurveDialog.__init__(self, parent=parent, toolbar=toolbar, **kwargs)
         TaurusBaseWidget.__init__(self, 'TaurusCurveDialog')
-        self.deprecated(rel='4.1', dep='tauruscurve', alt='taurustrend')
+        self.deprecated(rel='4.1', dep='tauruscurve', alt='taurusplot')
         self.setWindowFlags(Qt.Qt.Widget)
         self._designMode = designMode
         self._modelNames = CaselessList()

--- a/lib/taurus/qt/qtgui/extra_guiqwt/plot.py
+++ b/lib/taurus/qt/qtgui/extra_guiqwt/plot.py
@@ -57,8 +57,7 @@ class TaurusCurveDialog(CurveDialog, TaurusBaseWidget):
         '''see :class:`guiqwt.plot.CurveDialog` for other valid initialization parameters'''
         CurveDialog.__init__(self, parent=parent, toolbar=toolbar, **kwargs)
         TaurusBaseWidget.__init__(self, 'TaurusCurveDialog')
-        self.info("\n\nDEPRECATION WARNING: This widget is deprecated. "
-            "Use taurustrend instead\n\n")
+        self.deprecated(rel='4.1', dep='tauruscurve', alt='taurustrend')
         self.setWindowFlags(Qt.Qt.Widget)
         self._designMode = designMode
         self._modelNames = CaselessList()
@@ -205,8 +204,7 @@ class TaurusTrendDialog(CurveDialog, TaurusBaseWidget):
         '''see :class:`guiqwt.plot.CurveDialog` for other valid initialization parameters'''
         CurveDialog.__init__(self, parent=parent, toolbar=toolbar, **kwargs)
         TaurusBaseWidget.__init__(self, 'TaurusTrendDialog')
-        self.info("\n\nDEPRECATION WARNING: This widget is deprecated. "
-            "Use taurustrend instead\n\n")
+        self.deprecated(rel='4.1', dep='taurustrend1d', alt='taurustrend')
         self.setWindowFlags(Qt.Qt.Widget)
         self._designMode = designMode
         self._modelNames = CaselessList()


### PR DESCRIPTION
Add deprecation warnings for tauruscurve and taurustrend1d.

This widgets are deprecated, instead of them, taurustrend should
be used. Add deprecation warnings.