### PR TITLE
Add mechanism to discover taurus.qt.qtgui plugins

### DIFF
--- a/lib/taurus/qt/qtgui/__init__.py
+++ b/lib/taurus/qt/qtgui/__init__.py
@@ -38,6 +38,7 @@ import sys
 import glob
 import pkg_resources
 from taurus import tauruscustomsettings as __S
+from taurus import debug as __debug
 
 icon_dir = os.path.join(os.path.dirname(os.path.abspath(__icon.__file__)))
 # TODO: get .path file glob pattern from tauruscustomsettings
@@ -53,11 +54,18 @@ __icon.registerTheme(name=getattr(__S, 'QT_THEME_NAME', 'Tango'),
 
 # Discover the taurus.qt.qtgui plugins
 for __p in pkg_resources.iter_entry_points('taurus.qt.qtgui'):
-    __mod = __p.load()
-    setattr(sys.modules[__name__], __p.name, __mod)
-    sys.modules['%s.%s' % (__name__, __p.name)] = __mod
+    try:
+        __modname = '%s.%s' % (__name__, __p.name)
+        __mod = __p.load()
+        # Add it to the current module
+        setattr(sys.modules[__name__], __p.name, __mod)
+        # Add it to sys.modules
+        sys.modules[__modname] = __mod
+        __debug('Plugin "%s" loaded as "%s"', __p.module_name, __modname)
+    except Exception as e:
+        __debug('Could not load plugin "%s". Reason: %s', __p.module_name, e)
 
 # ------------------------------------------------------------------------
     
-del os, glob, __icon, icon_dir, pkg_resources, sys, __mod
+del os, glob, __icon, icon_dir, pkg_resources, sys, __mod, __modname, __debug
 

--- a/lib/taurus/qt/qtgui/__init__.py
+++ b/lib/taurus/qt/qtgui/__init__.py
@@ -51,15 +51,13 @@ __icon.registerTheme(name=getattr(__S, 'QT_THEME_NAME', 'Tango'),
 # Note: this is an experimental feature introduced in v 4.3.0a
 # It may be removed or changed in future releases
 
-# Discover the taurus.qt.qtgui plugins 
-__plugins = {
-    __entry_point.name: __entry_point.load()
-    for __entry_point in pkg_resources.iter_entry_points('taurus.qt.qtgui')
-}
-# Add plugins to the module
-for __mod_name, __mod in __plugins.items():
-    setattr(sys.modules[__name__], __mod_name, __mod)
+# Discover the taurus.qt.qtgui plugins
+for __p in pkg_resources.iter_entry_points('taurus.qt.qtgui'):
+    __mod = __p.load()
+    setattr(sys.modules[__name__], __p.name, __mod)
+    sys.modules['%s.%s' % (__name__, __p.name)] = __mod
+
 # ------------------------------------------------------------------------
     
-del os, glob, __icon, icon_dir, pkg_resources, sys
+del os, glob, __icon, icon_dir, pkg_resources, sys, __mod
 

--- a/lib/taurus/qt/qtgui/__init__.py
+++ b/lib/taurus/qt/qtgui/__init__.py
@@ -53,6 +53,7 @@ __icon.registerTheme(name=getattr(__S, 'QT_THEME_NAME', 'Tango'),
 # It may be removed or changed in future releases
 
 # Discover the taurus.qt.qtgui plugins
+__mod = __modname = None
 for __p in pkg_resources.iter_entry_points('taurus.qt.qtgui'):
     try:
         __modname = '%s.%s' % (__name__, __p.name)

--- a/lib/taurus/qt/qtgui/__init__.py
+++ b/lib/taurus/qt/qtgui/__init__.py
@@ -34,7 +34,9 @@ __docformat__ = 'restructuredtext'
 # register icon path files and icon theme on import of taurus.qt.qtgui
 import icon as __icon
 import os
+import sys
 import glob
+import pkg_resources
 from taurus import tauruscustomsettings as __S
 
 icon_dir = os.path.join(os.path.dirname(os.path.abspath(__icon.__file__)))
@@ -46,3 +48,15 @@ __icon.registerTheme(name=getattr(__S, 'QT_THEME_NAME', 'Tango'),
                      force=getattr(__S, 'QT_THEME_FORCE_ON_LINUX', False))
 
 del os, glob, __icon, icon_dir
+
+
+# Discover the taurus.qt.qtgui plugins
+plugins = {
+    entry_point.name: entry_point.load()
+    for entry_point in pkg_resources.iter_entry_points('taurus.qt.qtgui')
+}
+
+# Add plugins to the module
+for mod_name, mod in plugins.items():
+    setattr(sys.modules[__name__], mod_name, mod)
+

--- a/lib/taurus/qt/qtgui/__init__.py
+++ b/lib/taurus/qt/qtgui/__init__.py
@@ -47,16 +47,19 @@ __icon.registerTheme(name=getattr(__S, 'QT_THEME_NAME', 'Tango'),
                      path=getattr(__S, 'QT_THEME_DIR', ''),
                      force=getattr(__S, 'QT_THEME_FORCE_ON_LINUX', False))
 
-del os, glob, __icon, icon_dir
+# ------------------------------------------------------------------------
+# Note: this is an experimental feature introduced in v 4.3.0a
+# It may be removed or changed in future releases
 
-
-# Discover the taurus.qt.qtgui plugins
-plugins = {
-    entry_point.name: entry_point.load()
-    for entry_point in pkg_resources.iter_entry_points('taurus.qt.qtgui')
+# Discover the taurus.qt.qtgui plugins 
+__plugins = {
+    __entry_point.name: __entry_point.load()
+    for __entry_point in pkg_resources.iter_entry_points('taurus.qt.qtgui')
 }
-
 # Add plugins to the module
-for mod_name, mod in plugins.items():
-    setattr(sys.modules[__name__], mod_name, mod)
+for __mod_name, __mod in __plugins.items():
+    setattr(sys.modules[__name__], __mod_name, __mod)
+# ------------------------------------------------------------------------
+    
+del os, glob, __icon, icon_dir, pkg_resources, sys
 


### PR DESCRIPTION
Setuptools provides special support for plugins (entry_points).
Plugins can register themselves for discovery.

Add mechanism to discover and load all of the registered entry
points for the taurus.qt.qtgui module by using
"pkg_resources.iter_entry_points" method, and expose them as part of
the module.