### PR TITLE
Allow travis to fail on builds for debian 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ env:
 
 matrix:
     allow_failures:
+        - env: DOCKER_IMG=cpascual/taurus-test:debian-jessie
         - env: DOCKER_IMG=cpascual/taurus-test:debian-buster
 
 before_install:


### PR DESCRIPTION
The debian8 (Jessie) builds in travis are currently getting a lot
of spurious "no output for 10m" failures.
This should be addressed properly but as a workaround, just mark
this build as "allowed to fail"