### PR TITLE
Proposing fix for issue #648 (taurusLabel.setModelIndex() not working).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ develop branch) won't be reflected in this file.
 - Missing icons in buttons (#583, #598)
 - Exception in TaurusCommandForm (#608)
 - Launchers not showing output on MS Windows (#644)
-- Various issues with input widgets (#623, #661, #650, #669)
+- Various issues with input widgets (#623, #661, #650, #669, #651, #663)
 - Regressions in:
   - TaurusTrend (#618)
   - TaurusGrid (#609)

--- a/lib/taurus/qt/qtgui/base/taurusbase.py
+++ b/lib/taurus/qt/qtgui/base/taurusbase.py
@@ -640,6 +640,14 @@ class TaurusBaseComponent(TaurusListener, BaseConfigurableClass):
             fragmentName = self.modelFragmentName
         return self.modelObj.getFragmentObj(fragmentName)
 
+    def getModelIndexValue(self):
+        """
+        Called inside getDisplayValue to use with spectrum attributes. By default not used, but some widget might want to support this feature.
+
+        Override when needed.
+        """
+        return None
+
     def getFormatedToolTip(self, cache=True):
         """Returns a string with contents to be displayed in a tooltip.
 
@@ -817,6 +825,11 @@ class TaurusBaseComponent(TaurusListener, BaseConfigurableClass):
             v = self.getModelFragmentObj(fragmentName=fragmentName)
         except:
             return self.getNoneValue()
+
+        idx = self.getModelIndexValue()
+        if v is not None and idx is not None and len(idx):
+            for i in idx:
+                v = v[i]
 
         return self.displayValue(v)
 

--- a/lib/taurus/qt/qtgui/base/taurusbase.py
+++ b/lib/taurus/qt/qtgui/base/taurusbase.py
@@ -642,7 +642,9 @@ class TaurusBaseComponent(TaurusListener, BaseConfigurableClass):
 
     def getModelIndexValue(self):
         """
-        Called inside getDisplayValue to use with spectrum attributes. By default not used, but some widget might want to support this feature.
+        Called inside getDisplayValue to use with spectrum attributes.
+        By default not used, but some widget might want to support this
+        feature.
 
         Override when needed.
         """
@@ -827,7 +829,7 @@ class TaurusBaseComponent(TaurusListener, BaseConfigurableClass):
             return self.getNoneValue()
 
         idx = self.getModelIndexValue()
-        if v is not None and idx is not None and len(idx):
+        if v is not None and idx:
             for i in idx:
                 v = v[i]
 

--- a/lib/taurus/qt/qtgui/base/tauruscontroller.py
+++ b/lib/taurus/qt/qtgui/base/tauruscontroller.py
@@ -257,7 +257,7 @@ class TaurusConfigurationControllerHelper(object):
             try:
                 no_val = getattr(model, "no_" + param)  # TODO: Tango-centric
                 if val.lower() == no_val.lower():
-                    val = widget.getNoneValue()
+                    return widget.getNoneValue()
             except:
                 pass
         except AttributeError:
@@ -278,13 +278,13 @@ class TaurusConfigurationControllerHelper(object):
                     val = val.replace('<dev_name>', dev.getNormalName() or
                                       '---')
             else:
-                val = widget.getNoneValue()
+                return widget.getNoneValue()
         except:
             widget.debug("Invalid configuration parameter '%s'" % param)
-            val = widget.getNoneValue()
+            return widget.getNoneValue()
         if val is None:
-            val = widget.getNoneValue()
-        return val
+            return widget.getNoneValue()
+        return widget.displayValue(val)
 
 
 StyleSheetTemplate = """border-style: outset; border-width: 2px; border-color: {0}; {1}"""

--- a/lib/taurus/qt/qtgui/base/tauruscontroller.py
+++ b/lib/taurus/qt/qtgui/base/tauruscontroller.py
@@ -243,7 +243,7 @@ class TaurusConfigurationControllerHelper(object):
     @property
     def configParam(self):
         if self._configParam is None:
-            self._configParam = self.widget().getModelFragmentName() or ''
+            self._configParam = self.widget().modelFragmentName or ''
         return self._configParam
 
     def getDisplayValue(self, write=False):

--- a/lib/taurus/qt/qtgui/base/tauruscontroller.py
+++ b/lib/taurus/qt/qtgui/base/tauruscontroller.py
@@ -175,25 +175,25 @@ class TaurusAttributeControllerHelper(object):
 
 class TaurusScalarAttributeControllerHelper(TaurusAttributeControllerHelper):
 
-    def getDisplayValue(self, write=False):
+    def getDisplayValue(self, write=False, fragmentName=None):
         valueObj = self.valueObj()
         widget = self.widget()
         if valueObj is None or valueObj.rvalue is None:
-            return widget.getDisplayValue()
+            return widget.getDisplayValue(fragmentName=fragmentName)
 
         format = self.attrObj().data_format
         if format == DataFormat._0D:
-            return self._getDisplayValue(widget, valueObj, None, write)
+            return self._getDisplayValue(widget, valueObj, None, write, fragmentName)
 
         idx = widget.getModelIndexValue()
-        return self._getDisplayValue(widget, valueObj, idx, write)
+        return self._getDisplayValue(widget, valueObj, idx, write, fragmentName)
 
-    def _getDisplayValue(self, widget, valueObj, idx, write):
+    def _getDisplayValue(self, widget, valueObj, idx, write, fragmentName):
         try:
             if write:
                 value = valueObj.wvalue
             else:
-                value = valueObj.rvalue
+                value = widget.getModelFragmentObj(fragmentName)
             if idx is not None and len(idx):
                 for i in idx:
                     value = value[i]
@@ -246,14 +246,14 @@ class TaurusConfigurationControllerHelper(object):
             self._configParam = self.widget().modelFragmentName or ''
         return self._configParam
 
-    def getDisplayValue(self, write=False):
+    def getDisplayValue(self, write=False, fragmentName=None):
         widget = self.widget()
         model = self.configObj()
         if model is None:
             return widget.getNoneValue()
         param = self.configParam
         try:
-            val = widget.getModelFragmentObj()
+            val = widget.getModelFragmentObj(fragmentName)
             try:
                 no_val = getattr(model, "no_" + param)  # TODO: Tango-centric
                 if val.lower() == no_val.lower():

--- a/lib/taurus/qt/qtgui/base/tauruscontroller.py
+++ b/lib/taurus/qt/qtgui/base/tauruscontroller.py
@@ -175,25 +175,25 @@ class TaurusAttributeControllerHelper(object):
 
 class TaurusScalarAttributeControllerHelper(TaurusAttributeControllerHelper):
 
-    def getDisplayValue(self, write=False, fragmentName=None):
+    def getDisplayValue(self, write=False):
         valueObj = self.valueObj()
         widget = self.widget()
         if valueObj is None or valueObj.rvalue is None:
-            return widget.getDisplayValue(fragmentName=fragmentName)
+            return widget.getDisplayValue()
 
         format = self.attrObj().data_format
         if format == DataFormat._0D:
-            return self._getDisplayValue(widget, valueObj, None, write, fragmentName)
+            return self._getDisplayValue(widget, valueObj, None, write)
 
         idx = widget.getModelIndexValue()
-        return self._getDisplayValue(widget, valueObj, idx, write, fragmentName)
+        return self._getDisplayValue(widget, valueObj, idx, write)
 
-    def _getDisplayValue(self, widget, valueObj, idx, write, fragmentName):
+    def _getDisplayValue(self, widget, valueObj, idx, write):
         try:
             if write:
                 value = valueObj.wvalue
             else:
-                value = widget.getModelFragmentObj(fragmentName)
+                value = valueObj.rvalue
             if idx is not None and len(idx):
                 for i in idx:
                     value = value[i]
@@ -246,18 +246,18 @@ class TaurusConfigurationControllerHelper(object):
             self._configParam = self.widget().modelFragmentName or ''
         return self._configParam
 
-    def getDisplayValue(self, write=False, fragmentName=None):
+    def getDisplayValue(self, write=False):
         widget = self.widget()
         model = self.configObj()
         if model is None:
             return widget.getNoneValue()
         param = self.configParam
         try:
-            val = widget.getModelFragmentObj(fragmentName)
+            val = widget.getModelFragmentObj()
             try:
                 no_val = getattr(model, "no_" + param)  # TODO: Tango-centric
                 if val.lower() == no_val.lower():
-                    return widget.getNoneValue()
+                    val = widget.getNoneValue()
             except:
                 pass
         except AttributeError:
@@ -278,13 +278,13 @@ class TaurusConfigurationControllerHelper(object):
                     val = val.replace('<dev_name>', dev.getNormalName() or
                                       '---')
             else:
-                return widget.getNoneValue()
+                val = widget.getNoneValue()
         except:
             widget.debug("Invalid configuration parameter '%s'" % param)
-            return widget.getNoneValue()
+            val = widget.getNoneValue()
         if val is None:
-            return widget.getNoneValue()
-        return widget.displayValue(val)
+            val = widget.getNoneValue()
+        return val
 
 
 StyleSheetTemplate = """border-style: outset; border-width: 2px; border-color: {0}; {1}"""

--- a/lib/taurus/qt/qtgui/display/tauruslabel.py
+++ b/lib/taurus/qt/qtgui/display/tauruslabel.py
@@ -91,7 +91,7 @@ class TaurusLabelController(TaurusBaseController):
             pass
         else:
             value = self.getDisplayValue()
-        self._text = text = label.prefixText + value + label.suffixText
+        self._text = text = label.prefixText + str(value) + label.suffixText
 
         # Checks that the display fits in the widget and sets it to "..." if
         # it does not fit the widget

--- a/lib/taurus/qt/qtgui/display/tauruslabel.py
+++ b/lib/taurus/qt/qtgui/display/tauruslabel.py
@@ -90,7 +90,7 @@ class TaurusLabelController(TaurusBaseController):
         elif fgRole.lower() in ('', 'none'):
             pass
         else:
-            value = self.getDisplayValue()
+            value = self.getDisplayValue(fragmentName=fgRole)
         self._text = text = label.prefixText + str(value) + label.suffixText
 
         # Checks that the display fits in the widget and sets it to "..." if

--- a/lib/taurus/qt/qtgui/display/tauruslabel.py
+++ b/lib/taurus/qt/qtgui/display/tauruslabel.py
@@ -90,8 +90,8 @@ class TaurusLabelController(TaurusBaseController):
         elif fgRole.lower() in ('', 'none'):
             pass
         else:
-            value = self.getDisplayValue(fragmentName=fgRole)
-        self._text = text = label.prefixText + str(value) + label.suffixText
+            value = label.getDisplayValue(fragmentName=fgRole)
+        self._text = text = label.prefixText + value + label.suffixText
 
         # Checks that the display fits in the widget and sets it to "..." if
         # it does not fit the widget

--- a/lib/taurus/qt/qtgui/display/tauruslcd.py
+++ b/lib/taurus/qt/qtgui/display/tauruslcd.py
@@ -96,7 +96,7 @@ class TaurusLCDControllerAttribute(TaurusScalarAttributeControllerHelper, Taurus
         TaurusScalarAttributeControllerHelper.__init__(self)
         TaurusLCDController.__init__(self, lcd)
 
-    def _getDisplayValue(self, widget, valueObj, idx, write, fragmentName):
+    def _getDisplayValue(self, widget, valueObj, idx, write):
         try:
             if write:
                 value = valueObj.wvalue.magnitude

--- a/lib/taurus/qt/qtgui/display/tauruslcd.py
+++ b/lib/taurus/qt/qtgui/display/tauruslcd.py
@@ -96,7 +96,7 @@ class TaurusLCDControllerAttribute(TaurusScalarAttributeControllerHelper, Taurus
         TaurusScalarAttributeControllerHelper.__init__(self)
         TaurusLCDController.__init__(self, lcd)
 
-    def _getDisplayValue(self, widget, valueObj, idx, write):
+    def _getDisplayValue(self, widget, valueObj, idx, write, fragmentName):
         try:
             if write:
                 value = valueObj.wvalue.magnitude


### PR DESCRIPTION
Fix is really simple, instead of calling getDisplayValue on the label it should be done on "self", so that it ends up in TaurusScalarAttributeControllerHelper.getDisplayValue, where the modelIndex handling is implemented.