### PR TITLE
Enable unit test for write/read epics attribute

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
 script:
   - set -e
   - docker exec taurus-test /bin/bash -c "cd /taurus ; python setup.py install"
-  - docker exec taurus-test /bin/bash -c "TAURUS_STARTER_WAIT=5 taurustestsuite -e 'taurus\.core\.util\.test\.test_timer'"
+  - docker exec -t taurus-test /bin/bash -c "TAURUS_STARTER_WAIT=5 taurustestsuite -e 'taurus\.core\.util\.test\.test_timer'"
   - docker exec taurus-test /bin/bash -c "cd /taurus ; python setup.py build_sphinx"
   # deploy sphinx-built docs to taurus-doc repo
   - if [[ "$DOCKER_IMG" == "cpascual/taurus-test:debian-stretch" ]]; then

--- a/lib/taurus/core/epics/test/test_epicsattribute.py
+++ b/lib/taurus/core/epics/test/test_epicsattribute.py
@@ -54,9 +54,7 @@ from taurus.core.taurusbasetypes import TaurusAttrValue
                                 wvalue=Quantity('1m'),
                                 quality=AttrQuality.ATTR_VALID,
                                 error=None,
-                                ),
-            test_skip='There are troubles in the docker container. '
-                      'This test will be skipped till we fix it'
+                                )
             )
 @unittest.skipIf(sys.modules.has_key('epics') is False,
                  "epics module is not available")


### PR DESCRIPTION
The epics.AttributeTestCase.write_read_attr was disabled because
epics was not working in the CI test docker images.
Reactivate it because epics seems to work well now.