### PR TITLE
Fix strange behavior of Tango validator

### DIFF
--- a/lib/taurus/core/tango/tangovalidator.py
+++ b/lib/taurus/core/tango/tangovalidator.py
@@ -182,7 +182,8 @@ class TangoDeviceNameValidator(TaurusDeviceNameValidator):
                   r'(\?(?P<query>%(query)s))?' + \
                   r'(#%(fragment)s)?$'
         authority = '(?P<host>([\w\-_]+\.)*[\w\-_]+):(?P<port>\d{1,5})'
-        path = '/?(?P<devname>((?P<_devslashname>[^/?#:]+/[^/?#:]+/[^/?#:]+)))'
+        path = '/?(?P<devname>((?P<_devalias>(?<=//)([^/?#:]+))|' + \
+               '(?P<_devslashname>[^/?#:]+/[^/?#:]+/[^/?#:]+)))'
 
         return pattern % dict(scheme=self.scheme,
                               authority=authority,

--- a/lib/taurus/core/tango/tangovalidator.py
+++ b/lib/taurus/core/tango/tangovalidator.py
@@ -176,7 +176,19 @@ class TangoDeviceNameValidator(TaurusDeviceNameValidator):
         '''In non-strict mode, allow double-slash even if there is no Authority.
         (e.g., "tango://a/b/c" passes this non-strict form)
         '''
-        return self.namePattern.replace('tango):(', 'tango)://(')
+        pattern = r'^((?P<scheme>%(scheme)s)://)?' + \
+                  r'((?P<authority>%(authority)s)(?=/))?' + \
+                  r'(?P<path>%(path)s)' + \
+                  r'(\?(?P<query>%(query)s))?' + \
+                  r'(#%(fragment)s)?$'
+        authority = '(?P<host>([\w\-_]+\.)*[\w\-_]+):(?P<port>\d{1,5})'
+        path = '/?(?P<devname>((?P<_devslashname>[^/?#:]+/[^/?#:]+/[^/?#:]+)))'
+
+        return pattern % dict(scheme=self.scheme,
+                              authority=authority,
+                              path=path,
+                              query='(?!)',
+                              fragment='(?!)')
 
 
 class TangoAttributeNameValidator(TaurusAttributeNameValidator):
@@ -250,14 +262,16 @@ class TangoAttributeNameValidator(TaurusAttributeNameValidator):
         """
 
         # allow for *optional* double-slashes and *optional* ?configuration...
-        pattern = r'^(?P<scheme>%(scheme)s):(//)?' + \
+        pattern = r'^((?P<scheme>%(scheme)s)://)?' + \
                   r'((?P<authority>%(authority)s)(?=/))?' + \
                   r'(?P<path>%(path)s)' + \
                   r'(\?(?P<query>%(query)s))?' + \
                   r'(#%(fragment)s)?$'
+        authority = '(?P<host>([\w\-_]+\.)*[\w\-_]+):(?P<port>\d{1,5})'
+        query = 'configuration(=(?P<fragment>(?P<cfgkey>[^# ]+)))?'
 
         return pattern % dict(scheme=self.scheme,
-                              authority='(?P<host>([\w\-_]+\.)*[\w\-_]+):(?P<port>\d{1,5})',
+                              authority=authority,
                               path=self.path,
-                              query='configuration(=(?P<fragment>(?P<cfgkey>[^# ]+)))?',
+                              query=query,
                               fragment='(?!)')

--- a/lib/taurus/core/tango/tangovalidator.py
+++ b/lib/taurus/core/tango/tangovalidator.py
@@ -182,7 +182,7 @@ class TangoDeviceNameValidator(TaurusDeviceNameValidator):
                   r'(\?(?P<query>%(query)s))?' + \
                   r'(#%(fragment)s)?$'
         authority = '(?P<host>([\w\-_]+\.)*[\w\-_]+):(?P<port>\d{1,5})'
-        path = '/?(?P<devname>((?P<_devalias>(?<=//)([^/?#:]+))|' + \
+        path = '/?(?P<devname>((?P<_devalias>([^/?#:]+))|' + \
                '(?P<_devslashname>[^/?#:]+/[^/?#:]+/[^/?#:]+)))'
 
         return pattern % dict(scheme=self.scheme,
@@ -262,7 +262,6 @@ class TangoAttributeNameValidator(TaurusAttributeNameValidator):
         non-strict form, and the named group "fragment" will contain "label"
         """
 
-        # allow for *optional* double-slashes and *optional* ?configuration...
         pattern = r'^((?P<scheme>%(scheme)s)://)?' + \
                   r'((?P<authority>%(authority)s)(?=/))?' + \
                   r'(?P<path>%(path)s)' + \

--- a/lib/taurus/core/tango/test/test_tangovalidator.py
+++ b/lib/taurus/core/tango/test/test_tangovalidator.py
@@ -78,6 +78,12 @@ class TangoAuthValidatorTestCase(AbstractNameValidatorTestCase,
 @valid(name='tango:a/b/ c', groups={'devname': 'a/b/ c'})
 @invalid(name='tango:/a/b/c?')
 @valid(name='tango://a/b/c', strict=False)
+@valid(name='tango:alias', strict=False)
+@valid(name='tango://a/b/c', strict=False)
+@invalid(name='tango:foo:1234/alias', strict=False)
+@invalid(name='tango:foo:1234/a/b/c', strict=False)
+@invalid(name='foo:1234/alias', strict=False)
+@valid(name='foo:1234/a/b/c', strict=False)
 @invalid(name='tango://a/b/c', strict=True)
 @invalid(name='tango://devalias')
 @names(name='tango://foo:123/a/b/c',
@@ -97,6 +103,8 @@ class TangoDevValidatorTestCase(AbstractNameValidatorTestCase,
 #=========================================================================
 # Tests for Tango Attribute name validation (without fragment)
 #=========================================================================
+@valid(name='foo:10000/a/b/c/d', strict=False)
+@valid(name='mot/position', strict=False)
 @valid(name='tango:a/b/c/d', groups={'devname': 'a/b/c',
                                      'attrname': 'a/b/c/d',
                                      '_shortattrname': 'd'})

--- a/lib/taurus/core/tango/test/test_tangovalidator.py
+++ b/lib/taurus/core/tango/test/test_tangovalidator.py
@@ -78,7 +78,9 @@ class TangoAuthValidatorTestCase(AbstractNameValidatorTestCase,
 @valid(name='tango:a/b/ c', groups={'devname': 'a/b/ c'})
 @invalid(name='tango:/a/b/c?')
 @valid(name='tango://a/b/c', strict=False)
-@valid(name='tango:alias', strict=False)
+@valid(name='tango:alias')
+# @invalid(name='tango:alias', strict=False) # It matches with strict=True
+@valid(name='tango://alias', strict=False)
 @valid(name='tango://a/b/c', strict=False)
 @invalid(name='tango:foo:1234/alias', strict=False)
 @invalid(name='tango:foo:1234/a/b/c', strict=False)

--- a/lib/taurus/core/tango/test/test_tangovalidator.py
+++ b/lib/taurus/core/tango/test/test_tangovalidator.py
@@ -79,13 +79,12 @@ class TangoAuthValidatorTestCase(AbstractNameValidatorTestCase,
 @invalid(name='tango:/a/b/c?')
 @valid(name='tango://a/b/c', strict=False)
 @valid(name='tango:alias')
-# @invalid(name='tango:alias', strict=False) # It matches with strict=True
 @valid(name='tango://alias', strict=False)
 @valid(name='tango://a/b/c', strict=False)
 @invalid(name='tango:foo:1234/alias', strict=False)
 @invalid(name='tango:foo:1234/a/b/c', strict=False)
-@invalid(name='foo:1234/alias', strict=False)
-@valid(name='foo:1234/a/b/c', strict=False)
+@valid(name='foo:1234/alias', strict=False) # Implicit scheme
+@valid(name='foo:1234/a/b/c', strict=False) # Implicit scheme
 @invalid(name='tango://a/b/c', strict=True)
 @invalid(name='tango://devalias')
 @names(name='tango://foo:123/a/b/c',

--- a/lib/taurus/core/tango/test/test_tangovalidator.py
+++ b/lib/taurus/core/tango/test/test_tangovalidator.py
@@ -83,8 +83,8 @@ class TangoAuthValidatorTestCase(AbstractNameValidatorTestCase,
 @valid(name='tango://a/b/c', strict=False)
 @invalid(name='tango:foo:1234/alias', strict=False)
 @invalid(name='tango:foo:1234/a/b/c', strict=False)
-@valid(name='foo:1234/alias', strict=False) # Implicit scheme
-@valid(name='foo:1234/a/b/c', strict=False) # Implicit scheme
+@valid(name='foo:1234/alias', strict=False)  # Implicit scheme
+@valid(name='foo:1234/a/b/c', strict=False)  # Implicit scheme
 @invalid(name='tango://a/b/c', strict=True)
 @invalid(name='tango://devalias')
 @names(name='tango://foo:123/a/b/c',

--- a/lib/taurus/core/tango/test/test_tangovalidator.py
+++ b/lib/taurus/core/tango/test/test_tangovalidator.py
@@ -38,8 +38,11 @@ from taurus.core.tango.tangovalidator import (TangoAuthorityNameValidator,
                                               TangoAttributeNameValidator)
 
 import PyTango
-__GETENV = PyTango.ApiUtil.get_env_var
+import socket
 
+__PY_TANGO_HOST = PyTango.ApiUtil.get_env_var("TANGO_HOST")
+host, port = __PY_TANGO_HOST.split(':')
+__TANGO_HOST = "{0}:{1}".format(socket.getfqdn(host), port)
 
 #=========================================================================
 # Tests for Tango Authority  name validation
@@ -80,11 +83,11 @@ class TangoAuthValidatorTestCase(AbstractNameValidatorTestCase,
 @names(name='tango://foo:123/a/b/c',
        out=('tango://foo:123/a/b/c', '//foo:123/a/b/c', 'a/b/c'))
 @names(name='tango:sys/tg_test/1',
-       out=('tango://%s/sys/tg_test/1' % __GETENV("TANGO_HOST"),
+       out=('tango://%s/sys/tg_test/1' % __TANGO_HOST,
             'sys/tg_test/1', 'sys/tg_test/1'))
 @names(name='tango:alias', out=(None, None, 'alias'))
 # @names(name = 'tango:mot49', # commented out because it assumes mot49 exists
-#        out=('tango://%s/motor/motctrl13/1'% __GETENV("TANGO_HOST"),
+#        out=('tango://%s/motor/motctrl13/1'% __TANGO_HOST,
 #             'motor/motctrl13/1', 'mot49'))
 class TangoDevValidatorTestCase(AbstractNameValidatorTestCase,
                                 unittest.TestCase):
@@ -112,10 +115,10 @@ class TangoDevValidatorTestCase(AbstractNameValidatorTestCase,
 @names(name='tango://foo:123/a/b/c/d',
        out=('tango://foo:123/a/b/c/d', '//foo:123/a/b/c/d', 'd'))
 @names(name='tango:sys/tg_test/1/float_scalar',
-       out=('tango://%s/sys/tg_test/1/float_scalar' % __GETENV("TANGO_HOST"),
+       out=('tango://%s/sys/tg_test/1/float_scalar' % __TANGO_HOST,
             'sys/tg_test/1/float_scalar', 'float_scalar'))
 # @names(name = 'tango:mot49/position', # commented out because it assumes mot49
-#        out=('tango://%s/motor/motctrl13/1/position'% __GETENV("TANGO_HOST"),
+#        out=('tango://%s/motor/motctrl13/1/position'% __TANGO_HOST,
 #             'motor/motctrl13/1/position', 'position'))
 #=========================================================================
 # Tests for validation of Attribute name with fragment
@@ -147,8 +150,7 @@ class TangoDevValidatorTestCase(AbstractNameValidatorTestCase,
        out=('tango://foo:123/a/b/c/d',
             '//foo:123/a/b/c/d', 'd', 'label'))
 @names(name='tango:sys/tg_test/1/float_scalar#',
-       out=('tango://%s/sys/tg_test/1/float_scalar' %
-            __GETENV("TANGO_HOST"),
+       out=('tango://%s/sys/tg_test/1/float_scalar' % __TANGO_HOST,
             'sys/tg_test/1/float_scalar', 'float_scalar', ''))
 @names(name='tango://foo:123/a/b/c/d?configuration=label',
        out=('tango://foo:123/a/b/c/d',


### PR DESCRIPTION
Some back. comp. URIs do not work. The Tango validator does not
return the group when the strict mode is set to False.
    
Fix #586