### PR TITLE
Revert "Fix circular references"

### DIFF
--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -48,7 +48,7 @@ from taurus.core.taurusbasetypes import (TaurusEventType,
                                          SubscriptionState, TaurusAttrValue,
                                          DataFormat, DataType)
 from taurus.core.taurusoperation import WriteAttrOperation
-from taurus.core.util.event import (EventListener, BoundMethodWeakref)
+from taurus.core.util.event import EventListener
 from taurus.core.util.log import (debug, taurus4_deprecation,
                                   deprecation_decorator)
 
@@ -293,8 +293,6 @@ class TangoAttribute(TaurusAttribute):
         if self.factory().is_tango_subscribe_enabled():
             self._subscribeConfEvents()
 
-    def __del__(self):
-        self.cleanUp()
 
     def cleanUp(self):
         self.trace("[TangoAttribute] cleanUp")
@@ -662,10 +660,9 @@ class TangoAttribute(TaurusAttribute):
                 
         attr_name = self.getSimpleName()
 
-        # connects to self.push_event callback
         self.__chg_evt_id = self.__dev_hw_obj.subscribe_event(
                 attr_name, PyTango.EventType.CHANGE_EVENT,
-                BoundMethodWeakref(self.push_event), [], stateless)
+                self, [], stateless) # connects to self.push_event callback
         
         return self.__chg_evt_id
                 
@@ -712,11 +709,10 @@ class TangoAttribute(TaurusAttribute):
 
         attr_name = self.getSimpleName()
         try:
-            # connects to self.push_event callback
             self.__cfg_evt_id = self.__dev_hw_obj.subscribe_event(
                 attr_name,
                 PyTango.EventType.ATTR_CONF_EVENT,
-                BoundMethodWeakref(self.push_event), [], True)
+                self, [], True)  # connects to self.push_event callback
         except PyTango.DevFailed as e:
             self.debug("Error trying to subscribe to CONFIGURATION events.")
             self.traceback()

--- a/lib/taurus/core/taurusmodel.py
+++ b/lib/taurus/core/taurusmodel.py
@@ -225,8 +225,7 @@ class TaurusModel(Logger):
         if self._listeners is None or listener is None:
             return False
 
-        weak_listener = self._getCallableRef(
-            listener, BoundMethodWeakref(self._listenerDied))
+        weak_listener = self._getCallableRef(listener, self._listenerDied)
         if weak_listener in self._listeners:
             return False
         self._listeners.append(weak_listener)

--- a/lib/taurus/core/tauruspollingtimer.py
+++ b/lib/taurus/core/tauruspollingtimer.py
@@ -30,11 +30,10 @@ __all__ = ["TaurusPollingTimer"]
 __docformat__ = "restructuredtext"
 
 import time
-import weakref
 import threading
 
 from .util.log import Logger, DebugIt
-from .util.containers import CaselessWeakValueDict
+from .util.containers import CaselessDict
 from .util.timer import Timer
 
 
@@ -98,9 +97,9 @@ class TaurusPollingTimer(Logger):
         attr_dict = self.dev_dict.get(dev)
         if attr_dict is None:
             if attribute.factory().caseSensitive:
-                self.dev_dict[dev] = attr_dict = weakref.WeakValueDictionary()
+                self.dev_dict[dev] = attr_dict = {}
             else:
-                self.dev_dict[dev] = attr_dict = CaselessWeakValueDict()
+                self.dev_dict[dev] = attr_dict = CaselessDict()
         if attr_name not in attr_dict:
             attr_dict[attr_name] = attribute
             self.attr_nb += 1

--- a/lib/taurus/core/util/event.py
+++ b/lib/taurus/core/util/event.py
@@ -48,8 +48,8 @@ class BoundMethodWeakref(object):
 
     def __init__(self, bound_method, del_cb=None):
         cb = (del_cb and self._deleted)
-        self.func_ref = weakref.ref(bound_method.__func__, cb)
-        self.obj_ref = weakref.ref(bound_method.__self__, cb)
+        self.func_ref = weakref.ref(bound_method.im_func, cb)
+        self.obj_ref = weakref.ref(bound_method.im_self, cb)
         if cb:
             self.del_cb = CallableRef(del_cb)
         self.already_deleted = 0
@@ -61,12 +61,12 @@ class BoundMethodWeakref(object):
                 del_cb(self)
                 self.already_deleted = 1
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self):
         obj = self.obj_ref()
         if obj is not None:
             func = self.func_ref()
             if func is not None:
-                return func(obj, *args, **kwargs)
+                return func.__get__(obj)
 
     def __hash__(self):
         return id(self)


### PR DESCRIPTION
Reverts taurus-org/taurus#682 cause it breaks the expected behavior of `BoundMethodWeakref` class.
Sardana uses the `BoundMethodWeakref.__call__` in order to retrieve the reference to the method in: https://github.com/sardana-org/sardana/blob/82e1402b648dde4eafc44a8412778bf7dd8b8359/src/sardana/sardanaevent.py#L123
for further method invocation with the real arguments.