### PR TITLE
Use new docker tags in Travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,21 @@
 language: python
 
+python:
+  - "2.7"
+
 sudo: required
 
+services:
+  - docker
+
+env:
+  - DOCKER_IMG=cpascual/taurus-test:debian-jessie
+  - DOCKER_IMG=cpascual/taurus-test:debian-stretch
+  - DOCKER_IMG=cpascual/taurus-test:debian-buster
+
 matrix:
-    include:
-        - python: 2.7
-          os: linux
-          sudo: required
-          services:
-              - docker
-          env:
-              - DOCKER_IMG=cpascual/taurus-test:debian-jessie
-
-        - python: 2.7
-          os: linux
-          sudo: required
-          services:
-              - docker
-          env:
-              - DOCKER_IMG=cpascual/taurus-test:debian-stretch
-
-        - python: 2.7
-          os: linux
-          sudo: required
-          services:
-              - docker
-          env:
-              - DOCKER_IMG=cpascual/taurus-test:debian-buster
+    allow_failures:
+        - env: DOCKER_IMG=cpascual/taurus-test:debian-buster
 
 before_install:
   - docker run -d --name=taurus-test -h taurus-test --volume=`pwd`:/taurus $DOCKER_IMG

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
           services:
               - docker
           env:
-              - DOCKER_IMG=cpascual/taurus-test:latest
+              - DOCKER_IMG=cpascual/taurus-test:debian-jessie
 
         - python: 2.7
           os: linux
@@ -18,10 +18,17 @@ matrix:
           services:
               - docker
           env:
-              - DOCKER_IMG=cpascual/taurus-test:debian9
+              - DOCKER_IMG=cpascual/taurus-test:debian-stretch
+
+        - python: 2.7
+          os: linux
+          sudo: required
+          services:
+              - docker
+          env:
+              - DOCKER_IMG=cpascual/taurus-test:debian-buster
 
 before_install:
-  # run cpascual/taurus-test docker container (Debian8 with taurus-deps and xvfb installed)
   - docker run -d --name=taurus-test -h taurus-test --volume=`pwd`:/taurus $DOCKER_IMG
   - sleep 10
   


### PR DESCRIPTION
The docker tags in taurus-test docker image have been updated. Now
`debian-{jessie,stretch,buster}` are used insted, while "debian9" and
"latest" should no longer be used. Modify travis.yml accordingly.
