### PR TITLE
Remove build badges from doc page

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -44,35 +44,6 @@ interfaces.
 :Release: |release|
 
 
-.. image:: https://img.shields.io/pypi/pyversions/taurus.svg
-    :target: https://pypi.python.org/pypi/taurus
-    :alt: Python Versions
-    
-.. image:: https://img.shields.io/pypi/l/taurus.svg
-    :target: https://pypi.python.org/pypi/taurus
-    :alt: License
-    
-.. image:: https://img.shields.io/pypi/v/taurus.svg
-    :target: https://pypi.python.org/pypi/taurus
-    :alt: Latest Version
-
-.. image:: https://badge.fury.io/gh/taurus-org%2Ftaurus.svg
-    :target: https://github.com/taurus-org/taurus
-    :alt: GitHub
-    
-.. image:: https://readthedocs.org/projects/taurus/badge/
-    :target: http://taurus-scada.org/docs.html
-    :alt: Documentation
-    
-.. image:: https://travis-ci.org/taurus-org/taurus.svg?branch=develop
-    :target: https://travis-ci.org/taurus-org/taurus
-    :alt: Travis
-
-.. image:: https://ci.appveyor.com/api/projects/status/rxeo3hsycilnyn9k/branch/develop?svg=true
-    :target: https://ci.appveyor.com/project/taurusorg/taurus/branch/develop
-    :alt: Appveyor
-
-
 .. _Tango: http://www.tango-controls.org/
 .. _EPICS: http://www.aps.anl.gov/epics/
 .. _PyQt: http://www.riverbankcomputing.co.uk/software/pyqt/


### PR DESCRIPTION
The main doc page contains badge images showing the license, the
CI build status, etc. Lintian complains about them when packaging
the docs due to privacy concerns:
https://lintian.debian.org/tags/privacy-breach-generic.html
Remove the badges from the html docs.

Note: the same badges are still present in the README file, which is 
rendered in the project page. But this is ok since it is not packaged as html