### PR TITLE
Protect against non-existing DB

### DIFF
--- a/lib/taurus/core/tango/tangofactory.py
+++ b/lib/taurus/core/tango/tangofactory.py
@@ -294,7 +294,8 @@ class TangoFactory(Singleton, TaurusFactory, Logger):
                 self.debug("Could not create Authority %s", groups['authority'],
                            exc_info=1)
 
-            self.tango_db[name] = ret
+            if ret is not None:
+                self.tango_db[name] = ret
         return ret
 
     def getDevice(self, dev_name, create_if_needed=True, **kw):


### PR DESCRIPTION
If the tango db does not exist Taurus raises an TypeError.
Protect the code in TangoFactory.

Fix #716