### PR TITLE
Add tangoState property to tango device objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ develop branch) won't be reflected in this file.
 - Travis-built docs (not yet replacing the RTD ones) (#572)
 - TaurusLed now supports non-boolean attributes (#617)
 - Support for arbitrary bgRole in labels (#629)
+- `TangoDevice.tangoState` property (#672)
 - `--import-ascii` option in `taurusplot` launcher (#632)
 - State and event support in TangoSchemeTest DS (#628, #655)
 - Model info in widget tooltips (#640)

--- a/lib/taurus/core/tango/tangodevice.py
+++ b/lib/taurus/core/tango/tangodevice.py
@@ -405,3 +405,8 @@ class TangoDevice(TaurusDevice):
         if self._deviceStateObj is None:
             self._deviceStateObj = self.getAttribute("state")
         return self._deviceStateObj
+
+    @property
+    def tangoState(self):
+        """The value of the Tango state attribute"""
+        return self.stateObj.read().rvalue


### PR DESCRIPTION
Add TangoDevice.tangoState. It is a property that returns the value of
the state attribute of the device.

This allows, e.g. to set the bgRole of a TaurusLabel to display the color of the *tango* state instead of the taurus state:

```python
from taurus.qt.qtgui.application import TaurusApplication
from taurus.qt.qtgui.display import TaurusLabel

if __name__ == '__main__':
    import sys
    app = TaurusApplication()
    w = TaurusLabel()
    # Show the status attr in the foreground
    w.setModel('sys/tg_test/1/status')
    # show the *tango* state color as background
    w.setBgRole('parentObj.tangoState')
    w.show()
    sys.exit(app.exec_())
```