### PR TITLE
Skip the console dir in TaurusWidgetFactory

### DIFF
--- a/lib/taurus/qt/qtgui/util/tauruswidgetfactory.py
+++ b/lib/taurus/qt/qtgui/util/tauruswidgetfactory.py
@@ -80,7 +80,8 @@ class TaurusWidgetFactory(Singleton, Logger):
         wf = TaurusWidgetFactory()
         print wf.getTaurusWidgetClassNames()"""
 
-    skip_modules = ('widget', 'util', 'qtdesigner', 'uic', 'resource')
+    skip_modules = ('widget', 'util', 'qtdesigner', 'uic', 'resource',
+                    'console')
 
     def __init__(self):
         """ Initialization. Nothing to be done here for now."""


### PR DESCRIPTION
taurus.qt.qtgui.console is deprecated and raises a warning if
imported. This happens when TaurusWidgetFactory inspects all
taurus widgets on init, which confuses the users.
Do not inspect the taurus.qt.qtgui.console dir when initializing
TaurusWidgetFactory.

Fixes #637