### PR TITLE
Spinbox was showing units even if the model use fragments to display only the magnitude

### DIFF
--- a/lib/taurus/qt/qtgui/base/taurusbase.py
+++ b/lib/taurus/qt/qtgui/base/taurusbase.py
@@ -2061,6 +2061,30 @@ class TaurusBaseWritableWidget(TaurusBaseWidget):
         '''
         return []
 
+    def getDisplayValue(self, cache=True, fragmentName=None):
+        """Returns a string representation of the model value associated with
+        this component.
+
+        :param cache: (bool) (ignored, just for bck-compat).
+        :param fragmentName: (str or None) the returned value will correspond
+                        to the given fragmentName. If None passed,
+                         self.modelFragmentName will be used, and if None is
+                         set, the defaultFragmentName of the model will be used
+                         instead.
+
+        :return: (str) a string representation of the model value.
+        """
+        # @fixme: Even the widgets inheriting from this class interacts with
+        #         writable models (then the fragmentName by default that one
+        #         expects is 'wvalue' and not 'rvalue') it has been considered
+        #         that perhaps this could be considered an API modification
+        #         instead of a bugfix.
+        #         The bugfix impact has been bounded only within the
+        #         TaurusValueLineEdit.
+        return super(TaurusBaseWritableWidget,
+                     self).getDisplayValue(cache=cache,
+                                           fragmentName=fragmentName)
+
     def getValue(self):
         '''
         This method must be implemented in derived classes to return

--- a/lib/taurus/qt/qtgui/base/taurusbase.py
+++ b/lib/taurus/qt/qtgui/base/taurusbase.py
@@ -2081,9 +2081,8 @@ class TaurusBaseWritableWidget(TaurusBaseWidget):
         #         instead of a bugfix.
         #         The bugfix impact has been bounded only within the
         #         TaurusValueLineEdit.
-        return super(TaurusBaseWritableWidget,
-                     self).getDisplayValue(cache=cache,
-                                           fragmentName=fragmentName)
+        return TaurusBaseWidget.getDisplayValue(self, cache=cache,
+                                                fragmentName=fragmentName)
 
     def getValue(self):
         '''

--- a/lib/taurus/qt/qtgui/base/taurusbase.py
+++ b/lib/taurus/qt/qtgui/base/taurusbase.py
@@ -2062,27 +2062,19 @@ class TaurusBaseWritableWidget(TaurusBaseWidget):
         return []
 
     def getDisplayValue(self, cache=True, fragmentName=None):
-        """Returns a string representation of the model value associated with
-        this component.
-
-        :param cache: (bool) (ignored, just for bck-compat).
-        :param fragmentName: (str or None) the returned value will correspond
-                        to the given fragmentName. If None passed,
-                         self.modelFragmentName will be used, and if None is
-                         set, the defaultFragmentName of the model will be used
-                         instead.
-
-        :return: (str) a string representation of the model value.
-        """
-        # @fixme: Even the widgets inheriting from this class interacts with
-        #         writable models (then the fragmentName by default that one
-        #         expects is 'wvalue' and not 'rvalue') it has been considered
-        #         that perhaps this could be considered an API modification
-        #         instead of a bugfix.
-        #         The bugfix impact has been bounded only within the
-        #         TaurusValueLineEdit.
+        """Reimplemented from class:`TaurusBaseWidget`"""
+        # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        # The widgets inheriting from this class interact with
+        # writable models and therefore the fragmentName should fall back to 'wvalue' 
+        # instead of 'rvalue'. 
+        # But changing it now is delicate due to risk of introducing API
+        # incompatibilities for widgets already assuming the current default.
+        # So instead of reimplementing it here, the fix was constrained to 
+        # TaurusValueLineEdit.getDisplayValue()
+        # TODO: Consider reimplementing this to use wvalue by default
         return TaurusBaseWidget.getDisplayValue(self, cache=cache,
                                                 fragmentName=fragmentName)
+        # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
     def getValue(self):
         '''

--- a/lib/taurus/qt/qtgui/input/tauruslineedit.py
+++ b/lib/taurus/qt/qtgui/input/tauruslineedit.py
@@ -150,8 +150,8 @@ class TaurusValueLineEdit(Qt.QLineEdit, TaurusBaseWritableWidget):
                         (max_ is not None and value > max_)):
                     color = 'orange'
         # apply style
-        style = 'TaurusValueLineEdit {color: %s; font-weight: %s}' %\
-                (color, weight)
+        style = ('TaurusValueLineEdit {color: %s; font-weight: %s}' %
+                 (color, weight))
         self.setStyleSheet(style)
 
     def wheelEvent(self, evt):
@@ -216,11 +216,11 @@ class TaurusValueLineEdit(Qt.QLineEdit, TaurusBaseWritableWidget):
         :return: (str) a string representation of the model value.
         """
         if fragmentName is None and self.modelFragmentName is None:
-            return TaurusBaseWritableWidget.\
-                getDisplayValue(self, cache=cache, fragmentName='wvalue')
+            return TaurusBaseWritableWidget.getDisplayValue(
+                self, cache=cache, fragmentName='wvalue')
         else:
-            return TaurusBaseWritableWidget.\
-                getDisplayValue(self, cache=cache, fragmentName=fragmentName)
+            return TaurusBaseWritableWidget.getDisplayValue(
+                self, cache=cache, fragmentName=fragmentName)
 
     def setValue(self, v):
         model = self.getModelObj()
@@ -291,10 +291,10 @@ class TaurusValueLineEdit(Qt.QLineEdit, TaurusBaseWritableWidget):
                             TaurusBaseWritableWidget.setModel,
                             TaurusBaseWritableWidget.resetModel)
 
-    useParentModel = \
-        Qt.pyqtProperty("bool", TaurusBaseWritableWidget.getUseParentModel,
-                        TaurusBaseWritableWidget.setUseParentModel,
-                        TaurusBaseWritableWidget.resetUseParentModel)
+    useParentModel = Qt.pyqtProperty(
+        "bool", TaurusBaseWritableWidget.getUseParentModel,
+        TaurusBaseWritableWidget.setUseParentModel,
+        TaurusBaseWritableWidget.resetUseParentModel)
 
     autoApply = Qt.pyqtProperty("bool", TaurusBaseWritableWidget.getAutoApply,
                                 TaurusBaseWritableWidget.setAutoApply,

--- a/lib/taurus/qt/qtgui/input/tauruslineedit.py
+++ b/lib/taurus/qt/qtgui/input/tauruslineedit.py
@@ -206,7 +206,7 @@ class TaurusValueLineEdit(Qt.QLineEdit, TaurusBaseWritableWidget):
         if model is None:
             v_str = str(v)
         else:
-            v_str = str(self.displayValue(v))
+            v_str = str(self.getDisplayValue(v))
         v_str = v_str.strip()
         self.setText(v_str)
 

--- a/lib/taurus/qt/qtgui/input/tauruslineedit.py
+++ b/lib/taurus/qt/qtgui/input/tauruslineedit.py
@@ -23,11 +23,9 @@
 ##
 #############################################################################
 
-"""This module provides a set of basic taurus widgets based on QLineEdit"""
-
-__all__ = ["TaurusValueLineEdit"]
-
-__docformat__ = 'restructuredtext'
+"""
+This module provides a set of basic taurus widgets based on QLineEdit
+"""
 
 import sys
 import numpy
@@ -36,6 +34,10 @@ from taurus.external.pint import Quantity
 from taurus.qt.qtgui.base import TaurusBaseWritableWidget
 from taurus.qt.qtgui.util import PintValidator
 from taurus.core import DataType, DataFormat, TaurusEventType
+
+__all__ = ["TaurusValueLineEdit"]
+
+__docformat__ = 'restructuredtext'
 
 
 class TaurusValueLineEdit(Qt.QLineEdit, TaurusBaseWritableWidget):
@@ -72,7 +74,8 @@ class TaurusValueLineEdit(Qt.QLineEdit, TaurusBaseWritableWidget):
             if units != val.units:
                 val.setUnits(units)
 
-        # @TODO Other validators can be configured for other types (e.g. with string lengths, tango names,...)
+        # @TODO Other validators can be configured for other types
+        #       (e.g. with string lengths, tango names,...)
         else:
             self.setValidator(None)
             self.debug("Validator disabled")
@@ -93,9 +96,9 @@ class TaurusValueLineEdit(Qt.QLineEdit, TaurusBaseWritableWidget):
         if self._autoApply:
             self.writeValue()
 
-    #-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-
+    # ~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~
     # TaurusBaseWritableWidget overwriting
-    #-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-
+    # ~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~
     def notifyValueChanged(self, *args):
         '''reimplement to avoid autoapply on every partial edition'''
         self.emitValueChanged()
@@ -140,7 +143,8 @@ class TaurusValueLineEdit(Qt.QLineEdit, TaurusBaseWritableWidget):
                 color, weight = 'black', 'normal'
             # also check alarms (if applicable)
             modelObj = self.getModelObj()
-            if modelObj and modelObj.type in [DataType.Integer, DataType.Float]:
+            if modelObj and modelObj.type in [DataType.Integer,
+                                              DataType.Float]:
                 min_, max_ = modelObj.alarms
                 if ((min_ is not None and value < min_) or
                         (max_ is not None and value > max_)):
@@ -258,23 +262,25 @@ class TaurusValueLineEdit(Qt.QLineEdit, TaurusBaseWritableWidget):
         ret['icon'] = "designer:lineedit.png"
         return ret
 
-    #-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-
+    # ~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~
     # QT properties
-    #-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-
+    # ~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~
 
     model = Qt.pyqtProperty("QString", TaurusBaseWritableWidget.getModel,
                             TaurusBaseWritableWidget.setModel,
                             TaurusBaseWritableWidget.resetModel)
 
-    useParentModel = Qt.pyqtProperty("bool", TaurusBaseWritableWidget.getUseParentModel,
-                                     TaurusBaseWritableWidget.setUseParentModel,
-                                     TaurusBaseWritableWidget.resetUseParentModel)
+    useParentModel = \
+        Qt.pyqtProperty("bool", TaurusBaseWritableWidget.getUseParentModel,
+                        TaurusBaseWritableWidget.setUseParentModel,
+                        TaurusBaseWritableWidget.resetUseParentModel)
 
     autoApply = Qt.pyqtProperty("bool", TaurusBaseWritableWidget.getAutoApply,
                                 TaurusBaseWritableWidget.setAutoApply,
                                 TaurusBaseWritableWidget.resetAutoApply)
 
-    forcedApply = Qt.pyqtProperty("bool", TaurusBaseWritableWidget.getForcedApply,
+    forcedApply = Qt.pyqtProperty("bool",
+                                  TaurusBaseWritableWidget.getForcedApply,
                                   TaurusBaseWritableWidget.setForcedApply,
                                   TaurusBaseWritableWidget.resetForcedApply)
 
@@ -285,21 +291,41 @@ class TaurusValueLineEdit(Qt.QLineEdit, TaurusBaseWritableWidget):
 
 def main():
     import sys
-    from taurus.qt.qtgui.application import TaurusApplication
+    import taurus.qt.qtgui.application
+    Application = taurus.qt.qtgui.application.TaurusApplication
 
-    app = TaurusApplication()
+    app = Application.instance()
+    owns_app = app is None
+
+    if owns_app:
+        import taurus.core.util.argparse
+        parser = taurus.core.util.argparse.get_taurus_parser()
+        parser.usage = "%prog [options] <full_attribute_name(s)>"
+        app = Application(sys.argv, cmd_line_parser=parser,
+                          app_name="Taurus lineedit demo", app_version="1.0",
+                          org_domain="Taurus", org_name="Tango community")
+
+    args = app.get_command_line_args()
 
     form = Qt.QWidget()
     layout = Qt.QVBoxLayout()
     form.setLayout(layout)
-    for m in ('sys/tg_test/1/double_scalar',
-              'sys/tg_test/1/double_scalar'
-              ):
+    if len(args) == 0:
+        models = ['sys/tg_test/1/double_scalar', 'sys/tg_test/1/double_scalar']
+    else:
+        models = args
+    for model in models:
         w = TaurusValueLineEdit()
-        w.setModel(m)
+        w.setModel(model)
         layout.addWidget(w)
+    form.resize(300, 50)
     form.show()
-    sys.exit(app.exec_())
+
+    if owns_app:
+        sys.exit(app.exec_())
+    else:
+        return form
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/lib/taurus/qt/qtgui/input/tauruslineedit.py
+++ b/lib/taurus/qt/qtgui/input/tauruslineedit.py
@@ -216,13 +216,11 @@ class TaurusValueLineEdit(Qt.QLineEdit, TaurusBaseWritableWidget):
         :return: (str) a string representation of the model value.
         """
         if fragmentName is None and self.modelFragmentName is None:
-            return super(TaurusValueLineEdit,
-                         self).getDisplayValue(cache=cache,
-                                               fragmentName='wvalue')
+            return TaurusBaseWritableWidget.\
+                getDisplayValue(self, cache=cache, fragmentName='wvalue')
         else:
-            return super(TaurusValueLineEdit,
-                         self).getDisplayValue(cache=cache,
-                                               fragmentName=fragmentName)
+            return TaurusBaseWritableWidget.\
+                getDisplayValue(self, cache=cache, fragmentName=fragmentName)
 
     def setValue(self, v):
         model = self.getModelObj()

--- a/lib/taurus/qt/qtgui/input/tauruslineedit.py
+++ b/lib/taurus/qt/qtgui/input/tauruslineedit.py
@@ -201,6 +201,29 @@ class TaurusValueLineEdit(Qt.QLineEdit, TaurusBaseWritableWidget):
         value = self.getValue()
         self.setValue(value + Quantity(v, value.units))
 
+    def getDisplayValue(self, cache=True, fragmentName=None):
+        """Returns a string representation of the model value associated with
+        this component. As this is a writable widget, if there is no fragment
+        specified, the default behaviour is to display the wvalue.
+
+        :param cache: (bool) (ignored, just for bck-compat).
+        :param fragmentName: (str or None) the returned value will correspond
+                        to the given fragmentName. If None passed,
+                         self.modelFragmentName will be used, and if None is
+                         set, the defaultFragmentName of the model will be used
+                         instead.
+
+        :return: (str) a string representation of the model value.
+        """
+        if fragmentName is None and self.modelFragmentName is None:
+            return super(TaurusValueLineEdit,
+                         self).getDisplayValue(cache=cache,
+                                               fragmentName='wvalue')
+        else:
+            return super(TaurusValueLineEdit,
+                         self).getDisplayValue(cache=cache,
+                                               fragmentName=fragmentName)
+
     def setValue(self, v):
         model = self.getModelObj()
         if model is None:

--- a/lib/taurus/qt/qtgui/input/taurusspinbox.py
+++ b/lib/taurus/qt/qtgui/input/taurusspinbox.py
@@ -23,17 +23,19 @@
 ##
 #############################################################################
 
-"""This module provides a set of basic taurus widgets based on QAbstractSpinBox"""
-
-__all__ = ["TaurusValueSpinBox", "TaurusValueSpinBoxEx"]
-
-__docformat__ = 'restructuredtext'
+"""
+This module provides a set of basic taurus widgets based on QAbstractSpinBox
+"""
 
 from taurus.external.qt import Qt
 
 from tauruslineedit import TaurusValueLineEdit
 from taurus.qt.qtgui.icon import getStandardIcon
 from taurus.external.pint import Quantity
+
+__all__ = ["TaurusValueSpinBox", "TaurusValueSpinBoxEx"]
+
+__docformat__ = 'restructuredtext'
 
 
 class TaurusValueSpinBox(Qt.QAbstractSpinBox):
@@ -64,9 +66,9 @@ class TaurusValueSpinBox(Qt.QAbstractSpinBox):
     def keyPressEvent(self, evt):
         return self.lineEdit().keyPressEvent(evt)
 
-    #-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-
+    # ~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~
     # Mandatory overload from QAbstractSpinBox
-    #-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-
+    # ~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~
 
     def stepBy(self, steps):
         self.setValue(self.getValue() + self._getSingleStepQuantity() * steps)
@@ -99,9 +101,9 @@ class TaurusValueSpinBox(Qt.QAbstractSpinBox):
             ret |= Qt.QAbstractSpinBox.StepDownEnabled
         return ret
 
-    #-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-
+    # ~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~
     # Overload from QAbstractSpinBox
-    #-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-
+    # ~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~
 
     def validate(self, input, pos):
         """Overloaded to use the current validator from the TaurusValueLineEdit,
@@ -113,9 +115,9 @@ class TaurusValueSpinBox(Qt.QAbstractSpinBox):
             return Qt.QAbstractSpinBox.validate(self, input, pos)
         return val.validate(input, pos)
 
-    #-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-
+    # ~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~
     # Model related methods
-    #-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-
+    # ~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~
 
     def setModel(self, model):
         self.lineEdit().setModel(model)
@@ -195,6 +197,7 @@ class TaurusValueSpinBox(Qt.QAbstractSpinBox):
     forcedApply = Qt.pyqtProperty("bool", getForcedApply, setForcedApply,
                                   resetForcedApply)
 
+
 _S = """
 QSpinBox::up-button {
     border-width: 0px;
@@ -247,14 +250,54 @@ class TaurusValueSpinBoxEx(Qt.QWidget):
         setattr(self.spinBox, name, value)
 
 
-if __name__ == "__main__":
+def main():
     import sys
-    from taurus.qt.qtgui.application import TaurusApplication
-    app = TaurusApplication()
+    import taurus.qt.qtgui.application
+    Application = taurus.qt.qtgui.application.TaurusApplication
 
-    w = TaurusValueSpinBox()
-    w.setModel('sys/tg_test/1/double_scalar')
-    w.resize(300, 50)
+    app = Application.instance()
+    owns_app = app is None
+
+    if owns_app:
+        import taurus.core.util.argparse
+        parser = taurus.core.util.argparse.get_taurus_parser()
+        parser.usage = "%prog [options] <full_attribute_name(s)>"
+        app = Application(sys.argv, cmd_line_parser=parser,
+                          app_name="Taurus spinbox demo", app_version="1.0",
+                          org_domain="Taurus", org_name="Tango community")
+
+    args = app.get_command_line_args()
+
+    if len(args) == 0:
+        w = TaurusValueSpinBox()
+        w.setModel('sys/tg_test/1/double_scalar')
+        w.resize(300, 50)
+    else:
+        w = Qt.QWidget()
+        layout = Qt.QGridLayout()
+        w.setLayout(layout)
+        for model in args:
+            label = TaurusValueSpinBox()
+            label.setModel(model)
+            layout.addWidget(label)
+        w.resize(300, 50)
     w.show()
 
-    sys.exit(app.exec_())
+    if owns_app:
+        sys.exit(app.exec_())
+    else:
+        return w
+
+
+if __name__ == "__main__":
+    main()
+#     import sys
+#     from taurus.qt.qtgui.application import TaurusApplication
+#     app = TaurusApplication()
+
+#     w = TaurusValueSpinBox()
+#     w.setModel('sys/tg_test/1/double_scalar')
+#     w.resize(300, 50)
+#     w.show()
+
+#     sys.exit(app.exec_())


### PR DESCRIPTION
I've seen that a TaurusValueSpinBox was still showing the units in widgets where the model say, in the fragment, that only the magnitude was to be shown.

This pull request contains 2 commits. The first one was changes in the main function at the end of the file, for testing purposes (as well as a pep8 review). Then, like the main in the tauruslabel one can pass some attributes as arguments.

The commit with the solution itself is the second. There is a single change in the TaurusValueLineEdit.setValue(self, v). It was using self.displayValue(v) when the method that manages with the fragments is getDisplayValue.

/Sergi.