### PR TITLE
Set QWheel minimum height (Fix #788)

### DIFF
--- a/lib/taurus/qt/qtgui/input/qwheel.py
+++ b/lib/taurus/qt/qtgui/input/qwheel.py
@@ -325,6 +325,15 @@ class QWheelEdit(Qt.QFrame):
                                 self.getDecDigitCount())
         ed.setVisible(False)
         self._editor = ed
+
+        # set the minimum height for the widget
+        # (otherwise the hints seem to be ignored by the layouts)
+        min_height = max(ed.minimumSizeHint().height(),
+                         signLabel.minimumSizeHint().height())
+        if self.getShowArrowButtons():
+            min_height += 2 * _ArrowButton.ButtonSize
+        self.setMinimumHeight(min_height)
+
         self.clearWarning()
 
     def _clear(self):
@@ -864,6 +873,7 @@ class QWheelEdit(Qt.QFrame):
 
 
 def main():
+    import taurus.qt.qtgui.icon  # otherwise the arrows don't show in the demo
     global arrowWidget
 
     def resetAll():


### PR DESCRIPTION
Fix #788 by explicitly setting the minimum height of the QWheel widget
when it is being constructed.

This is a second attempt at fixing it after rejecting #794 approach.
Note that the ugly behaviour of TaurusForm of forcing minimum heights to its subwidgets (see https://github.com/taurus-org/taurus/pull/794#issuecomment-414935963) is not yet dealt-with (but it is not necessary to fix #788)