### PR TITLE
Deprecate TaurusMainWindow "Change Tango Host" action

### DIFF
--- a/lib/taurus/qt/qtgui/container/taurusmainwindow.py
+++ b/lib/taurus/qt/qtgui/container/taurusmainwindow.py
@@ -35,6 +35,7 @@ import os
 import sys
 
 from taurus import tauruscustomsettings
+from taurus.core.util import taurus4_deprecation
 from taurus.external.qt import Qt
 from taurusbasecontainer import TaurusBaseContainer
 
@@ -875,6 +876,8 @@ class TaurusMainWindow(Qt.QMainWindow, TaurusBaseContainer):
         self.unregisterConfigurableItem("_extApp[%s]" % str(action.text()),
                                         raiseOnError=False)
 
+    @taurus4_deprecation(dbg_msg="Change Tango Host action is TangoCentric",
+                         rel="4.1.1")
     def _onChangeTangoHostAction(self):
         '''
         slot called when the Change Tango Host is triggered. It prompts for a


### PR DESCRIPTION
TaurusMainWindow Change Tango Host action is Tango Centric and not
functional.

Deprecate it.

This is a first step towards solving issue #379