### PR TITLE
Add TangoFactory option to disable event subscribing

### DIFF
--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -618,7 +618,7 @@ class TangoAttribute(TaurusAttribute):
             self._activatePolling()
             self._call_dev_hw_subscribe_event(True)
                 
-    def _call_dev_hw_subscribe_event(self,stateless=True):      
+    def _call_dev_hw_subscribe_event(self, stateless=True):      
         try:
             attr_name = self.getSimpleName()
             cid = self.__dev_hw_obj.subscribe_event(

--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -287,7 +287,9 @@ class TangoAttribute(TaurusAttribute):
 
         # subscribe to configuration events (unsubscription done at cleanup)
         self.__cfg_evt_id = None
-        self._subscribeConfEvents()
+        self._ignore_events = self.factory().get_tango_events_disabled()
+        if not self._ignore_events:
+            self._subscribeConfEvents()
 
     def cleanUp(self):
         self.trace("[TangoAttribute] cleanUp")
@@ -603,24 +605,36 @@ class TangoAttribute(TaurusAttribute):
         self.__subscription_event = threading.Event()
         attr_name = self.getSimpleName()
 
+        if self._ignore_events:
+            self.__chg_evt_id = -1
+            self._activatePolling()
+            return
+
         try:
             self.__subscription_state = SubscriptionState.Subscribing
-            self.__chg_evt_id = self.__dev_hw_obj.subscribe_event(
-                attr_name, PyTango.EventType.CHANGE_EVENT,
-                self, [])  # connects to self.push_event callback
-
+            self._call_dev_hw_subscribe_event(False)
         except:
             self.__subscription_state = SubscriptionState.PendingSubscribe
             self._activatePolling()
-            self.__chg_evt_id = self.__dev_hw_obj.subscribe_event(
-                attr_name, PyTango.EventType.CHANGE_EVENT,
-                self, [], True)  # connects to self.push_event callback
-
+            self._call_dev_hw_subscribe_event(True)
+                
+    def _call_dev_hw_subscribe_event(self,stateless=True):      
+        try:
+            attr_name = self.getSimpleName()
+            cid = self.__dev_hw_obj.subscribe_event(
+                    attr_name, PyTango.EventType.CHANGE_EVENT,
+                    self, [], stateless) # connects to self.push_event callback
+            self.__chg_evt_id = cid
+            return cid
+        except:
+            self.error(traceback.format_exc())
+                
     def _unsubscribeEvents(self):
         # Careful in this method: This is intended to be executed in the cleanUp
         # so we should not access external objects from the factory, like the
         # parent object
-        if self.__dev_hw_obj is not None and self.__chg_evt_id is not None:
+        
+        if self.__dev_hw_obj is not None and self.__chg_evt_id not in (None,-1):
             self.trace("Unsubscribing to change events (ID=%d)",
                        self.__chg_evt_id)
             try:
@@ -675,7 +689,7 @@ class TangoAttribute(TaurusAttribute):
         # Careful in this method: This is intended to be executed in the cleanUp
         # so we should not access external objects from the factory, like the
         # parent object
-        if self.__cfg_evt_id and not self.__dev_hw_obj is None:
+        if self.__cfg_evt_id is not None and not self.__dev_hw_obj is None:
             self.trace("Unsubscribing to configuration events (ID=%s)",
                        str(self.__cfg_evt_id))
             try:

--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -601,7 +601,7 @@ class TangoAttribute(TaurusAttribute):
                 self.debug("failed to subscribe to chg events: HW is None")
                 return
 
-        if self.factory().is_tango_subscribe_enabled():
+        if not self.factory().is_tango_subscribe_enabled():
             self._activatePolling()
             return
 

--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -634,7 +634,7 @@ class TangoAttribute(TaurusAttribute):
         # so we should not access external objects from the factory, like the
         # parent object
         
-        if self.__dev_hw_obj is not None and self.__chg_evt_id not in (None,-1):
+        if self.__dev_hw_obj is not None and self.__chg_evt_id not in (None, -1):
             self.trace("Unsubscribing to change events (ID=%d)",
                        self.__chg_evt_id)
             try:

--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -583,6 +583,9 @@ class TangoAttribute(TaurusAttribute):
 
     def isUsingEvents(self):
         return self.__subscription_state == SubscriptionState.Subscribed
+    
+    def getSubscriptionState(self):
+        return self.__subscription_state    
 
     def _process_event_exception(self, ex):
         pass
@@ -590,6 +593,10 @@ class TangoAttribute(TaurusAttribute):
     def _subscribeEvents(self):
         """ Enable subscription to the attribute events. If change events are
             not supported polling is activated """
+        if self.__chg_evt_id is not None:
+            self.warning("chg events already subscribed (id=%s)"
+                       %self.__chg_evt_id)
+            return
 
         if self.__dev_hw_obj is None:
             dev = self.getParentObj()

--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -613,13 +613,15 @@ class TangoAttribute(TaurusAttribute):
             self._activatePolling()
             self._call_dev_hw_subscribe_event(True)
                 
-    def _call_dev_hw_subscribe_event(self, stateless=True):      
+    def _call_dev_hw_subscribe_event(self, stateless=True):
+        """ Executes event subscription on parent TangoDevice objectName
+        """
         attr_name = self.getSimpleName()
-        cid = self.__dev_hw_obj.subscribe_event(
+        self.__chg_evt_id = self.__dev_hw_obj.subscribe_event(
                 attr_name, PyTango.EventType.CHANGE_EVENT,
                 self, [], stateless) # connects to self.push_event callback
-        self.__chg_evt_id = cid
-        return cid
+        
+        return self.__chg_evt_id
                 
     def _unsubscribeEvents(self):
         # Careful in this method: This is intended to be executed in the cleanUp

--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -593,6 +593,7 @@ class TangoAttribute(TaurusAttribute):
     def _subscribeEvents(self):
         """ Enable subscription to the attribute events. If change events are
             not supported polling is activated """
+            
         if self.__chg_evt_id is not None:
             self.warning("chg events already subscribed (id=%s)"
                        %self.__chg_evt_id)
@@ -655,6 +656,12 @@ class TangoAttribute(TaurusAttribute):
     def _subscribeConfEvents(self):
         """ Enable subscription to the attribute configuration events."""
         self.trace("Subscribing to configuration events...")
+
+        if self.__cfg_evt_id is not None:
+            self.warning("cfg events already subscribed (id=%s)"
+                       %self.__cfg_evt_id)
+            return
+        
         if self.__dev_hw_obj is None:
             dev = self.getParentObj()
             if dev is None:

--- a/lib/taurus/core/tango/tangofactory.py
+++ b/lib/taurus/core/tango/tangofactory.py
@@ -109,6 +109,7 @@ class TangoFactory(Singleton, TaurusFactory, Logger):
     def reInit(self):
         """Reinitialize the singleton"""
         self._default_tango_host = None
+        self._tango_events_disabled = False
         self.dft_db = None
         self.tango_db = CaselessWeakValueDict()
         self.tango_db_queries = CaselessWeakValueDict()
@@ -182,6 +183,16 @@ class TangoFactory(Singleton, TaurusFactory, Logger):
         """Retruns the current default tango host
         """
         return self._default_tango_host
+    
+    def set_tango_events_disabled(self,value):
+        """ If True, disable event subscribing on TangoAttribute objects 
+        """
+        self._tango_events_disabled = value
+    
+    def get_tango_events_disabled(self):
+        """ Returns the current tango_events_disabled status
+        """
+        return self._tango_events_disabled
 
     def registerAttributeClass(self, attr_name, attr_klass):
         """Registers a new attribute class for the attribute name.

--- a/lib/taurus/core/tango/tangofactory.py
+++ b/lib/taurus/core/tango/tangofactory.py
@@ -109,7 +109,7 @@ class TangoFactory(Singleton, TaurusFactory, Logger):
     def reInit(self):
         """Reinitialize the singleton"""
         self._default_tango_host = None
-        self._tango_events_disabled = False
+        self._tango_subscribe_enabled = True
         self.dft_db = None
         self.tango_db = CaselessWeakValueDict()
         self.tango_db_queries = CaselessWeakValueDict()
@@ -184,15 +184,15 @@ class TangoFactory(Singleton, TaurusFactory, Logger):
         """
         return self._default_tango_host
     
-    def set_tango_events_disabled(self,value):
+    def set_tango_subscribe_enabled(self,value):
         """ If True, disable event subscribing on TangoAttribute objects 
         """
-        self._tango_events_disabled = value
+        self._tango_subscribe_enabled = value
     
-    def get_tango_events_disabled(self):
-        """ Returns the current tango_events_disabled status
+    def is_tango_subscribe_enabled(self):
+        """ Returns the current tango_subscribe_enabled status
         """
-        return self._tango_events_disabled
+        return self._tango_subscribe_enabled
 
     def registerAttributeClass(self, attr_name, attr_klass):
         """Registers a new attribute class for the attribute name.

--- a/lib/taurus/core/tango/tangofactory.py
+++ b/lib/taurus/core/tango/tangofactory.py
@@ -185,7 +185,7 @@ class TangoFactory(Singleton, TaurusFactory, Logger):
         return self._default_tango_host
     
     def set_tango_subscribe_enabled(self,value):
-        """ If True, disable event subscribing on TangoAttribute objects 
+        """ If True, enables event subscribing on TangoAttribute objects 
         """
         self._tango_subscribe_enabled = value
     


### PR DESCRIPTION
This is needed to bypass the Tango 9 slowness when connecting to hundreds of attributes. It doesn't affect default Taurus behaviour, just provides a flag that can be set by clients to disable the event subscribing if needed.

The changes are:
 - added set_tango_events_disabled() method to TangoFactory
 - used by TangoAttribute to subcribe or not to Tango Events
 - explicit call to DeviceProxy.subscribe_event moved to a separate method