### PR TITLE
Add deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ develop branch) won't be reflected in this file.
 ## Unreleased
 ### Deprecated
 - taurus.core.tango.search
+- taurus.qt.qtgui.container.taurusmainwindow._onChangeTangoHostAction (#379)
 
 ### Added
 - Re-added `taurus.external.ordereddict` (#599)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ develop branch) won't be reflected in this file.
 ## Unreleased
 ### Deprecated
 - taurus.core.tango.search
-- taurus.qt.qtgui.container.taurusmainwindow._onChangeTangoHostAction (#379)
+- TaurusMainWindow's "Change Tango Host" action (#379)
 
 ### Added
 - Re-added `taurus.external.ordereddict` (#599)

--- a/lib/taurus/qt/qtgui/container/taurusmainwindow.py
+++ b/lib/taurus/qt/qtgui/container/taurusmainwindow.py
@@ -35,6 +35,7 @@ import os
 import sys
 
 from taurus import tauruscustomsettings
+from taurus.core.util import deprecation_decorator
 from taurus.external.qt import Qt
 from taurusbasecontainer import TaurusBaseContainer
 
@@ -877,6 +878,8 @@ class TaurusMainWindow(Qt.QMainWindow, TaurusBaseContainer):
         self.unregisterConfigurableItem("_extApp[%s]" % str(action.text()),
                                         raiseOnError=False)
 
+    @deprecation_decorator(dbg_msg="Change Tango Host action is TangoCentric",
+                           rel="4.1.1")
     def _onChangeTangoHostAction(self):
         '''
         slot called when the Change Tango Host is triggered. It prompts for a

--- a/lib/taurus/qt/qtgui/container/taurusmainwindow.py
+++ b/lib/taurus/qt/qtgui/container/taurusmainwindow.py
@@ -879,7 +879,7 @@ class TaurusMainWindow(Qt.QMainWindow, TaurusBaseContainer):
                                         raiseOnError=False)
 
     @deprecation_decorator(dbg_msg="Change Tango Host action is TangoCentric",
-                           rel="4.1.1")
+                           rel="4.1.2")
     def _onChangeTangoHostAction(self):
         '''
         slot called when the Change Tango Host is triggered. It prompts for a


### PR DESCRIPTION
TaurusMainWindow Change Tango Host action is Tango Centric and not
functional.

Deprecate it.