### PR TITLE
Use simple name in TaurusDevicePanel label

### DIFF
--- a/lib/taurus/qt/qtgui/panel/taurusdevicepanel.py
+++ b/lib/taurus/qt/qtgui/panel/taurusdevicepanel.py
@@ -316,9 +316,14 @@ class TaurusDevicePanel(TaurusWidget):
             if self.getModel():
                 self.detach()  # Do not dettach previous model before pinging the new one (fail message will be shown at except: clause)
             TaurusWidget.setModel(self, model)
-            self.setWindowTitle(str(model).upper())
+            model_obj = self.getModelObj()
+
+            simple_name = model_obj.getSimpleName().upper()
+            self.setWindowTitle(simple_name)
             model = self.getModel()
-            self._label.setText(model.upper())
+            self._label.setToolTip(model_obj.getFullName().upper())
+            self._label.setText(simple_name)
+
             font = self._label.font()
             font.setPointSize(15)
             self._label.setFont(font)
@@ -379,7 +384,7 @@ class TaurusDevicePanel(TaurusWidget):
             qmsg = Qt.QMessageBox(Qt.QMessageBox.Critical, '%s Error' %
                                   model, '%s not available' % model, Qt.QMessageBox.Ok, self)
             qmsg.show()
-        self.setWindowTitle(self.getModel())
+
         return
 
     def detach(self):
@@ -407,6 +412,7 @@ class TaurusDevicePanel(TaurusWidget):
         detach_recursive(self)
         try:
             self._label.setText('')
+            self._label.setToolTip('')
             if hasattr(self, '_statelabel'):
                 self._statelabel.setModel('')
             self._status.setModel('')


### PR DESCRIPTION
Avoid large fullname in the TaurusDevicePanel label.
Add tooltip to show the fullname.