### PR TITLE
Avoid to import queue from python3

### DIFF
--- a/lib/taurus/qt/qtcore/util/emitter.py
+++ b/lib/taurus/qt/qtcore/util/emitter.py
@@ -27,7 +27,7 @@ emitter.py: This module provides a task scheduler used by TaurusGrid and
     TaurusDevTree widgets
 """
 
-from queue import Queue, Empty
+from Queue import Queue, Empty
 import traceback
 from functools import partial
 from collections import Iterable

--- a/lib/taurus/qt/qtcore/util/emitter.py
+++ b/lib/taurus/qt/qtcore/util/emitter.py
@@ -143,7 +143,7 @@ class TaurusEmitterThread(Qt.QThread):
     .. code-block:: python
 
         #Applying TaurusEmitterThread to an existing class:
-        from queue import Queue
+        from Queue import Queue
         from functools import partial
 
         def modelSetter(args):


### PR DESCRIPTION
The Queue module has been renamed to queue in Python 3.
The emitter module imports the "Queue" module from
python 3, since taurus uses python 2.7 this module
should be imported from python 2 version.

Change the import.