### PR TITLE
Fix 647: simplify API for setting Formatter on forms

### DIFF
--- a/lib/taurus/qt/qtgui/panel/taurusform.py
+++ b/lib/taurus/qt/qtgui/panel/taurusform.py
@@ -380,6 +380,16 @@ class TaurusForm(TaurusWidget):
                     rw.setFormat(format)
         return format
 
+    def setFormat(self, format):
+        """
+        Reimplemented to call setFormat on the taurusvalues
+        """
+        TaurusWidget.setFormat(self, format)
+        for item in self.getItems():
+            rw = item.readWidget()
+            if hasattr(rw, 'setFormat'):
+                rw.setFormat(format)
+
     def setCompact(self, compact):
         self._compact = compact
         for item in self.getItems():
@@ -472,6 +482,11 @@ class TaurusForm(TaurusWidget):
                 widget.setModifiableByUser(self.isModifiableByUser())
             except:
                 pass
+            try:
+                widget.setFormat(self.getFormat())
+            except Exception:
+                self.debug('Cannot set format %s to child %s',
+                           self.getFormat(), model)
             widget.setObjectName("__item%i" % i)
             self.registerConfigDelegate(widget)
             self._children.append(widget)

--- a/lib/taurus/qt/qtgui/panel/taurusvalue.py
+++ b/lib/taurus/qt/qtgui/panel/taurusvalue.py
@@ -206,6 +206,8 @@ class CenteredLed(TaurusLed):
 
 class DefaultUnitsWidget(TaurusLabel):
 
+    FORMAT = "{}"
+
     def __init__(self, *args):
         TaurusLabel.__init__(self, *args)
         self.setNoneValue('')

--- a/lib/taurus/qt/qtgui/panel/taurusvalue.py
+++ b/lib/taurus/qt/qtgui/panel/taurusvalue.py
@@ -445,6 +445,14 @@ class TaurusValue(Qt.QWidget, TaurusBaseWidget):
         if hasattr(self._readWidget, 'onSetFormatter'):
             return self._readWidget.onSetFormatter()
 
+    def setFormat(self, format):
+        """
+        Reimplemented to call setFormat of the read widget (if provided)
+        """
+        TaurusBaseWidget.setFormat(self, format)
+        if hasattr(getattr(self, '_readWidget', None), 'setFormat'):
+            return self._readWidget.setFormat(format)
+
     def getAllowWrite(self):
         return self._allowWrite
 

--- a/lib/taurus/qt/qtgui/panel/taurusvalue.py
+++ b/lib/taurus/qt/qtgui/panel/taurusvalue.py
@@ -30,7 +30,8 @@ taurusvalue.py:
 __all__ = ["TaurusValue", "TaurusValuesFrame", "DefaultTaurusValueCheckBox",
            "DefaultUnitsWidget", "TaurusPlotButton", "TaurusArrayEditorButton",
            "TaurusValuesTableButton", "TaurusValuesTableButton_W",
-           "DefaultLabelWidget", "TaurusDevButton", "TaurusImageButton"]
+           "DefaultLabelWidget", "DefaultReadWidgetLabel", "TaurusDevButton",
+           "TaurusImageButton"]
 
 __docformat__ = 'restructuredtext'
 


### PR DESCRIPTION
Fix #647 by implementing the features described in https://github.com/taurus-org/taurus/issues/647#issuecomment-352401115 .

Setting the format at form level now works as expected:

```python
from taurus.qt.qtgui.panel import TaurusForm
from taurus.qt.qtgui.application import TaurusApplication
import sys
from taurus.core.tango.util import tangoFormatter
app = TaurusApplication(sys.argv)
tf = TaurusForm()
tf.setFormat(tangoFormatter)
tf.setModel(["sys/tg_test/1/short_scalar_ro", "sys/tg_test/1/ampli"])
tf.show()
app.exec_()
```

and setting it at single value level works as well:
```python
from taurus.qt.qtgui.panel import TaurusForm
from taurus.qt.qtgui.application import TaurusApplication
import sys
from taurus.core.tango.util import tangoFormatter
app = TaurusApplication(sys.argv)
tf = TaurusForm()
tf.setModel(["sys/tg_test/1/short_scalar_ro", "sys/tg_test/1/ampli"])
tf[0].setFormat(tangoFormatter)
tf.show()
app.exec_()
```
