### PR TITLE
Solve Command+ComboBox bug, setParameters expected string not int

### DIFF
--- a/lib/taurus/qt/qtgui/panel/taurusform.py
+++ b/lib/taurus/qt/qtgui/panel/taurusform.py
@@ -676,7 +676,7 @@ class TaurusCommandsForm(TaurusWidget):
                         button.setParameters(self._defaultParameters[
                                              c.cmd_name.lower()][0])
                 pwidget.editTextChanged.connect(button.setParameters)
-                pwidget.currentIndexChanged.connect(button.setParameters)
+                pwidget.currentIndexChanged['QString'].connect(button.setParameters)
                 pwidget.activated.connect(button.setFocus)
                 button.commandExecuted.connect(pwidget.rememberCurrentText)
                 layout.addWidget(pwidget, row, 1)


### PR DESCRIPTION
QComboBox.currentIndexChanged is an overloaded signal, it can send either int or QString

The original code in Taurus 3  was:

self.connect(pwidget, Qt.SIGNAL('currentIndexChanged (const QString&)'),button.setParameters)

But when changing to API2 the "QString" modifier overloading was lost, it caused exceptions in setParameters as it expected string and received int instead. 

I tested the patch using Vacca and it works
