### PR TITLE
Fix wrong plugin info for TaurusTrend2DDialog

### DIFF
--- a/lib/taurus/qt/qtgui/extra_guiqwt/taurustrend2d.py
+++ b/lib/taurus/qt/qtgui/extra_guiqwt/taurustrend2d.py
@@ -279,7 +279,7 @@ class TaurusTrend2DDialog(ImageDialog, TaurusBaseWidget):
     def getQtDesignerPluginInfo(cls):
         """reimplemented from :class:`TaurusBaseWidget`"""
         ret = TaurusBaseWidget.getQtDesignerPluginInfo()
-        ret['module'] = 'taurus.qt.qtgui.plot'
+        ret['module'] = 'taurus.qt.qtgui.extra_guiqwt'
         ret['group'] = 'Taurus Display'
         ret['icon'] = 'designer:qwtplot.png'
         return ret


### PR DESCRIPTION
TaurusTrend2DDialog cannot be used in taurusdesigner due to a wrong
module info in the its designer plugin method. Fix it.