### PR TITLE
Bug fix in taurusbase.py concerning model indices (extension of pull request #681)

### DIFF
--- a/lib/taurus/qt/qtgui/base/taurusbase.py
+++ b/lib/taurus/qt/qtgui/base/taurusbase.py
@@ -830,9 +830,11 @@ class TaurusBaseComponent(TaurusListener, BaseConfigurableClass):
 
         idx = self.getModelIndexValue()
         if v is not None and idx:
-            for i in idx:
-                v = v[i]
-
+            try:
+                v = v[idx[-1]]
+            except Exception as e:
+                self.debug('Problem with applying model index: %r', e)
+                return self.getNoneValue()
         return self.displayValue(v)
 
     def setNoneValue(self, v):


### PR DESCRIPTION
Added try-except block to prevent crashes if spectrum model returned is [] (happens if ATTR_INVALID in tango).