### PR TITLE
Improve display widget Controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ develop branch) won't be reflected in this file.
 - Option to ignore outdated Tango events (#559)
 - Travis-built docs (not yet replacing the RTD ones) (#572)
 - TaurusLed now supports non-boolean attributes (#617)
+- Support for arbitrary bgRole in labels (#629)
 
 ### Changed
 - taurus.qt widgets can now be used without installing PyTango (#590)

--- a/lib/taurus/qt/qtgui/base/tauruscontroller.py
+++ b/lib/taurus/qt/qtgui/base/tauruscontroller.py
@@ -320,6 +320,12 @@ def updateLabelBackground(ctrl, widget):
                 bgItem = ctrl.state()
             elif bgRole == 'value':
                 bgItem = ctrl.value()
+            else:
+                modelObj = widget.getModelObj()
+                try:
+                    bgItem = modelObj.getFragmentObj(bgRole)
+                except:
+                    widget.warning('Invalid bgRole "%s"', bgRole)
             bgBrush, fgBrush = palette.qbrush(bgItem)
         _updatePaletteColors(widget, bgBrush, fgBrush, frameBrush)
     else:
@@ -334,6 +340,12 @@ def updateLabelBackground(ctrl, widget):
                 bgItem = ctrl.state()
             elif bgRole == 'value':
                 bgItem = ctrl.value()
+            else:
+                modelObj = widget.getModelObj()
+                try:
+                    bgItem = modelObj.getFragmentObj(bgRole)
+                except:
+                    widget.warning('Invalid bgRole "%s"', bgRole)
             color_ss = palette.qtStyleSheet(bgItem)
             ss = StyleSheetTemplate.format("rgba(255,255,255,128)",  color_ss)
         widget.setStyleSheet(ss)

--- a/lib/taurus/qt/qtgui/base/tauruscontroller.py
+++ b/lib/taurus/qt/qtgui/base/tauruscontroller.py
@@ -321,6 +321,8 @@ def updateLabelBackground(ctrl, widget):
             elif bgRole == 'value':
                 bgItem = ctrl.value()
             else:
+                # TODO: this is an *experimental* extension of the bgRole API
+                # added in v 4.1.2-alpha. It may change in future versions
                 modelObj = widget.getModelObj()
                 try:
                     bgItem = modelObj.getFragmentObj(bgRole)
@@ -341,6 +343,8 @@ def updateLabelBackground(ctrl, widget):
             elif bgRole == 'value':
                 bgItem = ctrl.value()
             else:
+                # TODO: this is an *experimental* extension of the bgRole API
+                # added in v 4.1.2-alpha. It may change in future versions
                 modelObj = widget.getModelObj()
                 try:
                     bgItem = modelObj.getFragmentObj(bgRole)

--- a/lib/taurus/qt/qtgui/base/tauruscontroller.py
+++ b/lib/taurus/qt/qtgui/base/tauruscontroller.py
@@ -306,7 +306,7 @@ def updateLabelBackground(ctrl, widget):
 
     if ctrl.usePalette():
         widget.setAutoFillBackground(True)
-        if bgRole in ('', 'none'):
+        if bgRole in ('', 'none', 'None'):
             transparentBrush = Qt.QBrush(Qt.Qt.transparent)
             frameBrush = transparentBrush
             bgBrush, fgBrush = transparentBrush, Qt.QBrush(Qt.Qt.black)
@@ -329,7 +329,7 @@ def updateLabelBackground(ctrl, widget):
             bgBrush, fgBrush = palette.qbrush(bgItem)
         _updatePaletteColors(widget, bgBrush, fgBrush, frameBrush)
     else:
-        if bgRole in ('', 'none'):
+        if bgRole in ('', 'none', 'None'):
             ss = StyleSheetTemplate.format("rgba(0,0,0,0)", "")
         else:
             bgItem, palette = None, QT_DEVICE_STATE_PALETTE

--- a/lib/taurus/qt/qtgui/display/demo/tauruslabeldemo.py
+++ b/lib/taurus/qt/qtgui/display/demo/tauruslabeldemo.py
@@ -104,6 +104,7 @@ def demo():
             fg_widget.setCurrentIndex(0)
             fg_widget.setEditable(True)
             bg_widget.setCurrentIndex(0)
+            bg_widget.setEditable(True)
 
             self.w_label = w
             self.w_model = model_widget

--- a/lib/taurus/qt/qtgui/display/demo/tauruslabeldemo.py
+++ b/lib/taurus/qt/qtgui/display/demo/tauruslabeldemo.py
@@ -91,7 +91,7 @@ def demo():
             fg_widget.addItems(["", "rvalue", "rvalue.magnitude",
                                 "rvalue.units", "wvalue", "wvalue.magnitude",
                                 "wvalue.units", "state", "quality", "none"])
-            bg_widget.addItems(["quality", "state", "none"])
+            bg_widget.addItems(["quality", "state", "value", "none"])
 
             model_widget.textChanged.connect(w.setModel)
             fg_widget.currentIndexChanged[str].connect(w.setFgRole)

--- a/lib/taurus/qt/qtgui/display/tauruslabel.py
+++ b/lib/taurus/qt/qtgui/display/tauruslabel.py
@@ -361,7 +361,20 @@ class TaurusLabel(Qt.QLabel, TaurusBaseWidget):
         return self._bgRole
 
     def setBgRole(self, bgRole):
-        self._bgRole = str(bgRole).lower()
+        """
+        Set the background role. The label background will be set according
+        to the current palette and the role. Valid roles are:
+        - 'none' : no background
+        - 'state' a color depending on the device state
+        - 'quality' a color depending on the attribute quality
+        - 'value' a color depending on the rvalue of the attribute
+        - <arbitrary member name> a color based on the value of an arbitrary
+          member of the model object (warning: experimental feature!)
+
+        .. warning:: the <arbitrary member name> support is still experimental
+                     and its API may change in future versions
+        """
+        self._bgRole = str(bgRole)
         self.controllerUpdate()
 
     def resetBgRole(self):

--- a/lib/taurus/qt/qtgui/display/taurusled.py
+++ b/lib/taurus/qt/qtgui/display/taurusled.py
@@ -168,6 +168,18 @@ try:
                   DevState.UNKNOWN: (False,    "black",    False),
                   None: (False,    "black",     True)}
 
+        def value(self):
+            widget, obj = self.widget(), self.modelObj()
+            fgRole = widget.fgRole
+            value = None
+            if fgRole == 'rvalue':
+                value = obj.rvalue
+            elif fgRole == 'wvalue':
+                value = obj.wvalue
+            elif fgRole == 'quality':
+                value = obj.quality
+            return value
+
         def usePreferedColor(self, widget):
             # never use prefered widget color. Use always the map
             return False

--- a/lib/taurus/qt/qtgui/panel/taurusdevicepanel.py
+++ b/lib/taurus/qt/qtgui/panel/taurusdevicepanel.py
@@ -217,7 +217,7 @@ class TaurusDevicePanel(TaurusWidget):
         self._stateframe.layout().addWidget(Qt.QLabel('State'), 0, 0, Qt.Qt.AlignCenter)
         self._statelabel = TaurusLabel(self._stateframe)
         self._statelabel.setMinimumWidth(100)
-        self._statelabel.setBgRole('rvalue')
+        self._statelabel.setBgRole('value')
         self._stateframe.layout().addWidget(self._statelabel, 0, 1, Qt.Qt.AlignCenter)
 
         self._statusframe = Qt.QScrollArea(self)

--- a/lib/taurus/qt/qtgui/panel/taurusdevicepanel.py
+++ b/lib/taurus/qt/qtgui/panel/taurusdevicepanel.py
@@ -217,11 +217,8 @@ class TaurusDevicePanel(TaurusWidget):
         self._stateframe.layout().addWidget(Qt.QLabel('State'), 0, 0, Qt.Qt.AlignCenter)
         self._statelabel = TaurusLabel(self._stateframe)
         self._statelabel.setMinimumWidth(100)
-        self._statelabel.setBgRole('state')
+        self._statelabel.setBgRole('rvalue')
         self._stateframe.layout().addWidget(self._statelabel, 0, 1, Qt.Qt.AlignCenter)
-        self._state = TaurusLed(self._stateframe)
-        self._state.setShowQuality(False)
-        self._stateframe.layout().addWidget(self._state, 0, 2, Qt.Qt.AlignCenter)
 
         self._statusframe = Qt.QScrollArea(self)
         self._status = TaurusLabel(self._statusframe)
@@ -342,7 +339,6 @@ class TaurusDevicePanel(TaurusWidget):
                 qpixmap = getCachedPixmap(logo)
 
             self._image.setPixmap(qpixmap)
-            self._state.setModel(model + '/state')  # TODO: Tango-centric
             if hasattr(self, '_statelabel'):
                 self._statelabel.setModel(
                     model + '/state')  # TODO: Tango-centric
@@ -411,7 +407,6 @@ class TaurusDevicePanel(TaurusWidget):
         detach_recursive(self)
         try:
             self._label.setText('')
-            self._state.setModel('')
             if hasattr(self, '_statelabel'):
                 self._statelabel.setModel('')
             self._status.setModel('')


### PR DESCRIPTION
Extend bgRole API of TaurusController to allow passing the name of a property of the model object as the bgRole.

This allows e.g. to simulate the behaviour of Taurus3 state labels by setting the model to a state and the bgRole to "rvalue":

```python
from taurus.qt.qtgui.application import TaurusApplication
from taurus.qt.qtgui.display import TaurusLabel
import sys
app = TaurusApplication()
w = TaurusLabel()
w.setModel( 'sys/tg_test/1/state')
w.setBgRole('rvalue')
w.show()
sys.exit(app.exec_())
```

<s>This Fixes #626</s> Update: actually, #626 does not really need this to be closed

Also, fix a related bug with state leds.

Finally, remove the state led of taurusdevicepanels since it is no longer needed.