### PR TITLE
Reset _permanentText in the setModel

### DIFF
--- a/lib/taurus/qt/qtgui/display/tauruslabel.py
+++ b/lib/taurus/qt/qtgui/display/tauruslabel.py
@@ -318,6 +318,7 @@ class TaurusLabel(Qt.QLabel, TaurusBaseWidget):
     def setModel(self, m):
         # force to build another controller
         self._controller = None
+        self._permanentText = None
         TaurusBaseWidget.setModel(self, m)
         if self.modelFragmentName:
             self.setFgRole(self.modelFragmentName)


### PR DESCRIPTION
TaurusLabel does not show the model value if previously
a permanent text has been set.

Fix #735 resetting the permanent text attribute in setModel