### PR TITLE
Expression 'x' in Enumeration fails on python3 with KeyError.

### DIFF
--- a/lib/taurus/core/util/enumeration.py
+++ b/lib/taurus/core/util/enumeration.py
@@ -142,6 +142,12 @@ class Enumeration(object):
         self._uniqueId += 1
         return n
 
+    def __contains__(self, i):
+        if isinstance(i, (int, long)):
+            return i in self.reverseLookup
+        elif isinstance(i, (str, unicode)):
+            return i in self.lookup
+
     def __getitem__(self, i):
         if isinstance(i, (int, long)):
             return self.whatis(i)
@@ -149,13 +155,13 @@ class Enumeration(object):
             return self.lookup[i]
 
     def __getattr__(self, attr):
-        if not self.has_key(attr):
+        if attr not in self:
             raise AttributeError
         return self.lookup[attr]
 
     def __doc_enum(self):
         rl = self.reverseLookup
-        keys = rl.keys()
+        keys = list(rl)
         keys.sort()
         values = "\n".join(["    - {0} ({1})".format(rl[k], k) for k in keys])
         self.__doc__ = self._name + " enumeration. " + \
@@ -163,14 +169,14 @@ class Enumeration(object):
 
     def __str__(self):
         rl = self.reverseLookup
-        keys = rl.keys()
+        keys = list(rl)
         keys.sort()
         values = ", ".join([rl[k] for k in keys])
         return self._name + "(" + values + ")"
 
     def __repr__(self):
         rl = self.reverseLookup
-        keys = rl.keys()
+        keys = list(rl)
         keys.sort()
         values = [rl[k] for k in keys]
         return "Enumeration('" + self._name + "', " + str(values) + ")"


### PR DESCRIPTION
To solve this problem, explicit __contains__ method is added.