### PR TITLE
Allow case sensitivity for epics object

### DIFF
--- a/lib/taurus/core/epics/epicsfactory.py
+++ b/lib/taurus/core/epics/epicsfactory.py
@@ -57,7 +57,7 @@ class EpicsFactory(Singleton, TaurusFactory, Logger):
     schemes = ("ca", "epics",)
     DEFAULT_DEVICE = 'ca:'
     DEFAULT_AUTHORITY = 'ca://'
-    caseSensitive = False
+    caseSensitive = True
     elementTypesMap = {TaurusElementType.Authority: EpicsAuthority,
                        TaurusElementType.Device: EpicsDevice,
                        TaurusElementType.Attribute: EpicsAttribute


### PR DESCRIPTION
Currently, case sensitivity for epics object is set False and "_lowerIfInsensitive" function on taurusplot.py modifies PV name to lower case.

```
if scheme == "scan" or not taurus.Factory(scheme).caseSensitive:
    models.append(str(m).lower())
 ```

As a result, model name does not match with those PVs whose name contain upper cases, and TaurusPlot and TaurusTrend fail retrieving their data.

This proposal sets caseSensitive true  and enables epics PVs containing upper case in their name to be displayed on TaurusPlot and TaurusTrend.