### PR TITLE
Make "Change Tango Host" action invisible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ develop branch) won't be reflected in this file.
 ### Changed
 - Serialization mode now is explicitly set to Serial
   in the case of TangoFactory (Taurus defaults to Concurrent) (#678)
+- TaurusMainWindow's "Change Tango Host" action is now invisible (#781)
 
 ### Fixed
 - TaurusModel ignoring the serialization mode (#678)

--- a/lib/taurus/qt/qtgui/container/taurusmainwindow.py
+++ b/lib/taurus/qt/qtgui/container/taurusmainwindow.py
@@ -387,7 +387,6 @@ class TaurusMainWindow(Qt.QMainWindow, TaurusBaseContainer):
         self.quitApplicationAction.triggered[()].connect(self.close)
         self.changeTangoHostAction = Qt.QAction(Qt.QIcon.fromTheme(
             "network-server"), 'Change Tango Host ...', self)
-        self.changeTangoHostAction.setShortcut(Qt.QKeySequence("Ctrl+P"))
         self.changeTangoHostAction.triggered[()].connect(self._onChangeTangoHostAction)
         # make this action invisible since it is deprecated
         self.changeTangoHostAction.setVisible(False)

--- a/lib/taurus/qt/qtgui/container/taurusmainwindow.py
+++ b/lib/taurus/qt/qtgui/container/taurusmainwindow.py
@@ -389,6 +389,8 @@ class TaurusMainWindow(Qt.QMainWindow, TaurusBaseContainer):
             "network-server"), 'Change Tango Host ...', self)
         self.changeTangoHostAction.setShortcut(Qt.QKeySequence("Ctrl+P"))
         self.changeTangoHostAction.triggered[()].connect(self._onChangeTangoHostAction)
+        # make this action invisible since it is deprecated
+        self.changeTangoHostAction.setVisible(False)
 
         self.loadPerspectiveAction = Qt.QAction(Qt.QIcon.fromTheme(
             "document-open"), 'Load Perspective ...', self)


### PR DESCRIPTION
The "taurus" menu in TaurusMainWindow contains the "Change Tango Host"
action, which is tango-centric, does nothing and is deprecated
(see #379). Remove the action from the menu.

Note that the action itself is not removed from the TaurusMainWindow. 
It is just made invisible in order not to change the API on a minor change.

Fix #379