### PR TITLE
Delegate the fireEvents to TaurusManager

### DIFF
--- a/lib/taurus/core/evaluation/evalattribute.py
+++ b/lib/taurus/core/evaluation/evalattribute.py
@@ -484,7 +484,7 @@ class EvaluationAttribute(TaurusAttribute):
         if len(self._listeners) > 1 and \
            (initial_subscription_state == SubscriptionState.Subscribed or
                 self.isPollingActive()):
-            Manager().addJob(self.__fireRegisterEvent, None, (listener,))
+            Manager().enqueueJob(self.__fireRegisterEvent, None, (listener,))
         return ret
 
     def removeListener(self, listener):

--- a/lib/taurus/core/evaluation/evalattribute.py
+++ b/lib/taurus/core/evaluation/evalattribute.py
@@ -484,7 +484,8 @@ class EvaluationAttribute(TaurusAttribute):
         if len(self._listeners) > 1 and \
            (initial_subscription_state == SubscriptionState.Subscribed or
                 self.isPollingActive()):
-            Manager().enqueueJob(self.__fireRegisterEvent, None, ((listener,),))
+            Manager().enqueueJob(self.__fireRegisterEvent,
+                                 job_args=((listener,),))
         return ret
 
     def removeListener(self, listener):

--- a/lib/taurus/core/evaluation/evalattribute.py
+++ b/lib/taurus/core/evaluation/evalattribute.py
@@ -484,7 +484,7 @@ class EvaluationAttribute(TaurusAttribute):
         if len(self._listeners) > 1 and \
            (initial_subscription_state == SubscriptionState.Subscribed or
                 self.isPollingActive()):
-            Manager().enqueueJob(self.__fireRegisterEvent, None, ((listener,)))
+            Manager().enqueueJob(self.__fireRegisterEvent, None, ((listener,),))
         return ret
 
     def removeListener(self, listener):

--- a/lib/taurus/core/evaluation/evalattribute.py
+++ b/lib/taurus/core/evaluation/evalattribute.py
@@ -484,7 +484,7 @@ class EvaluationAttribute(TaurusAttribute):
         if len(self._listeners) > 1 and \
            (initial_subscription_state == SubscriptionState.Subscribed or
                 self.isPollingActive()):
-            Manager().enqueueJob(self.__fireRegisterEvent, None, (listener,))
+            Manager().enqueueJob(self.__fireRegisterEvent, None, ((listener,)))
         return ret
 
     def removeListener(self, listener):

--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -591,7 +591,7 @@ class TangoAttribute(TaurusAttribute):
                 self.__fireRegisterEvent((listener,))
             else:
                 Manager().enqueueJob(self.__fireRegisterEvent, None,
-                                     jobargs=((listener,)),
+                                     jobargs=((listener,),),
                                      serialization_mode=sm)
         return ret
 

--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -584,9 +584,9 @@ class TangoAttribute(TaurusAttribute):
                 (initial_subscription_state == SubscriptionState.Subscribed or
                      self.isPollingActive()):
             sm = self._serialization_mode
-            if sm == TaurusSerializationMode.Serial:
-                self.deprecated('TaurusSerializationMode.Serial mode',
-                                alt="TaurusSerializationMode.SerialSync",
+            if sm == TaurusSerializationMode.TangoSerial:
+                self.deprecated(dep='TaurusSerializationMode.TangoSerial mode',
+                                alt="TaurusSerializationMode.Serial",
                                 rel='4.3.2')
                 self.__fireRegisterEvent((listener,))
             else:
@@ -790,9 +790,9 @@ class TangoAttribute(TaurusAttribute):
             manager = Manager()
             listeners = tuple(self._listeners)
             sm = self._serialization_mode
-            if sm == TaurusSerializationMode.Serial:
-                self.deprecated('TaurusSerializationMode.Serial mode',
-                                alt="TaurusSerializationMode.SerialSync",
+            if sm == TaurusSerializationMode.TangoSerial:
+                self.deprecated(dep='TaurusSerializationMode.TangoSerial mode',
+                                alt="TaurusSerializationMode.Serial",
                                 rel='4.3.2')
                 self.fireEvent(etype, evalue, listeners=listeners)
             else:

--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -581,8 +581,9 @@ class TangoAttribute(TaurusAttribute):
 
         # if initial_subscription_state == SubscriptionState.Subscribed:
         if (len(listeners) > 1
-            and (initial_subscription_state == SubscriptionState.Subscribed or
-                     self.isPollingActive())):
+            and (initial_subscription_state == SubscriptionState.Subscribed 
+                 or self.isPollingActive())
+           ):
             sm = self._serialization_mode
             if sm == TaurusSerializationMode.TangoSerial:
                 self.deprecated(dep='TaurusSerializationMode.TangoSerial mode',

--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -580,9 +580,9 @@ class TangoAttribute(TaurusAttribute):
             self._subscribeEvents()
 
         # if initial_subscription_state == SubscriptionState.Subscribed:
-        if len(listeners) > 1 and\
-                (initial_subscription_state == SubscriptionState.Subscribed or
-                     self.isPollingActive()):
+        if (len(listeners) > 1
+            and (initial_subscription_state == SubscriptionState.Subscribed or
+                     self.isPollingActive())):
             sm = self._serialization_mode
             if sm == TaurusSerializationMode.TangoSerial:
                 self.deprecated(dep='TaurusSerializationMode.TangoSerial mode',

--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -586,12 +586,12 @@ class TangoAttribute(TaurusAttribute):
             sm = self._serialization_mode
             if sm == TaurusSerializationMode.TangoSerial:
                 self.deprecated(dep='TaurusSerializationMode.TangoSerial mode',
-                                alt="TaurusSerializationMode.Serial",
+                                alt='TaurusSerializationMode.Serial',
                                 rel='4.3.2')
                 self.__fireRegisterEvent((listener,))
             else:
-                Manager().addJob(self.__fireRegisterEvent, None, (listener,),
-                                 taurus_serialization_mode=sm)
+                Manager().enqueueJob(self.__fireRegisterEvent, None,
+                                     (listener,), serialization_mode=sm)
         return ret
 
     def removeListener(self, listener):
@@ -796,9 +796,8 @@ class TangoAttribute(TaurusAttribute):
                                 rel='4.3.2')
                 self.fireEvent(etype, evalue, listeners=listeners)
             else:
-                manager.addJob(self.fireEvent, None, etype, evalue,
-                               listeners=listeners,
-                               taurus_serialization_mode=sm)
+                manager.enqueueJob(self.fireEvent, None, etype, evalue,
+                                   serialization_mode=sm)
 
     def _pushAttrEvent(self, event):
         """Handler of (non-configuration) events from the PyTango layer.

--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -580,12 +580,12 @@ class TangoAttribute(TaurusAttribute):
             self._subscribeEvents()
 
         # if initial_subscription_state == SubscriptionState.Subscribed:
-        if len(listeners) > 1 and (initial_subscription_state == SubscriptionState.Subscribed or self.isPollingActive()):
-            sm = self.getSerializationMode()
-            if sm == TaurusSerializationMode.Concurrent:
-                Manager().addJob(self.__fireRegisterEvent, None, (listener,))
-            else:
-                self.__fireRegisterEvent((listener,))
+        if len(listeners) > 1 and\
+                (initial_subscription_state == SubscriptionState.Subscribed or
+                     self.isPollingActive()):
+
+            Manager().addJob(self.__fireRegisterEvent, None, (listener,),
+                             taurus_serialization_mode=self._serialization_mode)
         return ret
 
     def removeListener(self, listener):
@@ -782,13 +782,10 @@ class TangoAttribute(TaurusAttribute):
             if etype is None:
                 return
             manager = Manager()
-            sm = self.getSerializationMode()
             listeners = tuple(self._listeners)
-            if sm == TaurusSerializationMode.Concurrent:
-                manager.addJob(self.fireEvent, None, etype, evalue,
-                               listeners=listeners)
-            else:
-                self.fireEvent(etype, evalue, listeners=listeners)
+            manager.addJob(self.fireEvent, None, etype, evalue,
+                           listeners=listeners,
+                           taurus_serialization_mode=self._serialization_mode)
 
     def _pushAttrEvent(self, event):
         """Handler of (non-configuration) events from the PyTango layer.

--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -590,8 +590,8 @@ class TangoAttribute(TaurusAttribute):
                                 rel='4.3.2')
                 self.__fireRegisterEvent((listener,))
             else:
-                Manager().enqueueJob(self.__fireRegisterEvent, None,
-                                     jobargs=((listener,),),
+                Manager().enqueueJob(self.__fireRegisterEvent,
+                                     job_args=((listener,),),
                                      serialization_mode=sm)
         return ret
 
@@ -797,9 +797,8 @@ class TangoAttribute(TaurusAttribute):
                                 rel='4.3.2')
                 self.fireEvent(etype, evalue, listeners=listeners)
             else:
-                manager.enqueueJob(self.fireEvent, None,
-                                   jobargs=(etype, evalue),
-                                   jobkwargs={'listeners': listeners},
+                manager.enqueueJob(self.fireEvent, job_args=(etype, evalue),
+                                   job_kwargs={'listeners': listeners},
                                    serialization_mode=sm)
 
     def _pushAttrEvent(self, event):

--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -591,7 +591,8 @@ class TangoAttribute(TaurusAttribute):
                 self.__fireRegisterEvent((listener,))
             else:
                 Manager().enqueueJob(self.__fireRegisterEvent, None,
-                                     (listener,), serialization_mode=sm)
+                                     jobargs=((listener,)),
+                                     serialization_mode=sm)
         return ret
 
     def removeListener(self, listener):
@@ -796,7 +797,9 @@ class TangoAttribute(TaurusAttribute):
                                 rel='4.3.2')
                 self.fireEvent(etype, evalue, listeners=listeners)
             else:
-                manager.enqueueJob(self.fireEvent, None, etype, evalue,
+                manager.enqueueJob(self.fireEvent, None,
+                                   jobargs=(etype, evalue),
+                                   jobkwargs={'listeners': listeners},
                                    serialization_mode=sm)
 
     def _pushAttrEvent(self, event):

--- a/lib/taurus/core/tango/tangofactory.py
+++ b/lib/taurus/core/tango/tangofactory.py
@@ -39,6 +39,7 @@ except ImportError:
     debug(msg)
     raise
 
+from taurus import tauruscustomsettings
 from taurus.core.taurusbasetypes import (TaurusElementType,
                                          TaurusSerializationMode)
 from taurus.core.taurusfactory import TaurusFactory
@@ -106,7 +107,9 @@ class TangoFactory(Singleton, TaurusFactory, Logger):
         self._polling_enabled = True
         self.reInit()
         self.scheme = 'tango'
-        self._serialization_mode = TaurusSerializationMode.SerialSync
+        self._serialization_mode = TaurusSerializationMode.get(
+            getattr(tauruscustomsettings, 'TANGO_SERIALIZATION_MODE',
+                    'Serial'))
 
     def reInit(self):
         """Reinitialize the singleton"""

--- a/lib/taurus/core/tango/tangofactory.py
+++ b/lib/taurus/core/tango/tangofactory.py
@@ -106,7 +106,7 @@ class TangoFactory(Singleton, TaurusFactory, Logger):
         self._polling_enabled = True
         self.reInit()
         self.scheme = 'tango'
-        self._serialization_mode = TaurusSerializationMode.Serial
+        self._serialization_mode = TaurusSerializationMode.SerialSync
 
     def reInit(self):
         """Reinitialize the singleton"""

--- a/lib/taurus/core/taurusbasetypes.py
+++ b/lib/taurus/core/taurusbasetypes.py
@@ -73,7 +73,7 @@ TaurusSerializationMode = Enumeration(
     'TaurusSerializationMode', (
         'Serial',
         'Concurrent',
-        'SerialSync',
+        'TangoSerial',
     ))
 
 TaurusEventType = Enumeration(

--- a/lib/taurus/core/taurusbasetypes.py
+++ b/lib/taurus/core/taurusbasetypes.py
@@ -72,7 +72,8 @@ OperationMode = Enumeration(
 TaurusSerializationMode = Enumeration(
     'TaurusSerializationMode', (
         'Serial',
-        'Concurrent'
+        'Concurrent',
+        'SerialSync',
     ))
 
 TaurusEventType = Enumeration(

--- a/lib/taurus/core/taurusmanager.py
+++ b/lib/taurus/core/taurusmanager.py
@@ -139,8 +139,8 @@ class TaurusManager(Singleton, Logger):
                 return
             self._thread_pool.add(job, callback, *args, **kw)
         else:
-            if not hasattr(self, "_sthread_pool") or \
-                            self._sthread_pool is None:
+            if (not hasattr(self, "_sthread_pool")
+                or self._sthread_pool is None):
                 self.info("Job cannot be processed.")
                 self.debug(
                     "The requested job cannot be processed. " +

--- a/lib/taurus/core/taurusmanager.py
+++ b/lib/taurus/core/taurusmanager.py
@@ -123,20 +123,20 @@ class TaurusManager(Singleton, Logger):
         self.deprecated(dep='addJob', alt='enqueueJob', rel='4.3.2')
         self.enqueueJob(job, callback, args, kw)
 
-    def enqueueJob(self, job, callback=None, jobargs=(), jobkwargs=None,
+    def enqueueJob(self, job, callback=None, job_args=(), job_kwargs=None,
                    serialization_mode=None):
         """ Enqueue a job (callable) to the queue. The new job will be
         processed by a separate thread
         :param job: (callable) a callable object
         :param callback: (callable) called after the job has been processed
-        :param jobargs: (sequence)  tuple of arguments passed to the job
-        :param jobkwargs: (dict) keyword arguments passed to the job
+        :param job_args: (sequence)  tuple of arguments passed to the job
+        :param job_kwargs: (dict) keyword arguments passed to the job
         :param serialization_mode:
         (taurus.core.taurusbasetypes.TaurusSerializationMode) serialization
         mode
         """
-        if jobkwargs is None:
-            jobkwargs = {}
+        if job_kwargs is None:
+            job_kwargs = {}
 
         if serialization_mode is None:
             serialization_mode = self._serialization_mode
@@ -148,7 +148,7 @@ class TaurusManager(Singleton, Logger):
                     "The requested job cannot be processed. "
                     + "Make sure this manager is initialized")
                 return
-            self._thread_pool.add(job, callback, *jobargs, **jobkwargs)
+            self._thread_pool.add(job, callback, *job_args, **job_kwargs)
         elif serialization_mode == TaurusSerializationMode.Serial:
             if (not hasattr(self, "_sthread_pool")
                     or self._sthread_pool is None):
@@ -158,7 +158,7 @@ class TaurusManager(Singleton, Logger):
                     + "Make sure this manager is initialized")
                 return
 
-            self._sthread_pool.add(job, callback, *jobargs, **jobkwargs)
+            self._sthread_pool.add(job, callback, *job_args, **job_kwargs)
         else:
             raise TaurusException("{} serialization mode not supported".format(
                 serialization_mode))

--- a/lib/taurus/core/taurusmanager.py
+++ b/lib/taurus/core/taurusmanager.py
@@ -123,7 +123,7 @@ class TaurusManager(Singleton, Logger):
         self.deprecated(dep='addJob', alt='enqueueJob', rel='4.3.2')
         self.enqueueJob(job, callback, args, kw)
 
-    def enqueueJob(self, job, callback=None, jobargs=None, jobkwargs=None,
+    def enqueueJob(self, job, callback=None, jobargs=(), jobkwargs=None,
                    serialization_mode=None):
         """ Enqueue a job (callable) to the queue. The new job will be
         processed by a separate thread
@@ -135,9 +135,6 @@ class TaurusManager(Singleton, Logger):
         (taurus.core.taurusbasetypes.TaurusSerializationMode) serialization
         mode
         """
-        if jobargs is None:
-            jobargs = ()
-
         if jobkwargs is None:
             jobkwargs = {}
 

--- a/lib/taurus/core/taurusmanager.py
+++ b/lib/taurus/core/taurusmanager.py
@@ -121,7 +121,7 @@ class TaurusManager(Singleton, Logger):
         """ Deprecated. Wrapper of enqueueJob. See enqueueJob documentation.
         """
         self.deprecated(dep='addJob', alt='enqueueJob', rel='4.3.2')
-        self.enqueueJob(job, callback=callback, jobargs=args, jobkwargs=kw)
+        self.enqueueJob(job, callback, args, kw)
 
     def enqueueJob(self, job, callback=None, jobargs=None, jobkwargs=None,
                    serialization_mode=None):

--- a/lib/taurus/core/taurusmanager.py
+++ b/lib/taurus/core/taurusmanager.py
@@ -117,17 +117,24 @@ class TaurusManager(Singleton, Logger):
         self._state = ManagerState.CLEANED
 
     def addJob(self, job, callback=None, *args, **kw):
-        """Add a new job (callable) to the queue. The new job will be processed
-        by a separate thread
+        """ Deprecated. Wrapper of enqueueJob. See enqueueJob documentation.
+        """
+        self.deprecated(dep='addJob', alt='enqueueJob', rel='4.3.2')
+        self.enqueueJob(job, callback=callback, jobargs=args, jobkwargs=kw)
 
+    def enqueueJob(self, job, callback=None, jobargs=None, jobkwargs=None,
+                   serialization_mode=None):
+        """ Enqueue a job (callable) to the queue. The new job will be
+        processed by a separate thread
         :param job: (callable) a callable object
         :param callback: (callable) called after the job has been processed
-        :param args: (list) list of arguments passed to the job
-        :param kw: (dict) keyword arguments passed to the job
+        :param jobargs: (list) list of arguments passed to the job
+        :param jobkwargs: (dict) keyword arguments passed to the job
+        :param serialization_mode:
+        (taurus.core.taurusbasetypes.TaurusSerializationMode) serialization
+        mode
         """
-        if kw.has_key("taurus_serialization_mode"):
-            serialization_mode = kw.pop("taurus_serialization_mode")
-        else:
+        if serialization_mode is None:
             serialization_mode = self._serialization_mode
 
         if serialization_mode == TaurusSerializationMode.Concurrent:
@@ -137,7 +144,7 @@ class TaurusManager(Singleton, Logger):
                     "The requested job cannot be processed. " +
                     "Make sure this manager is initialized")
                 return
-            self._thread_pool.add(job, callback, *args, **kw)
+            self._thread_pool.add(job, callback, *jobargs, **jobkwargs)
         else:
             if (not hasattr(self, "_sthread_pool")
                 or self._sthread_pool is None):
@@ -146,7 +153,7 @@ class TaurusManager(Singleton, Logger):
                     "The requested job cannot be processed. " +
                     "Make sure this manager is initialized")
                 return
-            self._sthread_pool.add(job, callback, *args, **kw)
+            self._sthread_pool.add(job, callback, *jobargs, **jobkwargs)
 
     def setSerializationMode(self, mode):
         """Sets the serialization mode for the system.

--- a/lib/taurus/core/taurusmanager.py
+++ b/lib/taurus/core/taurusmanager.py
@@ -91,7 +91,7 @@ class TaurusManager(Singleton, Logger):
         self._sthread_pool = ThreadPool(name="TaurusTSP",
                                        parent=self,
                                        Psize=1,
-                                       Qsize=float("inf")) #TODO check value
+                                       Qsize=0)
         self._plugins = None
 
         self._initial_default_scheme = self.default_scheme

--- a/lib/taurus/core/taurusmanager.py
+++ b/lib/taurus/core/taurusmanager.py
@@ -151,7 +151,7 @@ class TaurusManager(Singleton, Logger):
                     "Make sure this manager is initialized")
                 return
             self._thread_pool.add(job, callback, *jobargs, **jobkwargs)
-        else:
+        elif serialization_mode == TaurusSerializationMode.Serial:
             if (not hasattr(self, "_sthread_pool")
                 or self._sthread_pool is None):
                 self.info("Job cannot be processed.")
@@ -160,6 +160,9 @@ class TaurusManager(Singleton, Logger):
                     "Make sure this manager is initialized")
                 return
             self._sthread_pool.add(job, callback, *jobargs, **jobkwargs)
+        else:
+            raise TaurusException("{} serialization mode not supported".format(
+                serialization_mode))
 
     def setSerializationMode(self, mode):
         """Sets the serialization mode for the system.

--- a/lib/taurus/core/taurusmanager.py
+++ b/lib/taurus/core/taurusmanager.py
@@ -144,7 +144,7 @@ class TaurusManager(Singleton, Logger):
                     "The requested job cannot be processed. " +
                     "Make sure this manager is initialized")
                 return
-            self._thread_pool.add(job, callback, jobargs, jobkwargs)
+            self._thread_pool.add(job, callback, *jobargs, **jobkwargs)
         else:
             if (not hasattr(self, "_sthread_pool")
                 or self._sthread_pool is None):
@@ -153,7 +153,7 @@ class TaurusManager(Singleton, Logger):
                     "The requested job cannot be processed. " +
                     "Make sure this manager is initialized")
                 return
-            self._sthread_pool.add(job, callback, jobargs, jobkwargs)
+            self._sthread_pool.add(job, callback, *jobargs, **jobkwargs)
 
     def setSerializationMode(self, mode):
         """Sets the serialization mode for the system.

--- a/lib/taurus/core/taurusmanager.py
+++ b/lib/taurus/core/taurusmanager.py
@@ -36,7 +36,8 @@ from .util.singleton import Singleton
 from .util.log import Logger, taurus4_deprecation
 from .util.threadpool import ThreadPool
 
-from .taurusbasetypes import OperationMode, ManagerState, TaurusSerializationMode
+from .taurusbasetypes import (OperationMode, ManagerState,
+                              TaurusSerializationMode)
 from .taurusauthority import TaurusAuthority
 from .taurusdevice import TaurusDevice
 from .taurusattribute import TaurusAttribute
@@ -147,18 +148,19 @@ class TaurusManager(Singleton, Logger):
             if not hasattr(self, "_thread_pool") or self._thread_pool is None:
                 self.info("Job cannot be processed.")
                 self.debug(
-                    "The requested job cannot be processed. " +
-                    "Make sure this manager is initialized")
+                    "The requested job cannot be processed. "
+                    + "Make sure this manager is initialized")
                 return
             self._thread_pool.add(job, callback, *jobargs, **jobkwargs)
         elif serialization_mode == TaurusSerializationMode.Serial:
             if (not hasattr(self, "_sthread_pool")
-                or self._sthread_pool is None):
+                    or self._sthread_pool is None):
                 self.info("Job cannot be processed.")
                 self.debug(
-                    "The requested job cannot be processed. " +
-                    "Make sure this manager is initialized")
+                    "The requested job cannot be processed. "
+                    + "Make sure this manager is initialized")
                 return
+
             self._sthread_pool.add(job, callback, *jobargs, **jobkwargs)
         else:
             raise TaurusException("{} serialization mode not supported".format(
@@ -327,9 +329,11 @@ class TaurusManager(Singleton, Logger):
             for scheme in schemes:
                 if plugins.has_key(scheme):
                     k = plugins[scheme]
-                    self.warning("Conflicting plugins: %s and %s both implement "
-                                 "scheme %s. Will keep using %s" % (k.__name__,
-                                                                    plugin_class.__name__, scheme, k.__name__))
+                    self.warning(
+                        "Conflicting plugins: %s and %s both implement "
+                        "scheme %s. Will keep using %s" % (k.__name__,
+                                                           plugin_class.__name__,
+                                                           scheme, k.__name__))
                 else:
                     plugins[scheme] = plugin_class
         return plugins
@@ -382,8 +386,8 @@ class TaurusManager(Singleton, Logger):
             for s in m.__dict__.values():
                 plugin = None
                 try:
-                    if issubclass(s, TaurusFactory) and \
-                       issubclass(s, Singleton):
+                    if (issubclass(s, TaurusFactory)
+                            and issubclass(s, Singleton)):
                         if hasattr(s, 'schemes'):
                             schemes = getattr(s, 'schemes')
                             if len(schemes):
@@ -428,6 +432,7 @@ class TaurusManager(Singleton, Logger):
 
     def __repr__(self):
         return self.__str__name__("")
+
 
 if __name__ == '__main__':
     manager = TaurusManager()

--- a/lib/taurus/core/taurusmanager.py
+++ b/lib/taurus/core/taurusmanager.py
@@ -129,7 +129,7 @@ class TaurusManager(Singleton, Logger):
         processed by a separate thread
         :param job: (callable) a callable object
         :param callback: (callable) called after the job has been processed
-        :param jobargs: (list) list of arguments passed to the job
+        :param jobargs: (sequence)  tuple of arguments passed to the job
         :param jobkwargs: (dict) keyword arguments passed to the job
         :param serialization_mode:
         (taurus.core.taurusbasetypes.TaurusSerializationMode) serialization

--- a/lib/taurus/core/taurusmanager.py
+++ b/lib/taurus/core/taurusmanager.py
@@ -134,6 +134,12 @@ class TaurusManager(Singleton, Logger):
         (taurus.core.taurusbasetypes.TaurusSerializationMode) serialization
         mode
         """
+        if jobargs is None:
+            jobargs = ()
+
+        if jobkwargs is None:
+            jobkwargs = {}
+
         if serialization_mode is None:
             serialization_mode = self._serialization_mode
 

--- a/lib/taurus/core/taurusmanager.py
+++ b/lib/taurus/core/taurusmanager.py
@@ -144,7 +144,7 @@ class TaurusManager(Singleton, Logger):
                     "The requested job cannot be processed. " +
                     "Make sure this manager is initialized")
                 return
-            self._thread_pool.add(job, callback, *jobargs, **jobkwargs)
+            self._thread_pool.add(job, callback, jobargs, jobkwargs)
         else:
             if (not hasattr(self, "_sthread_pool")
                 or self._sthread_pool is None):
@@ -153,7 +153,7 @@ class TaurusManager(Singleton, Logger):
                     "The requested job cannot be processed. " +
                     "Make sure this manager is initialized")
                 return
-            self._sthread_pool.add(job, callback, *jobargs, **jobkwargs)
+            self._sthread_pool.add(job, callback, jobargs, jobkwargs)
 
     def setSerializationMode(self, mode):
         """Sets the serialization mode for the system.

--- a/lib/taurus/core/taurusmanager.py
+++ b/lib/taurus/core/taurusmanager.py
@@ -121,7 +121,7 @@ class TaurusManager(Singleton, Logger):
         """ Deprecated. Wrapper of enqueueJob. See enqueueJob documentation.
         """
         self.deprecated(dep='addJob', alt='enqueueJob', rel='4.3.2')
-        self.enqueueJob(job, callback, args, kw)
+        self.enqueueJob(job, callback=callback, job_args=args, job_kwargs=kw)
 
     def enqueueJob(self, job, callback=None, job_args=(), job_kwargs=None,
                    serialization_mode=None):
@@ -129,7 +129,7 @@ class TaurusManager(Singleton, Logger):
         processed by a separate thread
         :param job: (callable) a callable object
         :param callback: (callable) called after the job has been processed
-        :param job_args: (sequence)  tuple of arguments passed to the job
+        :param job_args: (sequence) positional arguments passed to the job
         :param job_kwargs: (dict) keyword arguments passed to the job
         :param serialization_mode:
         (taurus.core.taurusbasetypes.TaurusSerializationMode) serialization

--- a/lib/taurus/core/tauruspollingtimer.py
+++ b/lib/taurus/core/tauruspollingtimer.py
@@ -108,7 +108,7 @@ class TaurusPollingTimer(Logger):
             self.start()
         else:
             import taurus
-            taurus.Manager().addJob(attribute.poll, None)
+            taurus.Manager().enqueueJob(attribute.poll, None)
 
     def removeAttribute(self, attribute):
         """Unregisters the attribute from this polling. If the number of registered

--- a/lib/taurus/core/tauruspollingtimer.py
+++ b/lib/taurus/core/tauruspollingtimer.py
@@ -108,7 +108,7 @@ class TaurusPollingTimer(Logger):
             self.start()
         else:
             import taurus
-            taurus.Manager().enqueueJob(attribute.poll, None)
+            taurus.Manager().enqueueJob(attribute.poll)
 
     def removeAttribute(self, attribute):
         """Unregisters the attribute from this polling. If the number of registered

--- a/lib/taurus/tauruscustomsettings.py
+++ b/lib/taurus/tauruscustomsettings.py
@@ -147,3 +147,7 @@ _MAX_DEPRECATIONS_LOGGED = 1
 # If not set, it defaults to 'logos:taurus.png" 
 # (note that "logos:" is a Qt a registered path for "<taurus>/qt/qtgui/icon/logos/")
 # ORGANIZATION_LOGO = "logos:taurus.png"
+
+#: set the serialization mode for the tango scheme
+#: These are the possible values: 'Serial', 'Concurrent', or 'TangoSerial'
+#TANGO_SERIALIZATION_MODE = 'TangoSerial'


### PR DESCRIPTION
Use the TaurusManager PoolThread to manage the fireEvents
respecting the "serialization mode" of the scheme.

This PR delegates the control of the event queue to Taurus instead of Tango
when the serialization mode is Serial.