### PR TITLE
 Improve consistency in stepping for TaurusValueSpinbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,11 +25,14 @@ develop branch) won't be reflected in this file.
 ### Removed
 - All 3rd party code from taurus.external (now using dependencies
   instead of embeded 3rd party code)
+- CTRL and ALT keys are no longer used to modify step size in
+  TaurusValueLineEdit and TaurusValueSpinbox (#749)
 
 ## [4.3.1] - 2018-03-14
 A hotfix release needed for sardana 2.4
 
-### Fixed 
+### Fixed
+- consistency issues in stepping support in spinboxes and line edits (#749)
 - duplicated "tango://" prefix in panels created from Pool for sardana>=2.4
 - avoid problems if channel dimension info is set to None by sardana (#722)
 

--- a/lib/taurus/qt/qtgui/input/tauruslineedit.py
+++ b/lib/taurus/qt/qtgui/input/tauruslineedit.py
@@ -49,6 +49,7 @@ class TaurusValueLineEdit(Qt.QLineEdit, TaurusBaseWritableWidget):
                           name, designMode=designMode)
         self._enableWheelEvent = False
         self._last_value = None
+        self._singleStep = 1.
 
         self.setAlignment(Qt.Qt.AlignRight)
         self.setValidator(None)
@@ -182,7 +183,7 @@ class TaurusValueLineEdit(Qt.QLineEdit, TaurusBaseWritableWidget):
             numSteps *= 10
         elif (modifiers & Qt.Qt.AltModifier) and model.type == DataType.Float:
             numSteps *= .1
-        self._stepBy(numSteps)
+        self._stepBy(numSteps * self._singleStep)
 
     def keyPressEvent(self, evt):
         """Key press event handler"""
@@ -209,7 +210,7 @@ class TaurusValueLineEdit(Qt.QLineEdit, TaurusBaseWritableWidget):
             numSteps *= 10
         elif (modifiers & Qt.Qt.AltModifier) and model.type == DataType.Float:
             numSteps *= .1
-        self._stepBy(numSteps)
+        self._stepBy(numSteps * self._singleStep)
 
     def _stepBy(self, v):
         value = self.getValue()
@@ -280,6 +281,15 @@ class TaurusValueLineEdit(Qt.QLineEdit, TaurusBaseWritableWidget):
 
     def resetEnableWheelEvent(self):
         self.setEnableWheelEvent(False)
+
+    def getSingleStep(self):
+        return self._singleStep
+
+    def setSingleStep(self, step):
+        self._singleStep = step
+
+    def resetSingleStep(self):
+        self.setSingleStep(1.0)
 
     @classmethod
     def getQtDesignerPluginInfo(cls):

--- a/lib/taurus/qt/qtgui/input/tauruslineedit.py
+++ b/lib/taurus/qt/qtgui/input/tauruslineedit.py
@@ -178,12 +178,7 @@ class TaurusValueLineEdit(Qt.QLineEdit, TaurusBaseWritableWidget):
         evt.accept()
         numDegrees = evt.delta() / 8
         numSteps = numDegrees / 15
-        modifiers = evt.modifiers()
-        if modifiers & Qt.Qt.ControlModifier:
-            numSteps *= 10
-        elif (modifiers & Qt.Qt.AltModifier) and model.type == DataType.Float:
-            numSteps *= .1
-        self._stepBy(numSteps * self._singleStep)
+        self._stepBy(numSteps)
 
     def keyPressEvent(self, evt):
         """Key press event handler"""
@@ -205,16 +200,19 @@ class TaurusValueLineEdit(Qt.QLineEdit, TaurusBaseWritableWidget):
             return Qt.QLineEdit.keyPressEvent(self, evt)
 
         evt.accept()
-        modifiers = evt.modifiers()
-        if modifiers & Qt.Qt.ControlModifier:
-            numSteps *= 10
-        elif (modifiers & Qt.Qt.AltModifier) and model.type == DataType.Float:
-            numSteps *= .1
-        self._stepBy(numSteps * self._singleStep)
+        self._stepBy(numSteps)
 
-    def _stepBy(self, v):
+    def _stepBy(self, steps):
         value = self.getValue()
-        self.setValue(value + Quantity(v, value.units))
+        self.setValue(value + Quantity(steps * self._singleStep, value.units))
+
+        if self.getAutoApply():
+            self.editingFinished.emit()
+        else:
+            kmods = Qt.QCoreApplication.instance().keyboardModifiers()
+            controlpressed = bool(kmods & Qt.Qt.ControlModifier)
+            if controlpressed:
+                self.writeValue(forceApply=True)
 
     def setValue(self, v):
         """Set the displayed text from a given value object"""

--- a/lib/taurus/qt/qtgui/input/taurusspinbox.py
+++ b/lib/taurus/qt/qtgui/input/taurusspinbox.py
@@ -49,8 +49,6 @@ class TaurusValueSpinBox(Qt.QAbstractSpinBox):
         # Overwrite not to show quality by default
         self._showQuality = False
 
-        self._singleStep = 1.0
-
         lineEdit = TaurusValueLineEdit(designMode=designMode)
         lineEdit.setValidator(PintValidator(self))
         self.setLineEdit(lineEdit)
@@ -158,14 +156,14 @@ class TaurusValueSpinBox(Qt.QAbstractSpinBox):
         return self.lineEdit().resetForcedApply()
 
     def getSingleStep(self):
-        return self._singleStep
+        return self.lineEdit().getSingleStep()
 
     @Qt.pyqtSlot(float)
     def setSingleStep(self, step):
-        self._singleStep = step
+        self.lineEdit().setSingleStep(step)
 
     def resetSingleStep(self):
-        self.setSingleStep(1.0)
+        self.lineEdit().resetSingleStep()
 
     def _getSingleStepQuantity(self):
         """

--- a/lib/taurus/qt/qtgui/input/taurusspinbox.py
+++ b/lib/taurus/qt/qtgui/input/taurusspinbox.py
@@ -51,6 +51,7 @@ class TaurusValueSpinBox(Qt.QAbstractSpinBox):
 
         lineEdit = TaurusValueLineEdit(designMode=designMode)
         lineEdit.setValidator(PintValidator(self))
+        lineEdit.setEnableWheelEvent(True)
         self.setLineEdit(lineEdit)
         self.setAccelerated(True)
 
@@ -66,20 +67,15 @@ class TaurusValueSpinBox(Qt.QAbstractSpinBox):
     def keyPressEvent(self, evt):
         return self.lineEdit().keyPressEvent(evt)
 
+    def wheelEvent(self, evt):
+        return self.lineEdit().wheelEvent(evt)
+
     # ~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~
     # Mandatory overload from QAbstractSpinBox
     # ~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~
 
     def stepBy(self, steps):
-        self.setValue(self.getValue() + self._getSingleStepQuantity() * steps)
-
-        if self.lineEdit().getAutoApply():
-            self.lineEdit().editingFinished.emit()
-        else:
-            kmods = Qt.QCoreApplication.instance().keyboardModifiers()
-            controlpressed = bool(kmods & Qt.Qt.ControlModifier)
-            if controlpressed:
-                self.lineEdit().writeValue(forceApply=True)
+        return self.lineEdit()._stepBy(steps)
 
     def stepEnabled(self):
         ret = Qt.QAbstractSpinBox.StepEnabled(Qt.QAbstractSpinBox.StepNone)


### PR DESCRIPTION
TaurusValueSpinBox composes a TaurusValueLineEdit and delegates many of its features to it. But the "singleStep" property is not delegated and this causes inconsistent handling of step increments (e.g. pressing the keyboard up/down arrows ignores the step size, while using the up/down arrows of the spinbox widget takes it into account). 

Also, the use of the CTRL and ALT key to modify the step size is not consistently supported in all the possible step triggers (keyboard arrows, spinbox arrows and wheel events). And worse, both modifiers conflict with other roles (the control is used also for "force-applying" and the ALT+mouse for dragging windows)

Fix all these issues by refactoring the stepping feature of TaurusValueLineEdit (an make TaurusSpinbox delegate to it). Note that this involves *removing* the role as multiplier for the CTRL and ALT keys.

Note: this is an alternative solution to that suggested by @srgblnch  in #747
