### PR TITLE
Fix bug in setting serialization mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ develop branch) won't be reflected in this file.
 - Make spyder dependency optional (#556)
 
 ### Fixed
+- TaurusModel ignoring the serialization mode (#678)
 - Wrong "missing units" warnings for non-numerical attributes (#580)
 - Taurus3 backwards compatibility issues (#496, #550)
 - False positives in taurus.check_dependencies (#612)

--- a/lib/taurus/core/taurusmodel.py
+++ b/lib/taurus/core/taurusmodel.py
@@ -60,7 +60,7 @@ class TaurusModel(Logger):
             s_obj = parent
             if s_obj is None:
                 s_obj = self.factory()
-                serializationMode = s_obj.getSerializationMode()
+            serializationMode = s_obj.getSerializationMode()
         self._serialization_mode = serializationMode
 
         self._parentObj = parent


### PR DESCRIPTION
TaurusModel's logic for setting the serialization mode is wrong due to
a tabulation problem. This leads to TaurusDevices always being
initialized with serialization mode 'Serial', ignoring the mode set
in the Manager (by default, 'Concurrent'). Fix the tabulation issue and
restore the intended logic.

Warning: be aware that because the Concurrent mode was in practice not
set until now (in spite of being the intended situation), some code may
not have been properly tested under Concurrent serialization mode and
therefore potentially bugs which have been hidden may now suface.

The problem can be seen with the following code (it prints `Concurrent=False` unless this patch is applied):

```python
import taurus
m = taurus.Manager()
m.setSerializationMode(taurus.core.TaurusSerializationMode.Concurrent)
a = taurus.Attribute('sys/tg_test/1/double_scalar')
print "Concurrent=", a._serialization_mode==taurus.core.TaurusSerializationMode.Concurrent
```
