### PR TITLE
Allow to remove log handlers from Logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ develop branch) won't be reflected in this file.
 - (experimental) Delayed event subscription API (#605, #593)
 - (experimental) Entry point for taurus.qt.qtgui extensions (#684)
 - Support DevVoid in Tango-to-numpy type translation dicts (#666)
+- `removeLogHandler` method to `Logger` class (#691)
 
 ### Changed
 - Treat unit="No unit" as unitless in Tango attributes (#662)

--- a/lib/taurus/core/util/log.py
+++ b/lib/taurus/core/util/log.py
@@ -700,6 +700,14 @@ class Logger(Object):
         self.log_obj.addHandler(handler)
         self.log_handlers.append(handler)
 
+    def removeLogHandler(self, handler):
+        """Removes the given handler from this object's logger
+
+           :param handler: (logging.Handler) the handler to be removed
+        """
+        self.log_obj.removeHandler(handler)
+        self.log_handlers.remove(handler)
+
     def copyLogHandlers(self, other):
         """Copies the log handlers of other object to this object
 


### PR DESCRIPTION
This is the same PR as #690 but this time to the release-Jan18 branch.

Add method removeLogHandler to provide API for removing log handlers.

If accepted I will open a new PR to the support-3.x branch.