### PR TITLE
Catch disconnect exception in TaurusTrend

### DIFF
--- a/lib/taurus/qt/qtgui/plot/taurustrend.py
+++ b/lib/taurus/qt/qtgui/plot/taurustrend.py
@@ -1626,7 +1626,12 @@ class TaurusTrend(TaurusPlot):
         # stop the scale change notification temporally (to avoid duplicate
         # warnings)
         self.setUseArchiving(False)
-        self.axisWidget(self.xBottom).scaleDivChanged.disconnect(self._scaleChangeWarning)
+        try:
+            self.axisWidget(self.xBottom).scaleDivChanged.disconnect(
+                self._scaleChangeWarning)
+        except:
+            self.warning('Failed to disconnect ScaleChangeWarning dialog')        
+
         # show a dialog
         dlg = Qt.QDialog(self)
         dlg.setModal(True)


### PR DESCRIPTION
Whenever calling "taurustrend -a <attribute_name>" and changing the X scale, the following exception appeared and the plot wasn't updated:

```
Traceback (most recent call last): 
 File "/homelocal/sicilia/local/taurus/qt/qtgui/plot/taurustrend.py", line 1619, in _scaleChangeWarning 
   self.showArchivingWarning() 
 File "/homelocal/sicilia/local/taurus/qt/qtgui/plot/taurustrend.py", line 1629, in showArchivingWarning 
   self.axisWidget(self.xBottom).scaleDivChanged.disconnect(self._scaleChangeWarning) 
TypeError: disconnect() failed between 'scaleDivChanged' and 'unislot'
```

Probably it failed because the signal was not connected. It is a minor issue and there's no method to check the connection. I just added a try/except to print a warning and proceed to plot the data. 
