### PR TITLE
Fixed right-click segfault on TaurusMainWindow gui's

### DIFF
--- a/lib/taurus/qt/qtgui/container/taurusmainwindow.py
+++ b/lib/taurus/qt/qtgui/container/taurusmainwindow.py
@@ -807,8 +807,19 @@ class TaurusMainWindow(Qt.QMainWindow, TaurusBaseContainer):
             self.socketServer.close()
         Qt.QMainWindow.closeEvent(self, event)
         TaurusBaseContainer.closeEvent(self, event)
+        
+        # print "\n\n------ MAIN WINDOW CLOSED ------ \n\n"        
+        
+    def contextMenuEvent(self, event):
+        """Handle the popup menu event, as it is the last container in the chain
+        it must accept() events instead of ignore()
 
-        # print "\n\n------ MAIN WINDOW CLOSED ------ \n\n"
+        :param event: the popup menu event
+        """
+        if self.taurusMenu is not None:
+            self.taurusMenu.exec_(event.globalPos())
+        else:
+            event.accept()        
 
     def addExternalAppLauncher(self, extapp, toToolBar=True, toMenu=True):
         '''


### PR DESCRIPTION
As TaurusMainWindow is the last container in the chain
it must accept() events instead of ignore(). When ignoring
it tries to propagate the event to parent widgets, that in
this case is Null and generates segfaults