### PR TITLE
Define correct focus on a 'apply' button

### DIFF
--- a/lib/taurus/qt/qtgui/plot/qwtdialog.py
+++ b/lib/taurus/qt/qtgui/plot/qwtdialog.py
@@ -182,11 +182,17 @@ class TaurusPlotConfigDialog(Qt.QDialog):
         else:
             self.ui.peaksComboBox.setCurrentIndex(3)
 
-        # define correct focus on a 'apply' button
-        self.ui.buttonBox.button(Qt.QDialogButtonBox.Close).setAutoDefault(False)
-        self.ui.buttonBox.button(Qt.QDialogButtonBox.Close).setDefault(False)
-        self.ui.buttonBox.button(Qt.QDialogButtonBox.Apply).setAutoDefault(True)
-        self.ui.buttonBox.button(Qt.QDialogButtonBox.Apply).setDefault(True)
+        # put focus on Apply button by default (otherwise, on some desktop
+        # environments, the "close" button would be focused by default, 
+        # causing the dialog to close when using "ENTER" while editing values
+        self.ui.buttonBox.button(
+            Qt.QDialogButtonBox.Close).setAutoDefault(False)
+        self.ui.buttonBox.button(
+            Qt.QDialogButtonBox.Close).setDefault(False)
+        self.ui.buttonBox.button(
+            Qt.QDialogButtonBox.Apply).setAutoDefault(True)
+        self.ui.buttonBox.button(
+            Qt.QDialogButtonBox.Apply).setDefault(True)
 
         # connect signals
         self.ui.buttonBox.button(

--- a/lib/taurus/qt/qtgui/plot/qwtdialog.py
+++ b/lib/taurus/qt/qtgui/plot/qwtdialog.py
@@ -182,6 +182,12 @@ class TaurusPlotConfigDialog(Qt.QDialog):
         else:
             self.ui.peaksComboBox.setCurrentIndex(3)
 
+        # define correct focus on a 'apply' button
+        self.ui.buttonBox.button(Qt.QDialogButtonBox.Close).setAutoDefault(False)
+        self.ui.buttonBox.button(Qt.QDialogButtonBox.Close).setDefault(False)
+        self.ui.buttonBox.button(Qt.QDialogButtonBox.Apply).setAutoDefault(True)
+        self.ui.buttonBox.button(Qt.QDialogButtonBox.Apply).setDefault(True)
+
         # connect signals
         self.ui.buttonBox.button(
             Qt.QDialogButtonBox.Close).clicked.connect(self.hide)


### PR DESCRIPTION
Fix the problem with different focus on a 'apply' and 'colse' in the TaurusPlotConfigDialog (depends of the X environment), by define this order in the Taurus. This bug cause different behavior after pressing 'enter' key. See #772.

Fixes #772