### PR TITLE
Fix #533: Avoid exception in synoptics

### DIFF
--- a/lib/taurus/qt/qtgui/graphic/jdraw/jdraw_parser.py
+++ b/lib/taurus/qt/qtgui/graphic/jdraw/jdraw_parser.py
@@ -315,17 +315,8 @@ def new_parser(optimize=None, debug=0, outputdir=None):
         common_kwargs.pop('debuglog')
         common_kwargs.pop('errorlog')
 
-    try:
-        _path = os.path.join(outputdir, 'jdraw_lextab.py')
-        jdraw_lextab = imp.load_source('jdraw_lextab', _path)
-    except:
-        jdraw_lextab = 'jdraw_lextab'
-
-    try:
-        _path = os.path.join(outputdir, 'jdraw_yacctab.py')
-        jdraw_yacctab = imp.load_source('jdraw_lextab', _path)
-    except:
-        jdraw_yacctab = 'jdraw_yacctab'
+    jdraw_lextab = 'jdraw_lextab'
+    jdraw_yacctab = 'jdraw_yacctab'
 
     # Lexer
     l = lex.lex(lextab=jdraw_lextab, **common_kwargs)


### PR DESCRIPTION
The jdraw_parser.new_parser function has a buggy try/except block
that can cause an exception if the except block is not executed.

Remove the try/except.