### PR TITLE
Fixing TaurusLed handling of spectrum attributes.

### DIFF
--- a/lib/taurus/qt/qtgui/display/taurusled.py
+++ b/lib/taurus/qt/qtgui/display/taurusled.py
@@ -77,26 +77,19 @@ class _TaurusLedController(object):
         value = None
         if fgRole == 'rvalue':
             value = obj.rvalue
-            if type(value) == int:
-                value = bool(value)
         elif fgRole == 'wvalue':
             value = obj.wvalue
-            if type(value) == int:
-                value = bool(value)
         elif fgRole == 'quality':
             return obj.quality
 
         # handle 1D and 2D values
-        if obj.data_format == DataFormat._0D:
-            return value
+        if obj.data_format is not DataFormat._0D:
+            idx = widget.getModelIndexValue()
+            if idx:
+                for i in idx:
+                    value = value[i]
 
-        idx = widget.getModelIndexValue()
-        if idx is None or len(idx) == 0:
-            return value
-
-        for i in idx:
-            value = value[i]
-        return value
+        return bool(value)
 
     def usePreferedColor(self, widget):
         return True

--- a/lib/taurus/qt/qtgui/display/taurusled.py
+++ b/lib/taurus/qt/qtgui/display/taurusled.py
@@ -76,9 +76,13 @@ class _TaurusLedController(object):
         fgRole = widget.fgRole
         value = None
         if fgRole == 'rvalue':
-            value = bool(obj.rvalue)
+            value = obj.rvalue
+            if type(value) == int:
+                value = bool(value)
         elif fgRole == 'wvalue':
-            value = bool(obj.wvalue)
+            value = obj.wvalue
+            if type(value) == int:
+                value = bool(value)
         elif fgRole == 'quality':
             return obj.quality
 


### PR DESCRIPTION
This proposal fixes TaurusLed handling of spectrum boolean attributes, which was broken by the following commit (from November 2017):
[eb17e2ed33195bf08aa57673fe0f40016ffdeb87](https://github.com/taurus-org/taurus/commit/eb17e2ed33195bf08aa57673fe0f40016ffdeb87)

See also comment under the above commit for detailed explanation of the problem.