### PR TITLE
add taurus.external.ordereddict back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ develop branch) won't be reflected in this file.
 
 ## Unreleased
 
+### Added
+- Re-added `taurus.external.ordereddict` (#599)
+
 ### Changed
 - Tango model name validators now always return FQDN instead of PQDN
   for the tango host (#488)
@@ -55,6 +58,7 @@ develop branch) won't be reflected in this file.
 - tauruscurve (#514)
 
 ### Removed
+- `taurus.external.ordereddict` (#223)
 - `taurus.qt.qtgui.Q*` modules (Qt, QtCore, QtGui, Qwt5,...)
 - `taurus.qt.qtgui.util.taurusropepatch` module
 - `taurusqt.qtgui.util.genwidget`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,6 @@ develop branch) won't be reflected in this file.
 - tauruscurve (#514)
 
 ### Removed
-- `taurus.external.ordereddict` (#223)
 - `taurus.qt.qtgui.Q*` modules (Qt, QtCore, QtGui, Qwt5,...)
 - `taurus.qt.qtgui.util.taurusropepatch` module
 - `taurusqt.qtgui.util.genwidget`

--- a/lib/taurus/external/ordereddict/__init__.py
+++ b/lib/taurus/external/ordereddict/__init__.py
@@ -26,4 +26,4 @@
 from collections import OrderedDict
 from taurus.core.util import log as __log
 
-__log.deprecated(dep='taurus.external.ordereddict', rel='4.0.4')
+__log.deprecated(dep='taurus.external.ordereddict', rel='4.0.3')

--- a/lib/taurus/external/ordereddict/__init__.py
+++ b/lib/taurus/external/ordereddict/__init__.py
@@ -1,0 +1,8 @@
+from __future__ import absolute_import
+
+try:
+    # ordereddict from python 2.7 or from ordereddict installed package?
+    from collections import OrderedDict
+except ImportError:
+    # ordereddict from local import
+    import os

--- a/lib/taurus/external/ordereddict/__init__.py
+++ b/lib/taurus/external/ordereddict/__init__.py
@@ -1,8 +1,29 @@
-from __future__ import absolute_import
+# -*- coding: utf-8 -*-
 
-try:
-    # ordereddict from python 2.7 or from ordereddict installed package?
-    from collections import OrderedDict
-except ImportError:
-    # ordereddict from local import
-    import os
+##############################################################################
+##
+## This file is part of Taurus
+##
+## http://taurus-scada.org
+##
+## Copyright 2011 CELLS / ALBA Synchrotron, Bellaterra, Spain
+##
+## Taurus is free software: you can redistribute it and/or modify
+## it under the terms of the GNU Lesser General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## Taurus is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU Lesser General Public License for more details.
+##
+## You should have received a copy of the GNU Lesser General Public License
+## along with Taurus.  If not, see <http://www.gnu.org/licenses/>.
+##
+##############################################################################
+
+from collections import OrderedDict
+from taurus.core.util import log as __log
+
+__log.deprecated(dep='taurus.external.ordereddict', rel='4.0.4')

--- a/lib/taurus/external/ordereddict/__init__.py
+++ b/lib/taurus/external/ordereddict/__init__.py
@@ -26,4 +26,5 @@
 from collections import OrderedDict
 from taurus.core.util import log as __log
 
-__log.deprecated(dep='taurus.external.ordereddict', rel='4.0.3')
+__log.deprecated(dep='taurus.external.ordereddict', rel='4.0.3',
+                 alt='collections.OrderedDict')


### PR DESCRIPTION
Hi,

this is solution for the issue https://github.com/taurus-org/taurus/issues/592.

In taurus from 4.0 - 4.1 it was also removed

According to documentation also

    taurus.qt.qtgui.Q* modules (Qt, QtCore, QtGui, Qwt5,...)
    taurus.qt.qtgui.util.taurusropepatch module
    taurusqt.qtgui.util.genwidget

was removed but I don't know it those changes are revertible (keeping the current interface). 

Bests,
Jan