### PR TITLE
Treat "No unit" as a synonim of PyTango.constants.UnitNotSpec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ develop branch) won't be reflected in this file.
 - Model info in widget tooltips (#640)
 
 ### Changed
+- Treat unit="No unit" as unitless in Tango attributes (#662)
 - taurus.qt widgets can now be used without installing PyTango (#590)
 - Tango model name validators now always return FQDN instead of PQDN
   for the tango host (#488)

--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -1027,7 +1027,10 @@ class TangoAttribute(TaurusAttribute):
     def _unit_from_tango(self, unit):
         # silently treat unit-not-defined as unitless
         # TODO: consider logging that unit-not-defined is treated as unitless
-        # TODO: See https://github.com/taurus-org/taurus/issues/584
+        # TODO: See https://github.com/taurus-org/taurus/issues/584 and
+        # https://github.com/taurus-org/taurus/pull/662
+        # The extra comparison to "No unit" is necessary where
+        # server/database runs Tango 7 or 8 and client runs higher versions.
         if unit == PyTango.constants.UnitNotSpec or unit == "No unit":
             unit = None
         try:

--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -1025,13 +1025,16 @@ class TangoAttribute(TaurusAttribute):
         return self._pytango_attrinfoex.data_type
 
     def _unit_from_tango(self, unit):
-        if unit == PyTango.constants.UnitNotSpec:
+        # silently treat unit-not-defined as unitless
+        # TODO: consider logging that unit-not-defined is treated as unitless
+        # TODO: See https://github.com/taurus-org/taurus/issues/584
+        if unit == PyTango.constants.UnitNotSpec or unit == "No unit":
             unit = None
         try:
             return UR.parse_units(unit)
         except Exception as e:
             # TODO: Maybe we could dynamically register the unit in the UR
-            msg = 'Unknown unit "%s (will be treated as unitless)"'
+            msg = 'Unknown unit "%s" (will be treated as unitless)'
             if self.__already_warned_unit == unit:
                 self.debug(msg, unit)
             else:

--- a/lib/taurus/core/tango/util/tango_taurus.py
+++ b/lib/taurus/core/tango/util/tango_taurus.py
@@ -117,14 +117,14 @@ def unit_from_tango(unit):
     from taurus import deprecated
     deprecated(dep='unit_from_tango', rel='4.0.4', alt="pint's parse_units")
 
-    if unit == PyTango.constants.UnitNotSpec:
+    if unit == PyTango.constants.UnitNotSpec or unit == "No unit":
         unit = None
     try:
         return UR.parse_units(unit)
     except (UndefinedUnitError, UnicodeDecodeError):
         # TODO: Maybe we could dynamically register the unit in the UR
         from taurus import warning
-        warning('Unknown unit "%s (will be treated as unitless)"', unit)
+        warning('Unknown unit "%s" (will be treated as unitless)', unit)
         return UR.parse_units(None)
 
 


### PR DESCRIPTION
Fix #584

To be coherent with the current state of things in Tango and PyTango, I think that both "No unit"  and `PyTango.constants.UnitNotSpec` should be treated equally by taurus.

Note that this may change [if Tango decides to differentiate](https://github.com/tango-controls/TangoTickets/issues/8)

Currently Taurus is **silently** interpreting `PyTango.constants.UnitNotSpec` as unitless. i.e., tango is **not** giving a warning when the unit is `PyTango.constants.UnitNotSpec`, and is simply treating it as unitless. The warnings that we have observed are actually due to the fact that PyTango is returning "No unit" instead of `PyTango.constants.UnitNotSpec`. 

As I said above, I think that both should be treated in the same way, at least while (Py)Tango does not diferentiate.

  