### PR TITLE
Improve TangoSchemeTest device server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ develop branch) won't be reflected in this file.
 - TaurusLed now supports non-boolean attributes (#617)
 - Support for arbitrary bgRole in labels (#629)
 - `--import-ascii` option in `taurusplot` launcher (#632)
-- `ChangeState` command in TangoSchemeTest DS (#628)
+- State and event support in TangoSchemeTest DS (#628, #655)
 - Model info in widget tooltips (#640)
 
 ### Changed

--- a/lib/taurus/core/tango/test/res/TangoSchemeTest
+++ b/lib/taurus/core/tango/test/res/TangoSchemeTest
@@ -268,12 +268,13 @@ class TangoSchemeTest(Device):
                                  **attrs['float_scalar'])
 
 
-    _float_scalar_evt = numpy.random.random() * 100
+    _float_scalar_evt = default_rvalue['float']
+    _float_scalar_poll = default_rvalue['float']
 
     # READ ONLY METHODS
     # SCALARS
     def read_float_scalar_poll(self):
-        return numpy.random.random() * 100
+        self._float_scalar_poll *= -1
 
     def read_float_scalar_evt(self):
         return self._float_scalar_evt
@@ -485,17 +486,17 @@ class TangoSchemeTest(Device):
         while True:
             sleep(0.1)
             try:
-                if self.use_fixed_time:
-                    sleeptime = self.sleeptime
-                else:
-                    sleeptime = numpy.random.random()*10
+                if not self.use_fixed_time:
+                    self.sleeptime *= 2
+                    if self.sleeptime > 5:
+                        self.sleeptime = 0.1
 
-                self._float_scalar_evt = numpy.random.random() * 100
+                self._float_scalar_evt *= -1
 
                 self.push_change_event('float_scalar_evt',
                                        self._float_scalar_evt, time(),
                                        AttrQuality.ATTR_VALID)
-                sleep(sleeptime)
+                sleep(self.sleeptime)
             except Exception as e:
                 print 'Exception in update loop', e
                 sleep(1)
@@ -522,7 +523,7 @@ class TangoSchemeTest(Device):
     @command(dtype_in=float)
     def SetEventPeriod(self, period):
         """ Set a fixed event period for float_scalar_evt attribute.
-        If period is 0,  the event period will be random.
+        If period is 0,  the event period will vary from 0.1 to 5
         """
         if period == 0:
             self.use_fixed_time = False

--- a/lib/taurus/core/tango/test/res/TangoSchemeTest
+++ b/lib/taurus/core/tango/test/res/TangoSchemeTest
@@ -286,7 +286,7 @@ class TangoSchemeTest(Device):
         # push_change_event (self, attr_name, data, time_stamp, quality,
         #                    dim_x = 1, dim_y = 0)
         self.push_change_event('float_scalar_evt', data, time.time(),
-                               PyTango.AttrQuality.ATTR_VALID, 1, 0)
+                               AttrQuality.ATTR_VALID, 1, 0)
 
     def read_boolean_scalar_ro(self):
         return self.default_rvalue['bool']

--- a/lib/taurus/core/tango/test/res/TangoSchemeTest
+++ b/lib/taurus/core/tango/test/res/TangoSchemeTest
@@ -81,7 +81,6 @@ class TangoSchemeTest(Device):
                       'string': 'hello world',
                       'uchar': 1,
                       }
-
     default_unit = {'int': "mm",
                     'float': "mm"}
     # x10 default_rvalue
@@ -102,7 +101,6 @@ class TangoSchemeTest(Device):
                         'float': [-default_rvalue["float"] * 3,
                                   default_rvalue["float"] * 3]
                         }
-
     attrs = {'bool_scalar': dict(dtype=bool),
              'short_scalar': dict(unit=default_unit["int"],
                                   dtype=numpy.int16),
@@ -112,7 +110,6 @@ class TangoSchemeTest(Device):
              'float_scalar_poll': dict(unit=default_unit["float"],
                                   dtype=numpy.float32,
                                   polling_period=500),
-
              'double_scalar': dict(unit=default_unit["float"],
                                    dtype=numpy.float64),
              'string_scalar': dict(dtype=str),
@@ -150,7 +147,6 @@ class TangoSchemeTest(Device):
                                  max_dim_x=MAXDIMX, max_dim_y=MAXDIMY),
              'MIXEDcase': dict(dtype=str)
              }
-
     extra_cfg = {'short_scalar': dict(min_value=default_ranges['int'][0],
                                       max_value=default_ranges['int'][1],
                                       min_alarm=default_alarms['int'][0],
@@ -188,7 +184,8 @@ class TangoSchemeTest(Device):
                                  **attrs['string_scalar'])
     uchar_scalar_ro = attribute(access=AttrWriteType.READ,
                                 **attrs['uchar_scalar'])
-    # SPECTRUMS
+
+    # SPECTRA
     boolean_spectrum_ro = attribute(access=AttrWriteType.READ,
                                     **attrs['bool_spectrum'])
     short_spectrum_ro = attribute(access=AttrWriteType.READ,
@@ -197,6 +194,7 @@ class TangoSchemeTest(Device):
                                   **attrs['float_spectrum'])
     string_spectrum_ro = attribute(access=AttrWriteType.READ,
                                    **attrs['string_spectrum'])
+
     # IMAGES
     uchar_image_ro = attribute(access=AttrWriteType.READ,
                                  **attrs['uchar_image'])
@@ -233,7 +231,8 @@ class TangoSchemeTest(Device):
                               **attrs['string_scalar'])
     uchar_scalar = attribute(access=AttrWriteType.READ_WRITE,
                              **attrs['uchar_scalar'])
-    # SPECTRUM
+
+    # SPECTRA
     boolean_spectrum = attribute(access=AttrWriteType.READ_WRITE,
                                  **attrs['bool_spectrum'])
     short_spectrum = attribute(access=AttrWriteType.READ_WRITE,
@@ -246,6 +245,7 @@ class TangoSchemeTest(Device):
                                 **attrs['string_spectrum'])
     uchar_spectrum = attribute(access=AttrWriteType.READ_WRITE,
                                **attrs['uchar_spectrum'])
+
     # IMAGES
     boolean_image = attribute(access=AttrWriteType.READ_WRITE,
                               **attrs['bool_image'])
@@ -260,13 +260,11 @@ class TangoSchemeTest(Device):
     uchar_image = attribute(access=AttrWriteType.READ_WRITE,
                             **attrs['uchar_image'])
 
-
     # EVENTS
     float_scalar_poll = attribute(access=AttrWriteType.READ,
                                   **attrs['float_scalar_poll'])
     float_scalar_evt = attribute(access=AttrWriteType.READ_WRITE,
                                  **attrs['float_scalar'])
-
 
     _float_scalar_evt = default_rvalue['float']
     _float_scalar_poll = default_rvalue['float']
@@ -290,7 +288,6 @@ class TangoSchemeTest(Device):
         self.push_change_event('float_scalar_evt', data, time.time(),
                                PyTango.AttrQuality.ATTR_VALID, 1, 0)
 
-
     def read_boolean_scalar_ro(self):
         return self.default_rvalue['bool']
 
@@ -312,7 +309,7 @@ class TangoSchemeTest(Device):
     def read_uchar_scalar_ro(self):
         return self.default_rvalue['uchar']
 
-    # SPECTRUMS
+    # SPECTRA
     def read_boolean_spectrum_ro(self):
         return [self.default_rvalue['bool']] * self.DIMX
 
@@ -394,7 +391,7 @@ class TangoSchemeTest(Device):
     def write_uchar_scalar(self, v):
         self._uchar_scalar = v
 
-    # SPECTRUMS
+    # SPECTRA
     def read_boolean_spectrum(self):
         return getattr(self, '_boolean_spectrum',
                        [self.default_rvalue['bool']] * self.DIMX)
@@ -518,7 +515,6 @@ class TangoSchemeTest(Device):
     def ChangePollingPeriod(self, period):
         """ Change the polling period of float_scalar_poll attribute"""
         self.poll_attribute('float_scalar_poll', period)
-
 
     @command(dtype_in=float)
     def SetEventPeriod(self, period):

--- a/lib/taurus/core/tango/test/res/TangoSchemeTest
+++ b/lib/taurus/core/tango/test/res/TangoSchemeTest
@@ -23,10 +23,12 @@
 ##
 #############################################################################
 import numpy
-from time import time
+from time import (time, sleep)
 
 from PyTango import DeviceProxy, AttrWriteType, DevState, AttrQuality
 from PyTango.server import Device, DeviceMeta, attribute, run, command
+
+from threading import Thread
 
 
 class TangoSchemeTest(Device):
@@ -107,6 +109,10 @@ class TangoSchemeTest(Device):
              'short_scalar_nu': dict(dtype=numpy.int16),
              'float_scalar': dict(unit=default_unit["float"],
                                   dtype=numpy.float32),
+             'float_scalar_poll': dict(unit=default_unit["float"],
+                                  dtype=numpy.float32,
+                                  polling_period=500),
+
              'double_scalar': dict(unit=default_unit["float"],
                                    dtype=numpy.float64),
              'string_scalar': dict(dtype=str),
@@ -254,8 +260,36 @@ class TangoSchemeTest(Device):
     uchar_image = attribute(access=AttrWriteType.READ_WRITE,
                             **attrs['uchar_image'])
 
+
+    # EVENTS
+    float_scalar_poll = attribute(access=AttrWriteType.READ,
+                                  **attrs['float_scalar_poll'])
+    float_scalar_evt = attribute(access=AttrWriteType.READ_WRITE,
+                                 **attrs['float_scalar'])
+
+
+    _float_scalar_evt = numpy.random.random() * 100
+
     # READ ONLY METHODS
     # SCALARS
+    def read_float_scalar_poll(self):
+        return numpy.random.random() * 100
+
+    def read_float_scalar_evt(self):
+        return self._float_scalar_evt
+
+    def write_float_scalar_evt(self, value):
+        self._float_scalar_evt = value
+        self.push_change_event('float_scalar_evt', self._float_scalar_evt)
+
+    @command(dtype_in=numpy.float32)
+    def PushEvent(self, data):
+        # push_change_event (self, attr_name, data, time_stamp, quality,
+        #                    dim_x = 1, dim_y = 0)
+        self.push_change_event('float_scalar_evt', data, time.time(),
+                               PyTango.AttrQuality.ATTR_VALID, 1, 0)
+
+
     def read_boolean_scalar_ro(self):
         return self.default_rvalue['bool']
 
@@ -447,12 +481,54 @@ class TangoSchemeTest(Device):
     def write_uchar_image(self, v):
         self._uchar_image = v
 
+    def _update_loop(self):
+        while True:
+            sleep(0.1)
+            try:
+                if self.use_fixed_time:
+                    sleeptime = self.sleeptime
+                else:
+                    sleeptime = numpy.random.random()*10
+
+                self._float_scalar_evt = numpy.random.random() * 100
+
+                self.push_change_event('float_scalar_evt',
+                                       self._float_scalar_evt, time(),
+                                       AttrQuality.ATTR_VALID)
+                sleep(sleeptime)
+            except Exception as e:
+                print 'Exception in update loop', e
+                sleep(1)
+
     def init_device(self):
         # To setUp the state
         Device.init_device(self)
         self.set_state(DevState.ON)
         self._quality = AttrQuality.ATTR_VALID
+        self.set_change_event('float_scalar_evt', True, False)
+        # event thread
+        self.use_fixed_time = False
+        self.sleeptime = None
+        self.t = Thread(target=self._update_loop)
+        self.t.setDaemon(True)
+        self.t.start()
 
+    @command(dtype_in=int)
+    def ChangePollingPeriod(self, period):
+        """ Change the polling period of float_scalar_poll attribute"""
+        self.poll_attribute('float_scalar_poll', period)
+
+
+    @command(dtype_in=float)
+    def SetEventPeriod(self, period):
+        """ Set a fixed event period for float_scalar_evt attribute.
+        If period is 0,  the event period will be random.
+        """
+        if period == 0:
+            self.use_fixed_time = False
+        else:
+            self.use_fixed_time = True
+            self.sleeptime = period
 
     @command(dtype_in=str)
     def ChangeState(self, state):


### PR DESCRIPTION
Add two new attributes,  "float_scalar_poll" and "float_scalar_evt",
the first one has been configured to emit Period events
(the tango polling has been enabled), and the second one
has been configured to emit Change events.

There are two new commands to configure the periods of these events:
"SetEventPeriod" to set fixed change events, and "ChangePollingPeriod"
to change the polling period of "float_scalar_poll" attribute.