### PR TITLE
Add full model name to attribute description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ develop branch) won't be reflected in this file.
 - Support for arbitrary bgRole in labels (#629)
 - `--import-ascii` option in `taurusplot` launcher (#632)
 - `ChangeState` command in TangoSchemeTest DS (#628)
+- Model info in widget tooltips (#640)
 
 ### Changed
 - taurus.qt widgets can now be used without installing PyTango (#590)

--- a/lib/taurus/core/taurusattribute.py
+++ b/lib/taurus/core/taurusattribute.py
@@ -290,7 +290,8 @@ class TaurusAttribute(TaurusModel):
 
     def getDisplayDescrObj(self, cache=True):
         name = self.getLabel(cache=cache)
-        obj = [('name', name)]
+        obj = [('name', name),
+               ('model', self.getFullName() or '')]
         descr = self.description
         if descr:
             _descr = descr.replace("<", "&lt;").replace(">", "&gt;")


### PR DESCRIPTION
The attribute description is used by widgets to generate the tooltip.
Add full model name info to the description object