### PR TITLE
(Fix #667) Problems editing text of TaurusValueLineEdit

### DIFF
--- a/lib/taurus/qt/qtgui/input/tauruslineedit.py
+++ b/lib/taurus/qt/qtgui/input/tauruslineedit.py
@@ -126,12 +126,6 @@ class TaurusValueLineEdit(Qt.QLineEdit, TaurusBaseWritableWidget):
         TaurusBaseWritableWidget.updateStyle(self)
 
         value = self.getValue()
-        if value is None and self.hasPendingOperations():
-            try:
-                value = self.getModelValueObj().wvalue
-                self.setValue(value)
-            except:
-                value = None
 
         if value is None or not self.isTextValid():
             # invalid value

--- a/lib/taurus/qt/qtgui/input/tauruslineedit.py
+++ b/lib/taurus/qt/qtgui/input/tauruslineedit.py
@@ -239,6 +239,10 @@ class TaurusValueLineEdit(Qt.QLineEdit, TaurusBaseWritableWidget):
             model_format = model_obj.data_format
             if model_type in [DataType.Integer, DataType.Float]:
                 try:
+                    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                    # workaround for https://github.com/hgrecco/pint/issues/614
+                    text = text.lstrip('0') or '0'
+                    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                     q = Quantity(text)
                     # allow implicit units (assume wvalue.units implicitly)
                     if q.unitless:

--- a/lib/taurus/qt/qtgui/input/tauruslineedit.py
+++ b/lib/taurus/qt/qtgui/input/tauruslineedit.py
@@ -58,7 +58,7 @@ class TaurusValueLineEdit(Qt.QLineEdit, TaurusBaseWritableWidget):
         self.editingFinished.connect(self._onEditingFinished)
 
     def _updateValidator(self, value):
-        '''This method sets a validator depending on the data type'''
+        """This method sets a validator depending on the data type"""
         if isinstance(value.wvalue, Quantity):
             val = self.validator()
             if not isinstance(val, PintValidator):
@@ -81,8 +81,8 @@ class TaurusValueLineEdit(Qt.QLineEdit, TaurusBaseWritableWidget):
             self.debug("Validator disabled")
 
     def __decimalDigits(self, fmt):
-        '''returns the number of decimal digits from a format string
-        (or None if they are not defined)'''
+        """returns the number of decimal digits from a format string
+        (or None if they are not defined)"""
         try:
             if fmt[-1].lower() in ['f', 'g'] and '.' in fmt:
                 return int(fmt[:-1].split('.')[-1])
@@ -92,7 +92,7 @@ class TaurusValueLineEdit(Qt.QLineEdit, TaurusBaseWritableWidget):
             return None
 
     def _onEditingFinished(self):
-        '''slot for performing autoapply only when edition is finished'''
+        """slot for performing autoapply only when edition is finished"""
         if self._autoApply:
             self.writeValue()
 
@@ -100,7 +100,7 @@ class TaurusValueLineEdit(Qt.QLineEdit, TaurusBaseWritableWidget):
     # TaurusBaseWritableWidget overwriting
     # ~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~
     def notifyValueChanged(self, *args):
-        '''reimplement to avoid autoapply on every partial edition'''
+        """reimplement to avoid autoapply on every partial edition"""
         self.emitValueChanged()
 
     def handleEvent(self, evt_src, evt_type, evt_value):
@@ -122,6 +122,7 @@ class TaurusValueLineEdit(Qt.QLineEdit, TaurusBaseWritableWidget):
         return val.validate(str(self.text()), 0)[0] == val.Acceptable
 
     def updateStyle(self):
+        """Reimplemented from :class:`TaurusBaseWritableWidget`"""
         TaurusBaseWritableWidget.updateStyle(self)
 
         value = self.getValue()
@@ -155,6 +156,7 @@ class TaurusValueLineEdit(Qt.QLineEdit, TaurusBaseWritableWidget):
         self.setStyleSheet(style)
 
     def wheelEvent(self, evt):
+        """Wheel event handler"""
         if not self.getEnableWheelEvent() or Qt.QLineEdit.isReadOnly(self):
             return Qt.QLineEdit.wheelEvent(self, evt)
         model = self.getModelObj()
@@ -172,6 +174,7 @@ class TaurusValueLineEdit(Qt.QLineEdit, TaurusBaseWritableWidget):
         self._stepBy(numSteps)
 
     def keyPressEvent(self, evt):
+        """Key press event handler"""
         if evt.key() in (Qt.Qt.Key_Return, Qt.Qt.Key_Enter):
             Qt.QLineEdit.keyPressEvent(self, evt)
             evt.accept()


### PR DESCRIPTION
The changes done in #650 introduce a problem when editing text in
TaurusValueLineEdit widgets (see #667). 

Furthermore, it seems that the problem described in https://github.com/taurus-org/taurus/pull/650#issue-283282985 cannot be reproduced as described (see https://github.com/taurus-org/taurus/pull/650#issuecomment-359861563).

Therefore, revert the main change of #650 in order to fix #667.
