### PR TITLE
Handle exception when adding listener to non-ready device

### DIFF
--- a/lib/taurus/core/tango/tangodevice.py
+++ b/lib/taurus/core/tango/tangodevice.py
@@ -281,7 +281,12 @@ class TangoDevice(TaurusDevice):
         if weWereListening:
             # We were listening already, so we must fake an event to the new
             # subscribed listener with the current value
-            evt_value = self.__decode(self.stateObj.read())
+            try:
+                evt_value = self.__decode(self.stateObj.read())
+            except:
+                # the value may not be available (e.g. if device is not ready)
+                self.debug('Cannot read state')
+                return ret
             listeners = hasattr(listener, '__iter__') and listener or [
                 listener]
             self.fireEvent(TaurusEventType.Change, evt_value, listeners)


### PR DESCRIPTION
TangoDevice.addListener() fails to handle an exception when a second
listener is added and the device is not ready. Handle it.

Fixes #791