### PR TITLE
Fix #612: ignore extras info when checking requirements

### DIFF
--- a/lib/taurus/core/taurushelper.py
+++ b/lib/taurus/core/taurushelper.py
@@ -90,7 +90,8 @@ def check_dependencies():
         # requirements from PyPI
         for r in d.requires(extras=[extra]):
             try:
-                pkg_resources.require(str(r))
+                r = str(r).split(';')[0]  # remove marker if present (see #612)
+                pkg_resources.require(r)
                 print '\t[*]',
             except Exception:
                 print '\t[ ]',


### PR DESCRIPTION
Under some circumstances (e.g. when installing taurus with pip from
a tar.gz created with the sdist command), the
`pkg_resources.Requirement` objects (returned when interrogating taurus
for its requirements) include `.marker` information, whereas in other it
does not. This breaks the logic of `taurus.check_dependencies()`.
As a quick workaround, remove the markers info from the requirement
string.

Fixes #612 