### PR TITLE
TaurusValueSpinBox behaviour with keyboard arrows

### DIFF
--- a/lib/taurus/qt/qtgui/input/taurusspinbox.py
+++ b/lib/taurus/qt/qtgui/input/taurusspinbox.py
@@ -66,7 +66,19 @@ class TaurusValueSpinBox(Qt.QAbstractSpinBox):
         return self.lineEdit().getValue()
 
     def keyPressEvent(self, evt):
+        if evt.key() in (Qt.Qt.Key_Control, ):
+            self.setSingleStep(self._singleStep*10)
+        elif evt.key() in (Qt.Qt.Key_Alt, Qt.Qt.Key_AltGr):
+            self.setSingleStep(self._singleStep/10)
+        if evt.key() in (Qt.Qt.Key_Up, Qt.Qt.Key_Down):
+            return Qt.QAbstractSpinBox.keyPressEvent(self, evt)
         return self.lineEdit().keyPressEvent(evt)
+
+    def keyReleaseEvent(self, evt):
+        if evt.key() in (Qt.Qt.Key_Control, ):
+            self.setSingleStep(self._singleStep/10)
+        elif evt.key() in (Qt.Qt.Key_Alt, Qt.Qt.Key_AltGr):
+            self.setSingleStep(self._singleStep*10)
 
     # ~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~
     # Mandatory overload from QAbstractSpinBox


### PR DESCRIPTION
We realise the keyboard arrows in the spinbox widget were not acting like the button arrows in the widget. The behaviour in taurus3 was the same both ways using the singleStep.

There is also a functionality in LineEdit widgets to use a modifier of the step using Ctrl to multiply by 10 the step and Alt to divide by 10, while they are pressed.

This patch like to fix the behaviour of the keyboard arrows as well as to introduce the modifiers.