### PR TITLE
TaurusValueLineEdit Bug

### DIFF
--- a/lib/taurus/qt/qtgui/input/tauruslineedit.py
+++ b/lib/taurus/qt/qtgui/input/tauruslineedit.py
@@ -237,7 +237,7 @@ class TaurusValueLineEdit(Qt.QLineEdit, TaurusBaseWritableWidget):
             elif model_type == DataType.Bytes:
                 return bytes(text)
             else:
-                raise TypeError('Unsupported model type "%s"', model_type)
+                raise TypeError('Unsupported model type "%s"'%model_type)
         except Exception, e:
             self.warning('Cannot return value for "%s". Reason: %r', text, e)
             return None

--- a/lib/taurus/qt/qtgui/input/tauruslineedit.py
+++ b/lib/taurus/qt/qtgui/input/tauruslineedit.py
@@ -122,6 +122,12 @@ class TaurusValueLineEdit(Qt.QLineEdit, TaurusBaseWritableWidget):
         TaurusBaseWritableWidget.updateStyle(self)
 
         value = self.getValue()
+        if value is None and self.hasPendingOperations():
+            try:
+                value = self.getModelValueObj().wvalue
+                self.setValue(value)
+            except:
+                value = None
 
         if value is None or not self.isTextValid():
             # invalid value

--- a/lib/taurus/qt/qtgui/input/tauruslineedit.py
+++ b/lib/taurus/qt/qtgui/input/tauruslineedit.py
@@ -237,7 +237,7 @@ class TaurusValueLineEdit(Qt.QLineEdit, TaurusBaseWritableWidget):
             elif model_type == DataType.Bytes:
                 return bytes(text)
             else:
-                raise TypeError('Unsupported model type "%s"'%model_type)
+                raise TypeError('Unsupported model type "%s"' % model_type)
         except Exception, e:
             self.warning('Cannot return value for "%s". Reason: %r', text, e)
             return None


### PR DESCRIPTION
This bug affects TaurusValueLineEdit widget when events are disabled or not available. The widget is meant to keep the last value introduced by user and change to "blue" if the value is modified by other client.

But, in the case when the setModel() methods ends before the Polling timer has started the value of the widget is set to None ... and never updated afterwards, not even changing to "blue" when required.

To solve it, I overwrite the existing value if it was None and there are new pending operations (value has changed).

No operation is applied as a result of this change and we have tested with C.Falcón that it doesn't affect existing taurusforms.