### PR TITLE
Fix TaurusForm "Set Format" option does not work in compact mode

### DIFF
--- a/lib/taurus/qt/qtgui/panel/taurusform.py
+++ b/lib/taurus/qt/qtgui/panel/taurusform.py
@@ -397,9 +397,8 @@ class TaurusForm(TaurusWidget):
         """
         TaurusWidget.setFormat(self, format)
         for item in self.getItems():
-            rw = item.readWidget(followCompact=True)
-            if hasattr(rw, 'setFormat'):
-                rw.setFormat(format)
+            if hasattr(item, 'setFormat'):
+                item.setFormat(format)
 
     def setCompact(self, compact):
         self._compact = compact

--- a/lib/taurus/qt/qtgui/panel/taurusform.py
+++ b/lib/taurus/qt/qtgui/panel/taurusform.py
@@ -386,7 +386,7 @@ class TaurusForm(TaurusWidget):
         format = TaurusWidget.onSetFormatter(self)
         if format is not None:
             for item in self.getItems():
-                rw = item.readWidget()
+                rw = item.readWidget(followCompact=True)
                 if hasattr(rw, 'setFormat'):
                     rw.setFormat(format)
         return format
@@ -397,7 +397,7 @@ class TaurusForm(TaurusWidget):
         """
         TaurusWidget.setFormat(self, format)
         for item in self.getItems():
-            rw = item.readWidget()
+            rw = item.readWidget(followCompact=True)
             if hasattr(rw, 'setFormat'):
                 rw.setFormat(format)
 

--- a/lib/taurus/qt/qtgui/panel/taurusvalue.py
+++ b/lib/taurus/qt/qtgui/panel/taurusvalue.py
@@ -451,8 +451,12 @@ class TaurusValue(Qt.QWidget, TaurusBaseWidget):
         Reimplemented to call setFormat of the read widget (if provided)
         """
         TaurusBaseWidget.setFormat(self, format)
-        if hasattr(getattr(self, '_readWidget', None), 'setFormat'):
-            return self._readWidget.setFormat(format)
+        try:
+            rw = self.readWidget(followCompact=True)
+        except AttributeError:
+            return
+        if hasattr(rw, 'setFormat'):
+            rw.setFormat(format)
 
     def getAllowWrite(self):
         return self._allowWrite

--- a/lib/taurus/qt/qtgui/panel/taurusvalue.py
+++ b/lib/taurus/qt/qtgui/panel/taurusvalue.py
@@ -1085,8 +1085,14 @@ class TaurusValue(Qt.QWidget, TaurusBaseWidget):
         self.extraWidgetClassID = 'Auto'
 
     def setCompact(self, compact):
+
+        # don't do anything if it is already done
         if compact == self._compact:
             return
+
+        #do not switch to compact mode if the write widget is None
+        if compact and self.writeWidget() is None:
+           return
 
         # Backup the current RW format
         rw = self.readWidget(followCompact=True)

--- a/lib/taurus/qt/qtgui/panel/taurusvalue.py
+++ b/lib/taurus/qt/qtgui/panel/taurusvalue.py
@@ -1092,7 +1092,8 @@ class TaurusValue(Qt.QWidget, TaurusBaseWidget):
 
         #do not switch to compact mode if the write widget is None
         if compact and self.writeWidget() is None:
-           return
+            self.debug('No write widget. Ignoring setCompact(True)')
+            return
 
         # Backup the current RW format
         rw = self.readWidget(followCompact=True)

--- a/lib/taurus/qt/qtgui/panel/taurusvalue.py
+++ b/lib/taurus/qt/qtgui/panel/taurusvalue.py
@@ -442,7 +442,7 @@ class TaurusValue(Qt.QWidget, TaurusBaseWidget):
         """
         Reimplemented to call onSetFormatter of the read widget (if provided)
         """
-        rw = readWidget(followCompact=True)
+        rw = self.readWidget(followCompact=True)
         if hasattr(rw, 'onSetFormatter'):
             return rw.onSetFormatter()
 

--- a/lib/taurus/qt/qtgui/panel/taurusvalue.py
+++ b/lib/taurus/qt/qtgui/panel/taurusvalue.py
@@ -442,8 +442,9 @@ class TaurusValue(Qt.QWidget, TaurusBaseWidget):
         """
         Reimplemented to call onSetFormatter of the read widget (if provided)
         """
-        if hasattr(self._readWidget, 'onSetFormatter'):
-            return self._readWidget.onSetFormatter()
+        rw = readWidget(followCompact=True)
+        if hasattr(rw, 'onSetFormatter'):
+            return rw.onSetFormatter()
 
     def setFormat(self, format):
         """
@@ -1086,10 +1087,19 @@ class TaurusValue(Qt.QWidget, TaurusBaseWidget):
     def setCompact(self, compact):
         if compact == self._compact:
             return
+
+        # Backup the current RW format
+        rw = self.readWidget(followCompact=True)
+        format = rw.getFormat()
+
         self._compact = compact
         if self.getModel():
             self.updateReadWidget()
             self.updateWriteWidget()
+
+        # Apply the format to the new RW
+        rw = self.readWidget(followCompact=True)
+        rw.setFormat(format)
 
     def isCompact(self):
         return self._compact


### PR DESCRIPTION
The compact elements of a taurusform ignore the set format option.

Propagate the format when the read widget is compacted and vice versa.

Fix #787