### PR TITLE
Remove labelText property from TaurusValue

### DIFF
--- a/lib/taurus/qt/qtgui/panel/taurusvalue.py
+++ b/lib/taurus/qt/qtgui/panel/taurusvalue.py
@@ -354,8 +354,6 @@ class TaurusValue(Qt.QWidget, TaurusBaseWidget):
 
         self.registerConfigProperty(
             self.getLabelConfig, self.setLabelConfig, 'labelConfig')
-        self.registerConfigProperty(
-            self.getLabelText, self.setLabelText, 'labelText')
         self.registerConfigProperty(self.isCompact, self.setCompact, 'compact')
 
     def setVisible(self, visible):
@@ -1229,9 +1227,10 @@ class TaurusValue(Qt.QWidget, TaurusBaseWidget):
         try:
             self.getModelFragmentObj(config)
         except Exception:
-            msg = "Use setLabelText for setting an arbitrary label text"
-            self.deprecated(msg)
-            self.setLabelText(config)
+            try:
+                self._labelWidget.setText(config)
+            except:
+                self.debug("Setting permanent text to the label widget failed")
             return
         self._labelConfig = config
         self.updateLabelWidget()
@@ -1239,13 +1238,6 @@ class TaurusValue(Qt.QWidget, TaurusBaseWidget):
     def resetLabelConfig(self):
         self._labelConfig = 'label'
         self.updateLabelWidget()
-
-    def getLabelText(self):
-        return self._labelText
-
-    def setLabelText(self, text):
-        self._labelText = text
-        self._labelWidget.setPermanentText(text)
 
     def getSwitcherClass(self):
         '''Returns the TaurusValue switcher class (used in compact mode).


### PR DESCRIPTION
PR #496 introduced a new assumption that a label widget of a TaurusValue
must be a TaurusLabel or its subclass. But custom widgets were also
accepted in the past e.g. Sardana PMTV. Change it since this compromises
the API too much and remove a way of setting a label text using the
TaurusValue. Instead a label text should be set directly on the label
widget.

This Fixes #603 