### PR TITLE
Avoid deprecation warning in TaurusDevicePanel

### DIFF
--- a/lib/taurus/qt/qtgui/panel/taurusdevicepanel.py
+++ b/lib/taurus/qt/qtgui/panel/taurusdevicepanel.py
@@ -217,7 +217,7 @@ class TaurusDevicePanel(TaurusWidget):
         self._stateframe.layout().addWidget(Qt.QLabel('State'), 0, 0, Qt.Qt.AlignCenter)
         self._statelabel = TaurusLabel(self._stateframe)
         self._statelabel.setMinimumWidth(100)
-        self._statelabel.setBgRole('value')
+        self._statelabel.setBgRole('rvalue')
         self._stateframe.layout().addWidget(self._statelabel, 0, 1, Qt.Qt.AlignCenter)
 
         self._statusframe = Qt.QScrollArea(self)


### PR DESCRIPTION
TaurusDevicePanel triggers a deprecation warning when showing the state.

To reproduce: 

```
$ taurusdevicepanel sys/tg_test/1
(...)
MainThread     WARNING  2018-08-20 18:15:39,950 TaurusRootLogger: /nfs/home/cpascual/src/taurus/lib/taurus/qt/qtgui/base/tauruscontroller.py:83: DeprecationWarning: _get_value is deprecated since 4.0. Use .rvalue instead
  return getattr(valueObj, "value", None)

MainThread     INFO     2018-08-20 18:15:42,083 TaurusRootLogger: 
*********************
< Deprecation Counts (6):
        6 * "_get_value is deprecated since 4.0. Use .rvalue instead" >

```

This PR fixes it by using the new API (`.rvalue`) instead of the old one (`.value`)