### PR TITLE
Add Delayed subscriber to emitter classes

### DIFF
--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -222,7 +222,7 @@ class TangoAttrValue(TaurusAttrValue):
 
 
 class TangoAttribute(TaurusAttribute):
-    
+
     no_cfg_value = '-----'
     no_unit = 'No unit'
     no_standard_unit = 'No standard unit'
@@ -610,8 +610,8 @@ class TangoAttribute(TaurusAttribute):
                 return
 
         if not self.factory().is_tango_subscribe_enabled():
-            self.enablePolling(True)
-            return       
+            self._activatePolling()
+            return
 
         try:
             self.__subscription_state = SubscriptionState.Subscribing

--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -481,7 +481,11 @@ class TangoAttribute(TaurusAttribute):
                                self.fullname, self.__attr_err)
                     raise self.__attr_err
 
-        if not cache or (self.__subscription_state in (SubscriptionState.PendingSubscribe, SubscriptionState.Unsubscribed) and not self.isPollingActive()):
+        if not cache or (
+            self.__subscription_state in 
+                (SubscriptionState.PendingSubscribe, 
+                 SubscriptionState.Unsubscribed) 
+                and not self.isPollingActive()):
             try:
                 dev = self.getParentObj()
                 v = dev.read_attribute(self.getSimpleName())
@@ -625,6 +629,11 @@ class TangoAttribute(TaurusAttribute):
         """ Executes event subscription on parent TangoDevice objectName
         """
         attr_name = self.getSimpleName()
+        if stateless and (self.__subscription_state == 
+                          SubscriptionState.Unsubscribed 
+                          or self.isPollingActive()):
+            self.__subscription_state = SubscriptionState.PendingSubscribe
+            
         self.__chg_evt_id = self.__dev_hw_obj.subscribe_event(
                 attr_name, PyTango.EventType.CHANGE_EVENT,
                 self, [], stateless) # connects to self.push_event callback

--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -610,8 +610,8 @@ class TangoAttribute(TaurusAttribute):
                 return
 
         if not self.factory().is_tango_subscribe_enabled():
-            self._activatePolling()
-            return
+            self.enablePolling(True)
+            return       
 
         try:
             self.__subscription_state = SubscriptionState.Subscribing

--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -222,7 +222,7 @@ class TangoAttrValue(TaurusAttrValue):
 
 
 class TangoAttribute(TaurusAttribute):
-
+    
     no_cfg_value = '-----'
     no_unit = 'No unit'
     no_standard_unit = 'No standard unit'
@@ -610,8 +610,8 @@ class TangoAttribute(TaurusAttribute):
                 return
 
         if not self.factory().is_tango_subscribe_enabled():
-            self._activatePolling()
-            return
+            self.enablePolling(True)
+            return       
 
         try:
             self.__subscription_state = SubscriptionState.Subscribing

--- a/lib/taurus/qt/qtcore/util/emitter.py
+++ b/lib/taurus/qt/qtcore/util/emitter.py
@@ -183,7 +183,7 @@ class TaurusEmitterThread(Qt.QThread):
         :param queue: pass an external action queue (optional)
         :param method: action processor (e.g. modelSetter)
         :param cursor: QCursor during process (optional)
-        :param delay: delay in ms before thread start
+        :param sleep: delay in ms before thread start
         :param polling: process actions at fix period (milliseconds)
         :param loopwait: wait N milliseconds between actions
         
@@ -198,8 +198,8 @@ class TaurusEmitterThread(Qt.QThread):
         self.cursor = Qt.QCursor(
             Qt.Qt.WaitCursor) if cursor is True else cursor
         self._cursor = False
-        self.timewait = sleep
-        self.polling = polling
+        self.timewait = int(sleep)
+        self.polling = int(polling)
         self.loopwait = int(loopwait)
         if self.polling:
             self.refreshTimer = Qt.QTimer()
@@ -311,9 +311,7 @@ class TaurusEmitterThread(Qt.QThread):
         return
 
     def run(self):
-        Qt.QApplication.instance().thread().sleep(
-            int(self.timewait / 1000) if self.timewait > 10 
-                                else int(self.timewait))
+        Qt.QApplication.instance().thread().msleep(self.timewait)
         self.log.info('#' * 80)
         self.log.info('At TaurusEmitterThread.run()')
         self.next()

--- a/lib/taurus/qt/qtcore/util/emitter.py
+++ b/lib/taurus/qt/qtcore/util/emitter.py
@@ -142,7 +142,7 @@ class TaurusEmitterThread(Qt.QThread):
     .. code-block:: python
 
         #Applying TaurusEmitterThread to an existing class:
-        import queue
+        from queue import Queue
         from functools import partial
 
         def modelSetter(args):

--- a/lib/taurus/qt/qtcore/util/emitter.py
+++ b/lib/taurus/qt/qtcore/util/emitter.py
@@ -126,7 +126,7 @@ class TaurusEmitterThread(Qt.QThread):
       + ``next()`` can be called also externally to ensure that the main queue 
       is being processed.
       + the queue can be accessed externally using ``getQueue()``
-      + ``getQueue().qsize()`` returns the number of remaining objects in queue.
+      + ``getQueue().qsize()`` returns number of remaining objects in queue.
       + while there are objects in queue the ``.next()`` method will 
         override applications cursor. a call to ``next()`` with an empty queue 
         will restore the original cursor.
@@ -187,7 +187,6 @@ class TaurusEmitterThread(Qt.QThread):
         :param sleep: delay in ms before thread start
         :param polling: process actions at fix period (milliseconds)
         :param loopwait: wait N milliseconds between actions
-        
         """
         Qt.QThread.__init__(self, parent)
         self.name = name
@@ -251,7 +250,7 @@ class TaurusEmitterThread(Qt.QThread):
             self.getQueue().get()
             self._done += 1
 
-    def purge(self,obj):
+    def purge(self, obj):
         """
         Remove a given object from all queues
         """
@@ -395,7 +394,7 @@ class DelayedSubscriber(Logger):
         if parent:
             proxy = parent.getDeviceProxy()
             if not proxy:
-                self.debug('addModelObj(%s), proxy not available'%modelObj)
+                self.debug('addModelObj(%s), proxy not available' % modelObj)
                 return
 
         self._modelsQueue.put((modelObj._subscribeConfEvents,))
@@ -429,7 +428,6 @@ class SingletonWorker():
     :param method: the method to be executed using each queue item as argument
     :param cursor: if True or QCursor a custom cursor is set while 
         the Queue is not empty
-    
     """
     _thread = None
 
@@ -517,7 +515,7 @@ class SingletonWorker():
             self.queue.get()
             # self.thread.clear()
 
-    def purge(self,obj):
+    def purge(self, obj):
         """
         Remove a given object from all queues
         """

--- a/lib/taurus/qt/qtcore/util/emitter.py
+++ b/lib/taurus/qt/qtcore/util/emitter.py
@@ -27,7 +27,7 @@ emitter.py: This module provides a task scheduler used by TaurusGrid and
     TaurusDevTree widgets
 """
 
-import queue
+from queue import Queue, Empty
 import traceback
 from functools import partial
 from collections import Iterable
@@ -153,7 +153,7 @@ class TaurusEmitterThread(Qt.QThread):
             ...
             def __init__(self, parent = None, designMode = False):
                 ...
-                self.modelsQueue = queue.Queue()
+                self.modelsQueue = Queue()
                 self.modelsThread = TaurusEmitterThread(parent=self,
                         queue=self.modelsQueue,method=modelSetter )
                 ...
@@ -192,8 +192,8 @@ class TaurusEmitterThread(Qt.QThread):
         self.name = name
         self.log = Logger('TaurusEmitterThread(%s)' % self.name)
         self.log.setLogLevel(self.log.Info)
-        self.queue = queue or queue.Queue()
-        self.todo = queue.Queue()
+        self.queue = queue or Queue()
+        self.todo = Queue()
         self.method = method
         self.cursor = Qt.QCursor(
             Qt.Qt.WaitCursor) if cursor is True else cursor
@@ -252,7 +252,7 @@ class TaurusEmitterThread(Qt.QThread):
             self._done += 1
 
     def purge(obj):
-        nqueue = queue.Queue()
+        nqueue = Queue()
         while not self.todo.empty():
             i = self.todo.get()
             if obj not in i:
@@ -303,7 +303,7 @@ class TaurusEmitterThread(Qt.QThread):
                 Qt.QApplication.instance().restoreOverrideCursor()
                 self._cursor = False
 
-        except queue.Empty:
+        except Empty:
             self.log.warning(traceback.format_exc())
             pass
         except:
@@ -352,7 +352,7 @@ class DelayedSubscriber(Logger):
         self.call__init__(Logger, 'DelayedSubscriber(%s)'%self._schema, None)
         self._factory = taurus.Factory(schema)
 
-        self._modelsQueue = queue.Queue()
+        self._modelsQueue = Queue()
         self._modelsThread = TaurusEmitterThread(parent=parent,
             queue=self._modelsQueue, 
             method=self.modelSubscriber,
@@ -444,7 +444,7 @@ class SingletonWorker():
             SingletonWorker._thread = TaurusEmitterThread(
                 parent, name='SingletonWorker', cursor=cursor, sleep=sleep)
         self.thread = SingletonWorker._thread
-        self.queue = queue or queue.Queue()
+        self.queue = queue or Queue()
         if start:
             self.start()
 
@@ -476,7 +476,7 @@ class SingletonWorker():
                 i += 1
             self.log.info('%d Items added to emitter queue' % i)
             self.thread.emitter.newQueue.emit()
-        except queue.Empty:
+        except Empty:
             self.log.warning(traceback.format_exc())
         except:
             self.log.warning(traceback.format_exc())
@@ -516,7 +516,7 @@ class SingletonWorker():
         # self.thread.clear()
 
     def purge(obj):
-        nqueue = queue.Queue()
+        nqueue = Queue()
         while not self.queue.empty():
             i = self.queue.get()
             if obj not in i:

--- a/lib/taurus/qt/qtcore/util/emitter.py
+++ b/lib/taurus/qt/qtcore/util/emitter.py
@@ -176,7 +176,7 @@ class TaurusEmitterThread(Qt.QThread):
     """
 
     def __init__(self, parent=None, name='', queue=None, method=None,
-                 cursor=None, sleep=5000, polling=0, loopwait=5000):
+                 cursor=None, sleep=5000, polling=0, loopwait=5):
         """
         Parent must be not None and must be a TaurusGraphicsScene!
 
@@ -200,7 +200,7 @@ class TaurusEmitterThread(Qt.QThread):
         self._cursor = False
         self.timewait = sleep
         self.polling = polling
-        self.loopwait = int(loopwait*1e-3)
+        self.loopwait = int(loopwait)
         if self.polling:
             self.refreshTimer = Qt.QTimer()
             self.refreshTimer.timeout.connect(self.onRefresh)
@@ -331,8 +331,8 @@ class TaurusEmitterThread(Qt.QThread):
                     continue
             self.log.debug('Emitting doSomething signal ...')
             self.emitter.doSomething.emit(item)
-            if self.loopwait: 
-                self.sleep(self.loopwait)
+            if self.loopwait:
+                self.msleep(self.loopwait)
             # End of while
         self.log.info(
             '#' * 80 + '\nOut of TaurusEmitterThread.run()' + '\n' + '#' * 80)

--- a/lib/taurus/qt/qtcore/util/emitter.py
+++ b/lib/taurus/qt/qtcore/util/emitter.py
@@ -37,7 +37,7 @@ from taurus.external.qt import Qt
 from taurus.core.util.log import Logger
 from taurus.core.util.singleton import Singleton
 
-
+from taurus.core.taurusbasetypes import SubscriptionState
 
 ###############################################################################
 # Helping methods

--- a/lib/taurus/qt/qtcore/util/emitter.py
+++ b/lib/taurus/qt/qtcore/util/emitter.py
@@ -252,6 +252,10 @@ class TaurusEmitterThread(Qt.QThread):
             self._done += 1
 
     def purge(obj):
+        # TODO: remove this method?
+        # This method seems buggy (it uses unreferenced `self`)
+        # AFAIK it is not called from anywere in Taurus and it is not part of
+        # a Qt API
         nqueue = Queue()
         while not self.todo.empty():
             i = self.todo.get()
@@ -516,6 +520,10 @@ class SingletonWorker():
             # self.thread.clear()
 
     def purge(obj):
+        # TODO: remove this method?
+        # This method seems buggy (it uses unreferenced `self`)
+        # AFAIK it is not called from anywere in Taurus and it is not part of
+        # a Qt API
         nqueue = Queue()
         while not self.queue.empty():
             i = self.queue.get()

--- a/lib/taurus/qt/qtcore/util/emitter.py
+++ b/lib/taurus/qt/qtcore/util/emitter.py
@@ -251,11 +251,10 @@ class TaurusEmitterThread(Qt.QThread):
             self.getQueue().get()
             self._done += 1
 
-    def purge(obj):
-        # TODO: remove this method?
-        # This method seems buggy (it uses unreferenced `self`)
-        # AFAIK it is not called from anywere in Taurus and it is not part of
-        # a Qt API
+    def purge(self,obj):
+        """
+        Remove a given object from all queues
+        """
         nqueue = Queue()
         while not self.todo.empty():
             i = self.todo.get()
@@ -519,11 +518,10 @@ class SingletonWorker():
             self.queue.get()
             # self.thread.clear()
 
-    def purge(obj):
-        # TODO: remove this method?
-        # This method seems buggy (it uses unreferenced `self`)
-        # AFAIK it is not called from anywere in Taurus and it is not part of
-        # a Qt API
+    def purge(self,obj):
+        """
+        Remove a given object from all queues
+        """
         nqueue = Queue()
         while not self.queue.empty():
             i = self.queue.get()
@@ -531,6 +529,7 @@ class SingletonWorker():
                 nqueue.put(i)
         while not nqueue.empty():
             self.queue.put(nqueue.get())
+        self.next()
 
     def isRunning(self):
         return self._running

--- a/lib/taurus/qt/qtcore/util/emitter.py
+++ b/lib/taurus/qt/qtcore/util/emitter.py
@@ -395,11 +395,10 @@ class DelayedSubscriber(Logger):
         if parent:
             proxy = parent.getDeviceProxy()
             if not proxy:
-                # self.debug('addModelObj(%s), proxy not available'%modelObj)
+                self.debug('addModelObj(%s), proxy not available'%modelObj)
                 return
+
         self._modelsQueue.put((modelObj._subscribeConfEvents,))
-        modelObj.__subscription_state = SubscriptionState.PendingSubscribe
-        # modelObj._activatePolling()
         self.debug('addModelObj(%s)' % str(modelObj))
         self._modelsQueue.put((modelObj._call_dev_hw_subscribe_event, (True,)))
 

--- a/lib/taurus/qt/qtcore/util/emitter.py
+++ b/lib/taurus/qt/qtcore/util/emitter.py
@@ -346,7 +346,7 @@ class DelayedSubscriber(Logger):
     Taurus Schema that has not been previously subscribed.
     """
     
-    def __init__(self,schema,parent=None,sleep=10000,pause=5):
+    def __init__(self,schema,parent=None,sleep=10000,pause=5,period=0):
         
         self._schema = schema
         self.call__init__(Logger, 'DelayedSubscriber(%s)'%self._schema, None)
@@ -356,7 +356,7 @@ class DelayedSubscriber(Logger):
         self._modelsThread = TaurusEmitterThread(parent=parent,
             queue=self._modelsQueue, 
             method=self.modelSubscriber,
-            sleep=sleep,loopwait=pause)
+            sleep=sleep,loopwait=pause,polling=period)
 
         self._modelsQueue.put((self.addUnsubscribedAttributes,))
         self._modelsThread.start()

--- a/lib/taurus/qt/qtcore/util/emitter.py
+++ b/lib/taurus/qt/qtcore/util/emitter.py
@@ -27,7 +27,7 @@ emitter.py: This module provides a task scheduler used by TaurusGrid and
     TaurusDevTree widgets
 """
 
-import Queue
+import queue
 import traceback
 from functools import partial
 from collections import Iterable
@@ -142,7 +142,7 @@ class TaurusEmitterThread(Qt.QThread):
     .. code-block:: python
 
         #Applying TaurusEmitterThread to an existing class:
-        import Queue
+        import queue
         from functools import partial
 
         def modelSetter(args):
@@ -153,7 +153,7 @@ class TaurusEmitterThread(Qt.QThread):
             ...
             def __init__(self, parent = None, designMode = False):
                 ...
-                self.modelsQueue = Queue.Queue()
+                self.modelsQueue = queue.Queue()
                 self.modelsThread = TaurusEmitterThread(parent=self,
                         queue=self.modelsQueue,method=modelSetter )
                 ...
@@ -184,8 +184,8 @@ class TaurusEmitterThread(Qt.QThread):
         self.name = name
         self.log = Logger('TaurusEmitterThread(%s)' % self.name)
         self.log.setLogLevel(self.log.Info)
-        self.queue = queue or Queue.Queue()
-        self.todo = Queue.Queue()
+        self.queue = queue or queue.Queue()
+        self.todo = queue.Queue()
         self.method = method
         self.cursor = Qt.QCursor(
             Qt.Qt.WaitCursor) if cursor is True else cursor
@@ -229,7 +229,7 @@ class TaurusEmitterThread(Qt.QThread):
             self._done += 1
 
     def purge(obj):
-        nqueue = Queue.Queue()
+        nqueue = queue.Queue()
         while not self.todo.empty():
             i = self.todo.get()
             if obj not in i:
@@ -280,7 +280,7 @@ class TaurusEmitterThread(Qt.QThread):
                 Qt.QApplication.instance().restoreOverrideCursor()
                 self._cursor = False
 
-        except Queue.Empty:
+        except queue.Empty:
             self.log.warning(traceback.format_exc())
             pass
         except:
@@ -355,7 +355,7 @@ class SingletonWorker():
             SingletonWorker._thread = TaurusEmitterThread(
                 parent, name='SingletonWorker', cursor=cursor, sleep=sleep)
         self.thread = SingletonWorker._thread
-        self.queue = queue or Queue.Queue()
+        self.queue = queue or queue.Queue()
         if start:
             self.start()
 
@@ -387,7 +387,7 @@ class SingletonWorker():
                 i += 1
             self.log.info('%d Items added to emitter queue' % i)
             self.thread.emitter.newQueue.emit()
-        except Queue.Empty:
+        except queue.Empty:
             self.log.warning(traceback.format_exc())
         except:
             self.log.warning(traceback.format_exc())
@@ -427,7 +427,7 @@ class SingletonWorker():
         # self.thread.clear()
 
     def purge(obj):
-        nqueue = Queue.Queue()
+        nqueue = queue.Queue()
         while not self.queue.empty():
             i = self.queue.get()
             if obj not in i:

--- a/lib/taurus/qt/qtcore/util/emitter.py
+++ b/lib/taurus/qt/qtcore/util/emitter.py
@@ -23,20 +23,10 @@
 ###########################################################################
 
 """
-emitter.py: This module provides a task scheduler used by TaurusGrid and 
-    TaurusDevTree widgets
+emitter.py: This module provides a task scheduler used by TaurusGrid and TaurusDevTree widgets
 """
 
-try:
-    import queue
-    import queue as Queue    
-except:
-    #Python 2.6 backwards compatibility
-    import Queue
-    import Queue as queue
-
-
-    
+import Queue
 import traceback
 from functools import partial
 from collections import Iterable
@@ -46,7 +36,7 @@ from taurus.external.qt import Qt
 from taurus.core.util.log import Logger
 from taurus.core.util.singleton import Singleton
 
-from taurus.core.taurusbasetypes import SubscriptionState
+
 
 ###############################################################################
 # Helping methods
@@ -100,44 +90,33 @@ class TaurusEmitterThread(Qt.QThread):
     The TaurusEmitterThread Class
     ==========================
 
-    This object get items from a python Queue and performs a thread safe 
-    operation on them.
+    This object get items from a python Queue and performs a thread safe operation on them.
     It is useful to serialize Qt tasks in a background thread.
 
     :param parent: a Qt/Taurus object
     :param name: identifies object logs
-    :param queue: if None parent.getQueue() is used, if not then the queue 
-        passed as argument is used
+    :param queue: if None parent.getQueue() is used, if not then the queue passed as argument is used
     :param method: the method to be executed using each queue item as argument
-    :param cursor: if True or QCursor a custom cursor is set while 
-        the Queue is not empty
+    :param cursor: if True or QCursor a custom cursor is set while the Queue is not empty
 
     How TaurusEmitterThread works
     --------------------------
 
-    TaurusEmitterThread is a worker thread that processes a queue of iterables 
-    passed as arguments to the specified method every time that  
-    ``doSomething()`` is called:
+    TaurusEmitterThread is a worker thread that processes a queue of iterables passed as arguments to the specified method every time that  ``doSomething()`` is called:
 
-     * ``self.method(*item)`` will be called if TaurusEmitterThread.method 
-        has been initialized.
-     * ``item[0](item[1:])`` will be called if ``method`` is not initialized 
-        and the first element of the queued iterable is *callable*.
+     * ``self.method(*item)`` will be called if TaurusEmitterThread.method has been initialized.
+     * ``item[0](item[1:])`` will be called if ``method`` is not initialized and the first element of the queued iterable is *callable*.
 
     TaurusEmitterThread uses two queues:
 
      * ``self.queue`` manages the objects added externally:
 
-      + the ``next()`` method passes objects from ``self.queue`` 
-        to ``self.todo queue``
+      + the ``next()`` method passes objects from ``self.queue`` to ``self.todo queue``
       + every time that a *somethingDone* signal arrives ``next()`` is called.
-      + ``next()`` can be called also externally to ensure that the main queue 
-      is being processed.
+      + ``next()`` can be called also externally to ensure that the main queue is being processed.
       + the queue can be accessed externally using ``getQueue()``
       + ``getQueue().qsize()`` returns the number of remaining objects in queue.
-      + while there are objects in queue the ``.next()`` method will 
-        override applications cursor. a call to ``next()`` with an empty queue 
-        will restore the original cursor.
+      + while there are objects in queue the ``.next()`` method will override applications cursor. a call to ``next()`` with an empty queue will restore the original cursor.
 
      * ``self.todo`` is managed by the ``run()/start()`` method:
 
@@ -168,15 +147,13 @@ class TaurusEmitterThread(Qt.QThread):
                 ...
             def build_widgets(...):
                 ...
-                            previous,synoptic_value = \
-                                synoptic_value,TaurusValue(cell_frame)
+                            previous,synoptic_value = synoptic_value,TaurusValue(cell_frame)
                             #synoptic_value.setModel(model)
                             self.modelsQueue.put((synoptic_value,model))
                 ...
             def setModel(self,model):
                 ...
-                if hasattr(self,'modelsThread') and \
-                        not self.modelsThread.isRunning():
+                if hasattr(self,'modelsThread') and not self.modelsThread.isRunning():
                     self.modelsThread.start()
                 elif self.modelsQueue.qsize():
                     self.modelsThread.next()
@@ -185,7 +162,7 @@ class TaurusEmitterThread(Qt.QThread):
     """
 
     def __init__(self, parent=None, name='', queue=None, method=None,
-                 cursor=None, sleep=5000, polling=0, loopwait=5):
+                 cursor=None, sleep=5000, period_ms=0):
         """
         Parent must be not None and must be a TaurusGraphicsScene!
         """
@@ -200,13 +177,6 @@ class TaurusEmitterThread(Qt.QThread):
             Qt.Qt.WaitCursor) if cursor is True else cursor
         self._cursor = False
         self.timewait = sleep
-        self.polling = polling
-        self.loopwait = int(loopwait*1e-3)
-        if self.polling:
-            self.refreshTimer = Qt.QTimer()
-            self.refreshTimer.timeout.connect(self.onRefresh)
-        else:
-            self.refreshTimer = None
 
         self.emitter = QEmitter()
         self.emitter.moveToThread(Qt.QApplication.instance().thread())
@@ -216,22 +186,13 @@ class TaurusEmitterThread(Qt.QThread):
         self._done = 0
         # Moved to the end to prevent segfaults ...
         self.emitter.doSomething.connect(self._doSomething)
+        self.emitter.somethingDone.connect(self.next)
         
-        if not self.refreshTimer:
-            self.emitter.somethingDone.connect(self.next)
-        
+        self.period = period_ms
         
     def onRefresh(self):
-        try:
-            self.refreshTimer.setInterval(self.polling)
-            size = self.getQueue().qsize()
-            if size:
-                self.log.info('onRefresh(%s)'%size)
-                self.next()
-            else:
-                self.log.debug('onRefresh()')
-        except:
-            self.log.warning(traceback.format_exc())
+        self.refreshTimer.setInterval(self.period)
+        self.next()
 
     def getQueue(self):
         if self.queue:
@@ -243,8 +204,7 @@ class TaurusEmitterThread(Qt.QThread):
 
     def getDone(self):
         """ Returns % of done tasks in 0-1 range """
-        return self._done / (self._done + self.getQueue().qsize()) \
-                    if self._done else 0.
+        return self._done / (self._done + self.getQueue().qsize()) if self._done else 0.
 
     def clear(self):
         while not self.todo.empty():
@@ -277,23 +237,20 @@ class TaurusEmitterThread(Qt.QThread):
             try:
                 method(*args)
             except:
-                self.log.error('At TaurusEmitterThread._doSomething(%s): \n%s' 
-                    % (map(str, args), traceback.format_exc()))
+                self.log.error('At TaurusEmitterThread._doSomething(%s): \n%s' % (
+                    map(str, args), traceback.format_exc()))
         self.emitter.somethingDone.emit()
         self._done += 1
         return
 
     def next(self):
         queue = self.getQueue()
-        msg = 'At TaurusEmitterThread.next(), %d items remaining.' \
-                % queue.qsize()
-        (queue.empty() and not self.polling and self.log.info 
-            or self.log.debug)(msg)
+        msg = 'At TaurusEmitterThread.next(), %d items remaining.' % queue.qsize()
+        (queue.empty() and self.log.info or self.log.debug)(msg)
         try:
             if not queue.empty():
                 if not self._cursor and self.cursor is not None:
-                    Qt.QApplication.instance().setOverrideCursor(
-                        Qt.QCursor(self.cursor))
+                    Qt.QApplication.instance().setOverrideCursor(Qt.QCursor(self.cursor))
                     self._cursor = True
                 # A blocking get here would hang the GUIs!!!
                 item = queue.get(False)
@@ -312,14 +269,16 @@ class TaurusEmitterThread(Qt.QThread):
 
     def run(self):
         Qt.QApplication.instance().thread().sleep(
-            int(self.timewait / 1000) if self.timewait > 10 
-                                else int(self.timewait))
+            int(self.timewait / 1000) if self.timewait > 10 else int(self.timewait))  # wait(self.sleep)
         self.log.info('#' * 80)
         self.log.info('At TaurusEmitterThread.run()')
         self.next()
         
-        if self.refreshTimer:
-            self.refreshTimer.start(self.polling)
+        if self.period:
+            self.refreshTimer = Qt.QTimer()
+            Qt.QObject.connect(self.refreshTimer, 
+                            Qt.SIGNAL("timeout()"), self.onRefresh)
+            self.refreshTimer.start(self.period)        
         
         while True:
             self.log.debug('At TaurusEmitterThread.run() loop.')
@@ -331,108 +290,33 @@ class TaurusEmitterThread(Qt.QThread):
                     continue
             self.log.debug('Emitting doSomething signal ...')
             self.emitter.doSomething.emit(item)
-            if self.loopwait: 
-                self.sleep(self.loopwait)
             # End of while
         self.log.info(
             '#' * 80 + '\nOut of TaurusEmitterThread.run()' + '\n' + '#' * 80)
         # End of Thread
-        
-        
-class DelayedSubscriber(Logger):
+
+
+class SingletonWorker():  # Qt.QObject):
     """
-    DelayedSubscriber(schema) will use a TaurusEmitterThread to perform
-    a thread safe delayed subscribing on all Attributes of a given 
-    Taurus Schema that has not been previously subscribed.
-    """
-    
-    def __init__(self,schema,parent=None,sleep=10000,pause=5):
-        
-        self._schema = schema
-        self.call__init__(Logger, 'DelayedSubscriber(%s)'%self._schema, None)
-        self._factory = taurus.Factory(schema)
+    The SingletonWorker works
+    =========================
 
-        self._modelsQueue = queue.Queue()
-        self._modelsThread = TaurusEmitterThread(parent=parent,
-            queue=self._modelsQueue, 
-            method=self.modelSubscriber,
-            sleep=sleep,loopwait=pause)
+    The SingletonWorker class is constructed using the same arguments than the TaurusTreadEmitter class ; but instead of creating a QThread for each instance of the class it creates a single QThread for all instances.
 
-        self._modelsQueue.put((self.addUnsubscribedAttributes,))
-        self._modelsThread.start()
-        
-    def modelSubscriber(self,method,args=[]):
-        self.debug('modelSubscriber(%s,%s)'%(method,args))
-        return method(*args)
-    
-    def getUnsubscribedAttributes(self):
-        attrs = []
-        items = self._factory.getExistingAttributes().items()
-        for name,attr in items:
-            if attr is None: 
-                continue
-            elif attr.hasListeners() and not attr.isUsingEvents():
-                    attrs.append(attr)
-
-        return attrs
-            
-    def addUnsubscribedAttributes(self):
-        try:
-            items = self.getUnsubscribedAttributes()         
-            if len(items):
-                self.info('addUnsubscribedAttributes([%d])'%len(items))
-                for attr in items:
-                    self.addModelObj(attr)
-                self._modelsThread.next()
-                self.info('Thread queue: [%d]'%(self._modelsQueue.qsize()))                
-        except:
-            self.warning(traceback.format_exc())
-    
-    def addModelObj(self,modelObj):
-        parent = modelObj.getParentObj()
-        if parent:
-            proxy = parent.getDeviceProxy()
-            if not proxy:
-                #self.debug('addModelObj(%s), proxy not available'%modelObj)
-                return
-        self._modelsQueue.put((modelObj._subscribeConfEvents,))
-        modelObj.__subscription_state = SubscriptionState.PendingSubscribe
-        #modelObj._activatePolling()
-        self.debug('addModelObj(%s)'%str(modelObj))
-        self._modelsQueue.put((modelObj._call_dev_hw_subscribe_event,(True,)))
-
-    def cleanUp(self):
-        self.trace("[DelayedSubscriber] cleanUp")
-        self._modelsThread.stop()
-        Logger.cleanUp(self)
-        
-class SingletonWorker():
-    """
-    SingletonWorker is used to manage TaurusEmitterThread as Singleton objects
-
-    SingletonWorker is constructed using the same arguments 
-    than TaurusTreadEmitter ; but instead of creating a QThread for each 
-    instance it creates a single QThread for all instances.
-
-    The Queue is still different for each of the instances; it is connected 
-    to the TaurusEmitterThread signals (*next()* and *somethingDone()*) 
-    and each Worker queue is used as a feed for the shared QThread.
+    The Queue is still different for each of the instances; it is connected to the TaurusEmitterThread signals (*next()* and *somethingDone()*) and each Worker queue is used as a feed for the shared QThread.
 
     This implementation reduced the cpu of vacca application in a 50% factor.
 
     :param parent: a Qt/Taurus object
     :param name: identifies object logs
-    :param queue: if None parent.getQueue() is used, if not then the queue 
-        passed as argument is used
+    :param queue: if None parent.getQueue() is used, if not then the queue passed as argument is used
     :param method: the method to be executed using each queue item as argument
-    :param cursor: if True or QCursor a custom cursor is set while 
-        the Queue is not empty
-    
+    :param cursor: if True or QCursor a custom cursor is set while the Queue is not empty
+    This class is used to manage TaurusEmitterThread as Singleton objects:
     """
     _thread = None
 
-    def __init__(self, parent=None, name='', queue=None, method=None, 
-                 cursor=None, sleep=5000, log=Logger.Warning, start=True):
+    def __init__(self, parent=None, name='', queue=None, method=None, cursor=None, sleep=5000, log=Logger.Warning, start=True):
         self.name = name
         self.log = Logger('SingletonWorker(%s)' % self.name)
         self.log.setLogLevel(log)
@@ -459,9 +343,7 @@ class SingletonWorker():
             self.put(item)
         elif self.queue.empty():
             return
-        msg = 'At SingletonWorker.next(), '\
-            '%d items not passed yet to Emitter.' \
-                % self.queue.qsize()
+        msg = 'At SingletonWorker.next(), %d items not passed yet to Emitter.' % self.queue.qsize()
         self.log.info(msg)
         #(queue.empty() and self.log.info or self.log.debug)(msg)
         try:
@@ -508,8 +390,7 @@ class SingletonWorker():
     def clear(self):
         """
         This method will clear queue only if next() has not been called.
-        If you call self.thread.clear() it will clear objects for all workers!,
-        be careful
+        If you call self.thread.clear() it will clear objects for all workers!, be careful
         """
         while not self.queue.empty():
             self.queue.get()


### PR DESCRIPTION

Added DelayedSubscriber to emitter classes:

 - DelayedSubscriber is a QThread to retry event subscription once Qt
   is already running.
 - It required to replace _activatePolling() by enablePolling(True) in TangoAttribute
   when tango events are not enabled.
 - This commit adds a polling timer and a loop wait to TaurusEmitterThread,
   in order to manage cpu usage.
 - Reformat __doc__ for emitter classes
