### PR TITLE
Cast to bool the value in _TaurusLedController

### DIFF
--- a/lib/taurus/qt/qtgui/display/taurusled.py
+++ b/lib/taurus/qt/qtgui/display/taurusled.py
@@ -76,9 +76,9 @@ class _TaurusLedController(object):
         fgRole = widget.fgRole
         value = None
         if fgRole == 'rvalue':
-            value = obj.rvalue
+            value = bool(obj.rvalue)
         elif fgRole == 'wvalue':
-            value = obj.wvalue
+            value = bool(obj.wvalue)
         elif fgRole == 'quality':
             return obj.quality
 


### PR DESCRIPTION
TaurusLed in taurus 3 allows to use not boolean models, if its
values are '0' or  '1'.

e.g. eval:1 or eval:0

Improve the behaviour of the TaurusLed casting the value to bool for
non boolean models.