### PR TITLE
fixing typo and menu changes in users doc

### DIFF
--- a/doc/source/users/introduction.rst
+++ b/doc/source/users/introduction.rst
@@ -13,7 +13,7 @@ systems (such as EPICS_) and data sources.
           Tango-related examples. We intend to gradually introduce more 
           non-Tango examples
 
-Taurus was developed within the Sardana_ project, but since it has being found 
+Taurus was developed within the Sardana_ project, but since it has been found 
 useful for other projects not related to Sardana, it has been 
 moved to a separate project (although both projects are kept in sync and share 
 most of their developers).

--- a/doc/source/users/ui/arrayeditor.rst
+++ b/doc/source/users/ui/arrayeditor.rst
@@ -14,7 +14,7 @@ The :class:`ArrayEditor` is a widget for graphically editing a spectrum.
 It consists of two :ref:`plots <taurusplot_ui>` and a *control point area*. The plot
 on top shows the current and modified spectrum. The other plot shows
 the difference between the current and the modified spectrum. The Control point
-area shows details on the conrol points that have been defined.
+area shows details on the control points that have been defined.
 
 The spectrum can be modified by adding control points and moving them 
 along the vertical axis, either by setting the value in the controls area or by

--- a/doc/source/users/ui/plot.rst
+++ b/doc/source/users/ui/plot.rst
@@ -148,6 +148,8 @@ where you can add data sets to the plot from the following sources:
   You can use `x` as a dependent variable, which you can set as regular steps or
   using an arbitrary expression.
 
+Note that there is actually no way to remove RawData curve from the GUI.
+
 .. figure:: /_static/taurusplot-inputdata02.png 
    :align: center
 

--- a/doc/source/users/ui/plot.rst
+++ b/doc/source/users/ui/plot.rst
@@ -157,7 +157,7 @@ Storing and recovering current configuration
 
 Once you have customized the way the plot looks (see the
 `Plot Configuration dialog`_ section), you may want to save the settings for
-later use. This can be done using the `Store current settings` option from the
+later use. This can be done using the `Save current settings` option from the
 `TaurusPlot context menu`_.
 
 This will save which curves should be plotted and how they should look.

--- a/doc/source/users/ui/plot.rst
+++ b/doc/source/users/ui/plot.rst
@@ -192,7 +192,7 @@ features can be useful:
 
 - Peak locator: :class:`TaurusPlot` can locate and put a mark at the maximum and/or minimum
   points in the plotted data. You switch this option on and off using the
-  `Show Peaks` option from the `TaurusPlot context menu`_ or use from the
+  `Show min` and `Show max` option from the `TaurusPlot context menu`_ or use from the
   `Peak Markers` option in the `Plot Configuration dialog`_
 
   .. image:: /_static/taurusplot-datainfo03.png
@@ -266,9 +266,8 @@ Here are some tips for entering valid date/time values:
     - The date can be written in various formats. ISO format is recommended
       (e.g. "1917-10-25"), although others like, e.g. "25/10/1917"
       are also accepted.
-    - The time is given in 24 hours format (e.g. "21:45") and may include
-      (e.g. "21:45:01") secondshours:minutes , if given, may optionally 
-      include seconds: e.g.,  is
+    - The time is given in 24 hours format (e.g. "21:45") and may optionnaly
+      include seconds if given (e.g. "21:45:01")
     - Date is mandatory while time is optional. If time is given, it must be
       separated from the date with a single space (e.g. "1917-10-25 21:45:01")
     

--- a/doc/source/users/ui/taurusgui.rst
+++ b/doc/source/users/ui/taurusgui.rst
@@ -151,7 +151,7 @@ want to extend the application by adding custom panels to provide more features
 (e.g., to add an extra plot panel, or a new form).
 
 You can add a new panel by clicking in the "New Panel" button of the main tool
-bar (or selecting `View->Panel->New Panel...`). This will open a dialog offering
+bar (or selecting `Panels->New Panel...`). This will open a dialog offering
 a catalog of different panel types and options for your new panel. Once
 accepted, the new panel will appear floating, ready to be docked to the main window.
 

--- a/doc/source/users/ui/taurusgui.rst
+++ b/doc/source/users/ui/taurusgui.rst
@@ -174,10 +174,10 @@ future use and which are only meant for the current session.
   
   The dialog for selection which custom panels are to be stored permanently
   
-You can also open this dialog from the `Tools->Select panel Configuration` option.
+You can also open this dialog from the `Panels->Switch temporary/permanent status...` option.
 
 .. tip:: if you want to remove a custom panel from an application, just hide it
-         and use the `Select panel Configuration` option for making it
+         and use the `Switch temporary/permanent status...` option for making it
          "temporary" so that it is not stored for future sessions.
  
 .. _perspectives:
@@ -203,9 +203,9 @@ functionalities from the `View` menu).
   shows all available perspectives. The button on the right allows you to save
   the current arrangement as a perspective.
 
-Switching to another perspective can be done using the `Load perspectives` drop-
-down button in the perspectives toolbar (or using the `View->Load perspective`
-option).
+Switching to another perspective can be done using the `Load perspectives` 
+drop-down button in the perspectives toolbar (or using the
+`View->Load perspective` option).
 
 Apart from the pre-defined perspectives, you can always re-arrange panels and 
 store your preferred arrangement as a perspective using the
@@ -214,8 +214,8 @@ perspective` option).
 
 .. tip:: If you want to backup your current perspectives, or you want to use
   some perspectives you created in one computer in another computer (or another
-  user of the same computer) you can do so by using the `File->Export Settings`
-  option. Similarly, use the `File->Import Settings` option to update the application
+  user of the same computer) you can do so by using the `File->Export Settings ...`
+  option. Similarly, use the `File->Import Settings ...` option to update the application
   perspectives with those contained in the imported file.
   
 .. _synopticpanels:
@@ -223,7 +223,7 @@ perspective` option).
 Synoptic panels
 ---------------
 
-An special type of panel present in some TaurusGui-based applications is the
+A special type of panel present in some TaurusGui-based applications is the
 Synoptics. Synoptics panels are typically used for providing a visual
 representation of the hardware that is controlled by the GUI. Some elements or
 areas of the synoptic panel may be *active*, meaning that they can be selected
@@ -308,7 +308,7 @@ Also, some other temporary panels may be dynamically created depending on the ex
   
 In most specific GUIs the macroserver and door name to use are pre-configured and
 the user does not need to change them. Sometimes though, you may want to alter it.
-You can do so by using the `Tools->Macro execution configuration` option.
+You can do so by using the `Taurus->Macro execution configuration...` option.
 
 Automatic creation of Instrument panels from Pool info
 ''''''''''''''''''''''''''''''''''''''''''''''''''''''


### PR DESCRIPTION
That's just minor typo correction, and also some menu titles which seem to have changed.
I did not find a contrib for doc so I hope I've done this with respect to the standard you follow.

I plan to update this PR as I find new typos or menu titles changes.