### PR TITLE
Add a explicit replot when showing a trend

### DIFF
--- a/lib/taurus/qt/qtgui/plot/taurustrend.py
+++ b/lib/taurus/qt/qtgui/plot/taurustrend.py
@@ -980,6 +980,8 @@ class TaurusTrend(TaurusPlot):
         if self.isTimerNeeded(checkMinimized=False):
             self.debug('(re)starting the timer (in showEvent)')
             self._replotTimer.start()
+            # call a replot now (since it may not have been done while hidden)
+            self.doReplot()
 
     def hideEvent(self, event):
         '''reimplemented from :meth:`TaurusPlot.showEvent` so that


### PR DESCRIPTION
Fix #773 (a trend which has been hidden may not show updated values
for some time after being shown again) by doing an explicit replot
on show events.