### PR TITLE
Fix TaurusValueLineEdit ignores #wvalue.magnitude fragment

### DIFF
--- a/lib/taurus/qt/qtgui/input/tauruslineedit.py
+++ b/lib/taurus/qt/qtgui/input/tauruslineedit.py
@@ -105,6 +105,18 @@ class TaurusValueLineEdit(Qt.QLineEdit, TaurusBaseWritableWidget):
         """reimplement to avoid autoapply on every partial edition"""
         self.emitValueChanged()
 
+    def postAttach(self):
+        """reimplemented from :class:`TaurusBaseWritableWidget`"""
+        TaurusBaseWritableWidget.postAttach(self)
+        if self.isAttached():
+            try:
+                value = self.getModelObj().read(cache=True)
+                self._updateValidator(value)
+                v = value.wvalue
+            except:
+                v = None
+            self.setValue(v)
+
     def handleEvent(self, evt_src, evt_type, evt_value):
 
         # handle the case in which the line edit is not yet initialized


### PR DESCRIPTION
Line edits are failing to act on #wvalue.magnitude fragments.
The validator is not initialized when setValue  is called in
the postAttach method.

Fix #797 overwriting the postAttach method.