### PR TITLE
Fix several issues in TaurusValueLineEdit

### DIFF
--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -509,14 +509,14 @@ class TangoAttribute(TaurusAttribute):
                     self.__attr_value = self.decode(v)
                     self.__attr_err = None
                     return self.__attr_value
-                except PyTango.DevFailed, df:
+                except PyTango.DevFailed as df:
                     self.__attr_value = None
                     self.__attr_err = df
                     err = df[0]
                     self.debug("[Tango] read failed (%s): %s",
                                err.reason, err.desc)
                     raise df
-                except Exception, e:
+                except Exception as e:
                     self.__attr_value = None
                     self.__attr_err = e
                     self.debug("[Tango] read failed: %s", e)
@@ -711,7 +711,7 @@ class TangoAttribute(TaurusAttribute):
                 attr_name,
                 PyTango.EventType.ATTR_CONF_EVENT,
                 self, [], True)  # connects to self.push_event callback
-        except PyTango.DevFailed, e:
+        except PyTango.DevFailed as e:
             self.debug("Error trying to subscribe to CONFIGURATION events.")
             self.traceback()
             # Subscription failed either because event mechanism is not available
@@ -889,7 +889,7 @@ class TangoAttribute(TaurusAttribute):
 
     def setLabel(self, lbl):
         TaurusAttribute.setLabel(self, lbl)
-        infoex = self._pytango_attrinfoex
+        infoex = self._pytango_attrinfoex or PyTango.AttributeInfoEx()
         infoex.label = lbl
         self._applyConfig()
 
@@ -904,7 +904,7 @@ class TangoAttribute(TaurusAttribute):
         if high.unitless:
             high = Quantity(high.magnitude, self._units)
         TaurusAttribute.setRange(self, [low, high])
-        infoex = self._pytango_attrinfoex
+        infoex = self._pytango_attrinfoex or PyTango.AttributeInfoEx()
         if low.magnitude != float('-inf'):
             infoex.min_value = str(low.to(self._units).magnitude)
         else:
@@ -926,7 +926,7 @@ class TangoAttribute(TaurusAttribute):
         if high.unitless:
             high = Quantity(high.magnitude, self._units)
         TaurusAttribute.setWarnings(self, [low, high])
-        infoex = self._pytango_attrinfoex
+        infoex = self._pytango_attrinfoex or PyTango.AttributeInfoEx()
         if low.magnitude != float('-inf'):
             infoex.alarms.min_warning = str(low.to(self._units).magnitude)
         else:
@@ -948,7 +948,7 @@ class TangoAttribute(TaurusAttribute):
         if high.unitless:
             high = Quantity(high.magnitude, self._units)
         TaurusAttribute.setAlarms(self, [low, high])
-        infoex = self._pytango_attrinfoex
+        infoex = self._pytango_attrinfoex or PyTango.AttributeInfoEx()
         if low.magnitude != float('-inf'):
             infoex.alarms.min_alarm = str(low.to(self._units).magnitude)
         else:
@@ -960,75 +960,76 @@ class TangoAttribute(TaurusAttribute):
         self._applyConfig()
 
     def _applyConfig(self):
-        config = self._pytango_attrinfoex
+        config = self._pytango_attrinfoex or PyTango.AttributeInfoEx()
         self.setConfigEx(config)
 
     def _decodeAttrInfoEx(self, pytango_attrinfoex=None):
         if pytango_attrinfoex is None:
-            self._pytango_attrinfoex = PyTango.AttributeInfoEx()
+            return
+
+        self._pytango_attrinfoex = i = pytango_attrinfoex
+
+        self.writable = i.writable != PyTango.AttrWriteType.READ
+        self._label = i.label
+        self.data_format = data_format_from_tango(i.data_format)
+        desc = description_from_tango(i.description)
+        if desc != "":
+            self._description = desc
+        self.type = data_type_from_tango(i.data_type)
+        ###############################################################
+        # changed in taurus4: range, alarm and warning now return
+        # quantities if appropriate
+        if self.isNumeric():
+            units = self._unit_from_tango(i.unit)
         else:
-            self._pytango_attrinfoex = i = pytango_attrinfoex
+            units = UR.parse_units(None)
 
-            self.writable = i.writable != PyTango.AttrWriteType.READ
-            self._label = i.label
-            self.data_format = data_format_from_tango(i.data_format)
-            desc = description_from_tango(i.description)
-            if desc != "":
-                self._description = desc
-            self.type = data_type_from_tango(i.data_type)
-            ###############################################################
-            # changed in taurus4: range, alarm and warning now return
-            # quantities if appropriate
-            if self.isNumeric():
-                units = self._unit_from_tango(i.unit)
-            else:
-                units = UR.parse_units(None)
+        if PyTango.is_numerical_type(i.data_type, inc_array=True):
+            Q_ = partial(quantity_from_tango_str, units=units,
+                         dtype=i.data_type)
+            ninf, inf = float('-inf'), float('inf')
+            min_value = Q_(i.min_value) or Quantity(ninf, units)
+            max_value = Q_(i.max_value) or Quantity(inf, units)
+            min_alarm = Q_(i.alarms.min_alarm) or Quantity(ninf, units)
+            max_alarm = Q_(i.alarms.max_alarm) or Quantity(inf, units)
+            min_warning = Q_(i.alarms.min_warning) or Quantity(ninf, units)
+            max_warning = Q_(i.alarms.max_warning) or Quantity(inf, units)
+            self._range = [min_value, max_value]
+            self._warning = [min_warning, max_warning]
+            self._alarm = [min_alarm, max_alarm]
 
-            if PyTango.is_numerical_type(i.data_type, inc_array=True):
-                Q_ = partial(quantity_from_tango_str, units=units,
-                             dtype=i.data_type)
-                ninf, inf = float('-inf'), float('inf')
-                min_value = Q_(i.min_value) or Quantity(ninf, units)
-                max_value = Q_(i.max_value) or Quantity(inf, units)
-                min_alarm = Q_(i.alarms.min_alarm) or Quantity(ninf, units)
-                max_alarm = Q_(i.alarms.max_alarm) or Quantity(inf, units)
-                min_warning = Q_(i.alarms.min_warning) or Quantity(ninf, units)
-                max_warning = Q_(i.alarms.max_warning) or Quantity(inf, units)
-                self._range = [min_value, max_value]
-                self._warning = [min_warning, max_warning]
-                self._alarm = [min_alarm, max_alarm]
-
-            ###############################################################
-            # The following members will be accessed via __getattr__
-            # self.standard_unit
-            # self.display_unit
-            # self.disp_level
-            ###############################################################
-            # Tango-specific extension of TaurusConfigValue
-            self.display_level = display_level_from_tango(i.disp_level)
-            self.tango_writable = i.writable
-            self.max_dim = i.max_dim_x, i.max_dim_y
-            ###############################################################
-            fmt = standard_display_format_from_tango(i.data_type, i.format)
-            self.format_spec = fmt.lstrip('%')  # format specifier
-            match = re.search("[^\.]*\.(?P<precision>[0-9]+)[eEfFgG%]", fmt)
-            if match:
-                self.precision = int(match.group(1))
-            # self._units and self._display_format is to be used by
-            # TangoAttrValue for performance reasons. Do not rely on it in other
-            # code
-            self._units = units
+        ###############################################################
+        # The following members will be accessed via __getattr__
+        # self.standard_unit
+        # self.display_unit
+        # self.disp_level
+        ###############################################################
+        # Tango-specific extension of TaurusConfigValue
+        self.display_level = display_level_from_tango(i.disp_level)
+        self.tango_writable = i.writable
+        self.max_dim = i.max_dim_x, i.max_dim_y
+        ###############################################################
+        fmt = standard_display_format_from_tango(i.data_type, i.format)
+        self.format_spec = fmt.lstrip('%')  # format specifier
+        match = re.search("[^\.]*\.(?P<precision>[0-9]+)[eEfFgG%]", fmt)
+        if match:
+            self.precision = int(match.group(1))
+        # self._units and self._display_format is to be used by
+        # TangoAttrValue for performance reasons. Do not rely on it in other
+        # code
+        self._units = units
 
     @property
     @deprecation_decorator(alt='format_spec or precision', rel='4.0.4')
     def format(self):
-        i = self._pytango_attrinfoex
+        i = self._pytango_attrinfoex or PyTango.AttributeInfoEx()
         return standard_display_format_from_tango(i.data_type, i.format)
 
     @property
     def _tango_data_type(self):
         '''returns the *tango* (not Taurus) data type'''
-        return self._pytango_attrinfoex.data_type
+        i = self._pytango_attrinfoex or PyTango.AttributeInfoEx()
+        return i.data_type
 
     def _unit_from_tango(self, unit):
         # silently treat unit-not-defined as unitless

--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -1162,7 +1162,16 @@ class TangoAttribute(TaurusAttribute):
         """Returns the current configuration of the attribute."""
         return weakref.proxy(self)
 
-    def getAttributeInfoEx(self):
+    def getAttributeInfoEx(self, cache=True):
+        if not cache:
+            try:
+                attr_name = self.getSimpleName()
+                attrinfoex = self.__dev_hw_obj.attribute_query(attr_name)
+                self._decodeAttrInfoEx(attrinfoex)
+            except:
+                self.warning("Error getting attribute configuration")
+                self.traceback()
+
         return self._pytango_attrinfoex
 
     @taurus4_deprecation(alt='.rvalue.units')

--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -399,7 +399,9 @@ class TangoAttribute(TaurusAttribute):
     def decode(self, attr_value):
         """Decodes a value that was received from PyTango into the expected
         representation"""
-        # TODO decode of the configuration
+        if self._pytango_attrinfoex is None:
+            self.getAttributeInfoEx(cache=False)
+            self._decodeAttrInfoEx()
         value = TangoAttrValue(pytango_dev_attr=attr_value, attr=self)
         return value
 
@@ -1169,8 +1171,8 @@ class TangoAttribute(TaurusAttribute):
                 attr_name = self.getSimpleName()
                 attrinfoex = self.__dev_hw_obj.attribute_query(attr_name)
                 self._decodeAttrInfoEx(attrinfoex)
-            except:
-                self.warning("Error getting attribute configuration")
+            except Exception as e:
+                self.debug("Error getting attribute configuration: %s", e)
                 self.traceback()
 
         return self._pytango_attrinfoex

--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -652,8 +652,8 @@ class TangoAttribute(TaurusAttribute):
         """
         
         if self.__chg_evt_id is not None:
-            self.warning("chg events already subscribed (id=%s)"
-                       %self.__chg_evt_id)
+            self.warning("chg events already subscribed (id=%s)",
+                         self.__chg_evt_id)
             return
                 
         attr_name = self.getSimpleName()

--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -650,6 +650,12 @@ class TangoAttribute(TaurusAttribute):
     def _call_dev_hw_subscribe_event(self, stateless=True):
         """ Executes event subscription on parent TangoDevice objectName
         """
+        
+        if self.__chg_evt_id is not None:
+            self.warning("chg events already subscribed (id=%s)"
+                       %self.__chg_evt_id)
+            return
+                
         attr_name = self.getSimpleName()
 
         self.__chg_evt_id = self.__dev_hw_obj.subscribe_event(

--- a/lib/taurus/qt/qtgui/base/tauruscontroller.py
+++ b/lib/taurus/qt/qtgui/base/tauruscontroller.py
@@ -97,18 +97,17 @@ class TaurusBaseController(object):
         return self.widget().getDisplayValue()
 
     def handleEvent(self, evt_src, evt_type, evt_value):
-        if evt_src == self.modelObj():  # update the "_last" values only if the event source is the model (it could be the background...)
-            if evt_type == TaurusEventType.Change or evt_type == TaurusEventType.Periodic:
-                if (self.widget() and self._last_value is None 
-	                    and self._last_config_value is None):
-                    # After a device is reconnected, attribute config must 
-                    # be reloaded if no config event has been received yet
-                    self.widget().info('Reloading attr_config')
-		    # TODO: Tango-centric
-                    self.modelObj().getAttributeInfoEx(cache = False)
+        # update the "_last" values only if the event source is the model
+        # (it could be the background...)
+        if evt_src == self.modelObj():
+            if evt_type in (TaurusEventType.Change, TaurusEventType.Periodic):
+                if self._last_value is None:
+                    # reset the format so that it gets updated by displayValue
+                    self.widget().resetFormat()
                 self._last_value = evt_value
             elif evt_type == TaurusEventType.Config:  # TODO: adapt to tep14
                 self._last_config_value = evt_value
+                self.widget().resetFormat()
             else:
                 self._last_error_value = evt_value
                 # In case of error, modify the last_value as well

--- a/lib/taurus/qt/qtgui/base/tauruscontroller.py
+++ b/lib/taurus/qt/qtgui/base/tauruscontroller.py
@@ -104,6 +104,7 @@ class TaurusBaseController(object):
                     # After a device is reconnected, attribute config must 
                     # be reloaded if no config event has been received yet
                     self.widget().info('Reloading attr_config')
+		    # TODO: Tango-centric
                     self.modelObj().getAttributeInfoEx(cache = False)
                 self._last_value = evt_value
             elif evt_type == TaurusEventType.Config:  # TODO: adapt to tep14

--- a/lib/taurus/qt/qtgui/base/tauruscontroller.py
+++ b/lib/taurus/qt/qtgui/base/tauruscontroller.py
@@ -99,8 +99,8 @@ class TaurusBaseController(object):
     def handleEvent(self, evt_src, evt_type, evt_value):
         if evt_src == self.modelObj():  # update the "_last" values only if the event source is the model (it could be the background...)
             if evt_type == TaurusEventType.Change or evt_type == TaurusEventType.Periodic:
-                if self.widget() and self._last_value is None and \
-                        self._last_config_value is None:
+                if (self.widget() and self._last_value is None 
+	                    and self._last_config_value is None):
                     # After a device is reconnected, attribute config must 
                     # be reloaded if no config event has been received yet
                     self.widget().info('Reloading attr_config')

--- a/lib/taurus/qt/qtgui/base/tauruscontroller.py
+++ b/lib/taurus/qt/qtgui/base/tauruscontroller.py
@@ -99,6 +99,12 @@ class TaurusBaseController(object):
     def handleEvent(self, evt_src, evt_type, evt_value):
         if evt_src == self.modelObj():  # update the "_last" values only if the event source is the model (it could be the background...)
             if evt_type == TaurusEventType.Change or evt_type == TaurusEventType.Periodic:
+                if self.widget() and self._last_value is None and \
+                        self._last_config_value is None:
+                    # After a device is reconnected, attribute config must 
+                    # be reloaded if no config event has been received yet
+                    self.widget().info('Reloading attr_config')
+                    self.modelObj().getAttributeInfoEx(cache = False)
                 self._last_value = evt_value
             elif evt_type == TaurusEventType.Config:  # TODO: adapt to tep14
                 self._last_config_value = evt_value

--- a/lib/taurus/qt/qtgui/input/tauruslineedit.py
+++ b/lib/taurus/qt/qtgui/input/tauruslineedit.py
@@ -127,6 +127,7 @@ class TaurusValueLineEdit(Qt.QLineEdit, TaurusBaseWritableWidget):
 
         if self._value is None and self.hasPendingOperations():
             try:
+                self.getModelObj().getAttributeInfoEx(cache = False)
                 value = self.getModelValueObj().wvalue
                 self.info('Overwriting wvalue=None with %s' % (value))
                 self.setValue(value)

--- a/lib/taurus/qt/qtgui/input/tauruslineedit.py
+++ b/lib/taurus/qt/qtgui/input/tauruslineedit.py
@@ -48,6 +48,7 @@ class TaurusValueLineEdit(Qt.QLineEdit, TaurusBaseWritableWidget):
         self.call__init__(TaurusBaseWritableWidget,
                           name, designMode=designMode)
         self._enableWheelEvent = False
+        self._value = None
 
         self.setAlignment(Qt.Qt.AlignRight)
         self.setValidator(None)
@@ -124,14 +125,16 @@ class TaurusValueLineEdit(Qt.QLineEdit, TaurusBaseWritableWidget):
     def updateStyle(self):
         TaurusBaseWritableWidget.updateStyle(self)
 
-        value = self.getValue()
-        if value is None and self.hasPendingOperations():
+        if self._value is None and self.hasPendingOperations():
             try:
                 value = self.getModelValueObj().wvalue
+                self.info('Overwriting wvalue=None with %s' % (value))
                 self.setValue(value)
             except:
                 value = None
 
+        value = self.getValue()
+        
         if value is None or not self.isTextValid():
             # invalid value
             color, weight = 'gray', 'normal'
@@ -229,6 +232,7 @@ class TaurusValueLineEdit(Qt.QLineEdit, TaurusBaseWritableWidget):
         else:
             v_str = str(self.getDisplayValue(v))
         v_str = v_str.strip()
+        self._value = v
         self.setText(v_str)
 
     def getValue(self):

--- a/lib/taurus/qt/qtgui/input/tauruslineedit.py
+++ b/lib/taurus/qt/qtgui/input/tauruslineedit.py
@@ -110,6 +110,8 @@ class TaurusValueLineEdit(Qt.QLineEdit, TaurusBaseWritableWidget):
             self._updateValidator(evt_value)
         TaurusBaseWritableWidget.handleEvent(
             self, evt_src, evt_type, evt_value)
+        if evt_type == TaurusEventType.Error:
+            self.updateStyle()
 
     def isTextValid(self):
         """
@@ -138,7 +140,7 @@ class TaurusValueLineEdit(Qt.QLineEdit, TaurusBaseWritableWidget):
 
         value = self.getValue()
         
-        if value is None or not self.isTextValid():
+        if value is None or not self.isTextValid() or not self.isEnabled():
             # invalid value
             color, weight = 'gray', 'normal'
         else:

--- a/lib/taurus/qt/qtgui/input/tauruslineedit.py
+++ b/lib/taurus/qt/qtgui/input/tauruslineedit.py
@@ -105,6 +105,7 @@ class TaurusValueLineEdit(Qt.QLineEdit, TaurusBaseWritableWidget):
         self.emitValueChanged()
 
     def handleEvent(self, evt_src, evt_type, evt_value):
+        self.setEnabled(evt_type != TaurusEventType.Error)
         if evt_type in (TaurusEventType.Change, TaurusEventType.Periodic):
             self._updateValidator(evt_value)
         TaurusBaseWritableWidget.handleEvent(
@@ -131,6 +132,7 @@ class TaurusValueLineEdit(Qt.QLineEdit, TaurusBaseWritableWidget):
                 value = self.getModelValueObj().wvalue
                 self.info('Overwriting wvalue=None with %s' % (value))
                 self.setValue(value)
+                self.setEnabled(value is not None)
             except:
                 value = None
 

--- a/lib/taurus/qt/qtgui/panel/taurusvalue.py
+++ b/lib/taurus/qt/qtgui/panel/taurusvalue.py
@@ -38,7 +38,7 @@ import weakref
 import re
 from taurus.external.qt import Qt
 import taurus.core
-from taurus.core import DataType, DataFormat
+from taurus.core import DataType, DataFormat, TaurusEventType
 
 from taurus.core.taurusbasetypes import TaurusElementType
 from taurus.qt.qtcore.mimetypes import TAURUS_ATTR_MIME_TYPE, TAURUS_DEV_MIME_TYPE, TAURUS_MODEL_MIME_TYPE
@@ -310,6 +310,7 @@ class TaurusValue(Qt.QWidget, TaurusBaseWidget):
         self.call__init__wo_kw(Qt.QWidget, parent)
         self.call__init__(TaurusBaseWidget, name, designMode=designMode)
 
+        self.__error = False
         self.__modelClass = None
         self._designMode = designMode
 
@@ -1165,13 +1166,19 @@ class TaurusValue(Qt.QWidget, TaurusBaseWidget):
         """Reimplemented from :meth:`TaurusBaseWidget.handleEvent`
         to update subwidgets on config events
         """
-        if evt_type == taurus.core.taurusbasetypes.TaurusEventType.Config and not self._designMode:
+        if self._designMode:
+            return
+
+        if self.__error or evt_type == TaurusEventType.Config:
             self.updateCustomWidget()
             self.updateLabelWidget()
             self.updateReadWidget()
             self.updateWriteWidget()
             self.updateUnitsWidget()
             self.updateExtraWidget()
+
+        # set/unset the error flag
+        self.__error = (evt_type == TaurusEventType.Error)
 
     def isValueChangedByUser(self):
         try:


### PR DESCRIPTION
On behalf of @mbroseta and @cpascual 

solves problems with nones and units after (re)connection with event-less devices

#649: line edit ignoring errors from device
#650: value not loaded without events
#667, #673: side effects of the previous fix
CS-14995: line edit and value label ignoring format on device reconnection

All the previous errors where reproduced using:

a Tango device with a RW attribute, with "deg" units and %6.2e format

and this code as client:

```python
import taurus
from taurus.qt.qtgui.application import TaurusApplication
from taurus.qt.qtgui.input import TaurusValueLineEdit
from taurus.core.tango.util import tangoFormatter

taurus.Factory('tango').set_tango_subscribe_enabled(False)

m = 'sys/tg_test/1/float_scalar'
a = taurus.Attribute(m)

app = TaurusApplication()

w = TaurusValueLineEdit()
w.setFormat(tangoFormatter)
w.setModel(m)
w.show()

app.exec_()
```

Fix #649 , 
Fix #650 , 
Fix #667, 
Fix #673 
Fix CS-14995