### PR TITLE
Import PyTango for Tango centric functions

### DIFF
--- a/lib/taurus/qt/qtgui/panel/taurusmessagepanel.py
+++ b/lib/taurus/qt/qtgui/panel/taurusmessagepanel.py
@@ -553,6 +553,8 @@ def py_exc():
 
 def tg_exc():
     """Shows a tango exception in a TaurusMessagePanel"""
+    # TODO: This function is Tango centric
+    import PyTango
     try:
         PyTango.Except.throw_exception(
             'TangoException', 'A simple tango exception', 'right here')
@@ -563,6 +565,8 @@ def tg_exc():
 
 def tg_serv_exc():
     """Shows a tango exception from a server in a TaurusMessagePanel"""
+    # TODO: This function is Tango centric
+    import PyTango
     import taurus
     dev = taurus.Device("sys/tg_test/1")
     try:
@@ -577,6 +581,8 @@ def tg_serv_exc():
 
 def py_tg_serv_exc():
     """Shows a tango exception from a python server in a TaurusMessagePanel"""
+    # TODO: This function is Tango centric
+    import PyTango
     try:
         PyTango.Except.throw_exception(
             'TangoException', 'A simple tango exception', 'right here')


### PR DESCRIPTION
Import PyTango for Tango centric functions.
Add TODO, in order to remember that these functions are
Tango centric as of today.

This PR solves bugs found in taurusdemo message panel.
