### PR TITLE
Convert model name list to CaselessList

### DIFF
--- a/lib/taurus/qt/qtgui/plot/taurustrend.py
+++ b/lib/taurus/qt/qtgui/plot/taurustrend.py
@@ -1157,6 +1157,8 @@ class TaurusTrend(TaurusPlot):
         try:
             # For it to work properly, 'names' must be a CaselessList, just as
             # self.trendSets is a CaselessDict
+            if not isinstance(names, CaselessList):
+                names = CaselessList(names)
             del_sets = [name for name in self.trendSets.keys()
                         if name not in names]
 


### PR DESCRIPTION
This commit will convert model name list to CaselessList in case it is not one.

Current code does not cause any problem if you launch TaurusTrend only once. However, if you create TaurusGUI and create a TaurusTrend panel, it fails retrieving models whose name contains upper case from second launch because of the del_sets.

This proposal will prevent model list that contains upper cases in their name but shouldn't be removed from being removed by del_sets.