### PR TITLE
Fix: Taurusform does not allow to change the label

### DIFF
--- a/lib/taurus/qt/qtgui/display/tauruslabel.py
+++ b/lib/taurus/qt/qtgui/display/tauruslabel.py
@@ -457,14 +457,22 @@ class TaurusLabel(Qt.QLabel, TaurusBaseWidget):
 
     def displayValue(self, v):
         """Reimplementation of displayValue for TaurusLabel"""
-        if self._permanentText is not None:
-            value = self._permanentText
-        else:
+        if self._permanentText is None:
             value = TaurusBaseWidget.displayValue(self, v)
+        else:
+            value = self._permanentText
 
         attr = self.getModelObj()
         dev = attr.getParent()
-        return value.format(dev=dev, attr=attr)
+
+        try:
+            v = value.format(dev=dev, attr=attr)
+        except Exception as e:
+            self.warning(
+                "Error formatting display (%r). Reverting to raw string", e)
+            v = value
+
+        return v
 
     @classmethod
     def getQtDesignerPluginInfo(cls):

--- a/lib/taurus/qt/qtgui/display/tauruslabel.py
+++ b/lib/taurus/qt/qtgui/display/tauruslabel.py
@@ -252,7 +252,7 @@ class TaurusLabel(Qt.QLabel, TaurusBaseWidget):
 
         # register configurable properties
         self.registerConfigProperty(
-            self.getPermanentText, self.setPermanentText, "permanentText"
+            self.getPermanentText, self._setPermanentText, "permanentText"
             )
 
     def _calculate_controller_class(self):
@@ -418,9 +418,10 @@ class TaurusLabel(Qt.QLabel, TaurusBaseWidget):
     def getPermanentText(self):
         return self._permanentText
 
-    def setPermanentText(self, text):
-        self.setText_(text)
+    def _setPermanentText(self, text):
         self._permanentText = text
+        if text is not None:
+            self.setText_(text)
 
     def setText_(self, text):
         """Method to expose QLabel.setText"""
@@ -428,7 +429,7 @@ class TaurusLabel(Qt.QLabel, TaurusBaseWidget):
 
     def setText(self, text):
         """Reimplementation of setText to set permanentText"""
-        self.setPermanentText(text)
+        self._setPermanentText(text)
 
     def setAutoTrim(self, trim):
         self._autoTrim = trim

--- a/lib/taurus/qt/qtgui/display/tauruslabel.py
+++ b/lib/taurus/qt/qtgui/display/tauruslabel.py
@@ -98,7 +98,7 @@ class TaurusLabelController(TaurusBaseController):
         self._trimmedText = self._shouldTrim(label, text)
         if self._trimmedText:
             text = "<a href='...'>...</a>"
-        label.setText(text)
+        label.setText_(text)
 
     def _shouldTrim(self, label, text):
         if not label.autoTrim:
@@ -419,8 +419,16 @@ class TaurusLabel(Qt.QLabel, TaurusBaseWidget):
         return self._permanentText
 
     def setPermanentText(self, text):
-        self.setText(text)
+        self.setText_(text)
         self._permanentText = text
+
+    def setText_(self, text):
+        """Method to expose QLabel.setText"""
+        Qt.QLabel.setText(self, text)
+
+    def setText(self, text):
+        """Reimplementation of setText to set permanentText"""
+        self.setPermanentText(text)
 
     def setAutoTrim(self, trim):
         self._autoTrim = trim
@@ -448,9 +456,15 @@ class TaurusLabel(Qt.QLabel, TaurusBaseWidget):
         self.setAutoTrim(self.DefaultAutoTrim)
 
     def displayValue(self, v):
+        """Reimplementation of displayValue for TaurusLabel"""
         if self._permanentText is not None:
-            return self._permanentText
-        return TaurusBaseWidget.displayValue(self, v)
+            value = self._permanentText
+        else:
+            value = TaurusBaseWidget.displayValue(self, v)
+
+        attr = self.getModelObj()
+        dev = attr.getParent()
+        return value.format(dev=dev, attr=attr)
 
     @classmethod
     def getQtDesignerPluginInfo(cls):

--- a/lib/taurus/qt/qtgui/panel/taurusvalue.py
+++ b/lib/taurus/qt/qtgui/panel/taurusvalue.py
@@ -1242,7 +1242,8 @@ class TaurusValue(Qt.QWidget, TaurusBaseWidget):
             self._labelWidget._permanentText = None
         except Exception:
             try:
-                self._labelWidget.setText(config)
+                self._labelWidget.setText(self._BCK_COMPAT_TAGS.get(config,
+                                                                    config))
             except:
                 self.debug("Setting permanent text to the label widget failed")
             return

--- a/lib/taurus/qt/qtgui/panel/taurusvalue.py
+++ b/lib/taurus/qt/qtgui/panel/taurusvalue.py
@@ -142,7 +142,7 @@ class DefaultLabelWidget(TaurusLabel):
             r_action.setEnabled(self.taurusValueBuddy().hasPendingOperations())
         if self.taurusValueBuddy().isModifiableByUser():
             menu.addAction("Change label",
-                           self.taurusValueBuddy().onChangeLabelConfig)
+                           self.taurusValueBuddy()._onChangeLabelText)
             menu.addAction("Change Read Widget",
                            self.taurusValueBuddy().onChangeReadWidget)
             menu.addAction("Set Formatter",
@@ -350,7 +350,6 @@ class TaurusValue(Qt.QWidget, TaurusBaseWidget):
         self._allowWrite = True
         self._minimumHeight = None
         self._labelConfig = '{attr.label}'
-        self._labelText = None
         self.setModifiableByUser(False)
 
         if parent is not None:
@@ -636,6 +635,10 @@ class TaurusValue(Qt.QWidget, TaurusBaseWidget):
         return self._customWidgetMap
 
     def onChangeLabelConfig(self):
+        self.deprecated(msg="onChangeLabelConfig is deprecated", rel="Jan2018")
+        self._onChangeLabelText()
+
+    def _onChangeLabelText(self):
         keys = ['{attr.label}', '{attr.name}', '{attr.fullname}', '{dev.name}',
                 '{dev.fullname}']
 
@@ -810,9 +813,6 @@ class TaurusValue(Qt.QWidget, TaurusBaseWidget):
             # set the model for the subwidget
             if hasattr(self._labelWidget, 'setModel'):
                 self._labelWidget.setModel(self.getFullModelName())
-
-            if self._labelText is not None:
-                self._labelWidget.setText(self._labelText)
 
     def updateReadWidget(self):
         # get the class for the widget and replace it if necessary
@@ -1234,9 +1234,9 @@ class TaurusValue(Qt.QWidget, TaurusBaseWidget):
         :param config: fragment
         :type config: str
         """
+        self._labelConfig = config
         # backwards compatibility: this method used to work for setting
         # an arbitrary text to the label widget
-        self._labelConfig = config
         try:
             self.getModelFragmentObj(config)
             self._labelWidget._permanentText = None

--- a/lib/taurus/qt/qtgui/panel/taurusvalue.py
+++ b/lib/taurus/qt/qtgui/panel/taurusvalue.py
@@ -1242,8 +1242,12 @@ class TaurusValue(Qt.QWidget, TaurusBaseWidget):
             self._labelWidget._permanentText = None
         except Exception:
             try:
-                self._labelWidget.setText(self._BCK_COMPAT_TAGS.get(config,
-                                                                    config))
+                for old in re.findall('<.+?>', config):
+                    new = self._BCK_COMPAT_TAGS.get(old, old)
+                    self.deprecated(dep=old, alt=new)
+                    config = config.replace(old, new)
+
+                self._labelWidget.setText(config)
             except:
                 self.debug("Setting permanent text to the label widget failed")
             return


### PR DESCRIPTION
The PR #496 added a regresion in the taurusform change label feature.

Fix it by:

- In DefaultLabelWidget class:
  - revert the changes in _BCK_COMPAT_TAGS
  - fix getDisplayValue

- Fix taurusValue onChangeLabelConfig method.

- Reimplement taurusLabel setText to use setPemanentText.
- Fix displayValue to allow format strings

Fix #641