### PR TITLE
Handle datetime strings without microseconds

### DIFF
--- a/lib/taurus/qt/qtgui/plot/taurusplot.py
+++ b/lib/taurus/qt/qtgui/plot/taurusplot.py
@@ -52,11 +52,16 @@ from curvesAppearanceChooserDlg import CurveAppearanceProperties
 
 
 def isodatestr2float(s, sep='_'):
-    '''
+    """
     converts a date string in iso format to a timestamp (seconds since epoch)
-    with microseconds precision
-    '''
-    d = datetime.strptime(s, '%Y-%m-%d' + sep + '%H:%M:%S.%f')
+    with microseconds precision if available
+    """
+    try:
+        # with microseconds
+        d = datetime.strptime(s, '%Y-%m-%d' + sep + '%H:%M:%S.%f')
+    except:
+        # without microseconds
+        d = datetime.strptime(s, '%Y-%m-%d' + sep + '%H:%M:%S')
     return time.mktime(d.timetuple()) + d.microsecond * 1e-6
 
 


### PR DESCRIPTION
The TaurusPlot.importAscii method raises a ValueError when importing
timestamp strings written without decimals in the seconds.

For example:
```
ValueError: time data '2018-04-09_00:08:49' does not match format '%Y-%m-%d_%H:%M:%S.%f'
```

This absence of decimals has been observed in some cases with files
exported by TaurusTrend.

Make the isodatestr2float converter function more robust by allowing
to handle both cases (with and without decimals)

This can be tested with the following file: 
[foo.txt](https://github.com/taurus-org/taurus/files/1984236/foo.txt)
