### PR TITLE
Try to populate TaurusCommandForm even if device not ready

### DIFF
--- a/lib/taurus/qt/qtgui/panel/taurusform.py
+++ b/lib/taurus/qt/qtgui/panel/taurusform.py
@@ -636,13 +636,19 @@ class TaurusCommandsForm(TaurusWidget):
         Inserts command buttons and parameter widgets in the layout, according to
         the commands from the model
         '''
-        #self.debug('In TaurusCommandsForm._updateCommandWidgets())')
+
         dev = self.getModelObj()
-        if dev is None or dev.state != TaurusDevState.Ready:
-            self.debug('Cannot connect to device')
+        if dev is None:
             self._clearFrame()
             return
-        commands = sorted(dev.command_list_query(), key=self._sortKey)
+
+        try:
+            commands = sorted(dev.command_list_query(), key=self._sortKey)
+        except Exception as e:
+            self.warning('Problem querying commands from %s. Reason: %s',
+                         dev, e)
+            self._clearFrame()
+            return
 
         for f in self.getViewFilters():
             commands = filter(f, commands)


### PR DESCRIPTION
This is a fix for #727. 

TaurusCommandForm conservatively clears its contents if the device is not in "Ready"
state. Relax this limitation and try to populate it anyway, falling back to clear in case of 
problems querying the commands.

I've tested this solution  with the TangoTest device but I am calling for help for other people 
testing it with other devices (not just TangoTest) to check if the proposed solution is safe enough.

@taurus-org/integrators (and anyone else, of course), can you have a look at it?

Fixes #727