### PR TITLE
Relax spyder dependency

### DIFF
--- a/lib/taurus/qt/qtgui/editor/__init__.py
+++ b/lib/taurus/qt/qtgui/editor/__init__.py
@@ -30,11 +30,7 @@ __docformat__ = 'restructuredtext'
 try:
    from .tauruseditor import *
 except Exception as e:
-   from taurus.qt.qtgui.display import create_fallback as __create
-   TaurusBaseEditor = __create("TaurusBaseEditor")
    from taurus import warning, debug
-   warning('Problem with taurus.qt.editor.\n'
-           ' A dummy TaurusBaseEditor will be used\n' +
-           ' (maybe you do not have spyder >=3 ?). ')
+   warning('Problem with taurus.qt.editor (hint: is spyder >=3 installed?)')
    debug('%r', e)
 

--- a/lib/taurus/qt/qtgui/editor/__init__.py
+++ b/lib/taurus/qt/qtgui/editor/__init__.py
@@ -27,10 +27,14 @@
 
 __docformat__ = 'restructuredtext'
 
-from .tauruseditor import *
+try:
+   from .tauruseditor import *
+except Exception as e:
+   from taurus.qt.qtgui.display import create_fallback as __create
+   TaurusBaseEditor = __create("TaurusBaseEditor")
+   from taurus import warning, debug
+   warning('Problem with taurus.qt.editor.\n'
+           ' A dummy TaurusBaseEditor will be used\n' +
+           ' (maybe you do not have spyder >=3 ?). ')
+   debug('%r', e)
 
-# try:
-#    from .tauruseditor import *
-# except:
-#    from taurus.qt.qtgui.display import create_fallback as __create
-#    TaurusBaseEditor = __create("TaurusBaseEditor")

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,6 @@ extras_require = {
                   # 'PyQt4.Qwt5 >=5.2.0',  # [Taurus-Qt-Plot]
                   'ply >=2.3',  # [Taurus-Qt-Synoptic]
                   'lxml >=2.1',  # [Taurus-Qt-TaurusGUI]
-                  'spyder >=3.0',  # [Taurus-Qt-Editor]
                   'guiqwt >=3',  # [Taurus-Qt-Guiqwt]
                   ],
     'taurus-tango': ['PyTango >=7.1',
@@ -74,6 +73,10 @@ extras_require = {
                      ],
     'taurus-h5file': ['h5file',
                       ],
+    # separate the editor from 'taurus-qt' to avoid forcing spyder>3
+    # which implies many more dependencies that may be hard on older system
+    'taurus-qt-editor': ['spyder >=3',
+                         ],
 }
 
 console_scripts = [


### PR DESCRIPTION
Installing spyder>=3 can be a problem in older systems (e.g. debian 8)
because it forces many dependencies (e.g. ipython>4) which may not be
wanted. On the other hand, spyder is only needed for taurus.qt.editor.

Allow importing taurus.qt.editor even if spyder is not installed.
In that case, return a dummy widget and log a warning. 
Also make the extras_requires target for spyder more specific.

This will fix the errors seen in the travis builds since #554 was merged.