### PR TITLE
Fix Taurusform: Change label fails for devices

### DIFF
--- a/lib/taurus/core/tango/tangodevice.py
+++ b/lib/taurus/core/tango/tangodevice.py
@@ -168,9 +168,11 @@ class TangoDevice(TaurusDevice):
             rvalue of the returned TangoAttributeValue is now a member of
             TaurusDevState instead of TaurusSWDevState
         """
+        if not cache:
+            self.warning('Ignoring argument `cache=False`to getValueObj()')
         from taurus.core.tango.tangoattribute import TangoAttrValue
         ret = TangoAttrValue()
-        ret.rvalue = self.state(cache)
+        ret.rvalue = self.state
         return ret
 
     def getDisplayDescrObj(self, cache=True):

--- a/lib/taurus/qt/qtgui/display/tauruslabel.py
+++ b/lib/taurus/qt/qtgui/display/tauruslabel.py
@@ -32,7 +32,6 @@ __docformat__ = 'restructuredtext'
 import operator
 import re
 
-from taurus.core import (TaurusDevice, TaurusAttribute)
 from taurus.core.taurusbasetypes import (TaurusElementType, TaurusEventType,
                                          AttrQuality, TaurusDevState)
 from taurus.external.qt import Qt
@@ -491,10 +490,10 @@ class TaurusLabel(Qt.QLabel, TaurusBaseWidget):
         dev = None
         attr = None
 
-        modelclass = self.getModelClass()
-        if modelclass and issubclass(modelclass, TaurusDevice):
+        modeltype = self.getModelType()
+        if modeltype == TaurusElementType.Device:
             dev = self.getModelObj()
-        elif modelclass and issubclass(modelclass, TaurusAttribute):
+        elif modeltype == TaurusElementType.Attribute:
             attr = self.getModelObj()
             dev = attr.getParent()
 

--- a/lib/taurus/qt/qtgui/display/tauruslabel.py
+++ b/lib/taurus/qt/qtgui/display/tauruslabel.py
@@ -32,6 +32,7 @@ __docformat__ = 'restructuredtext'
 import operator
 import re
 
+from taurus.core import (TaurusDevice, TaurusAttribute)
 from taurus.core.taurusbasetypes import (TaurusElementType, TaurusEventType,
                                          AttrQuality, TaurusDevState)
 from taurus.external.qt import Qt
@@ -487,8 +488,15 @@ class TaurusLabel(Qt.QLabel, TaurusBaseWidget):
         else:
             value = self._permanentText
 
-        attr = self.getModelObj()
-        dev = attr.getParent()
+        dev = None
+        attr = None
+
+        modelclass = self.getModelClass()
+        if modelclass and issubclass(modelclass, TaurusDevice):
+            dev = self.getModelObj()
+        elif modelclass and issubclass(modelclass, TaurusAttribute):
+            attr = self.getModelObj()
+            dev = attr.getParent()
 
         try:
             v = value.format(dev=dev, attr=attr)

--- a/lib/taurus/qt/qtgui/panel/taurusvalue.py
+++ b/lib/taurus/qt/qtgui/panel/taurusvalue.py
@@ -105,7 +105,7 @@ class DefaultLabelWidget(TaurusLabel):
             # The following is a workaround to avoid tango-centricity, but
             # it has the drawback that the model is not set (e.g., no tooltip)
             devName = self.taurusValueBuddy().getModelObj().getSimpleName()
-            TaurusLabel.setModel(self, None)
+            TaurusLabel.setModel(self, model)
             self.setText(devName)
 
     _BCK_COMPAT_TAGS = {'<attr_name>': '{attr.name}',

--- a/lib/taurus/qt/qtgui/panel/taurusvalue.py
+++ b/lib/taurus/qt/qtgui/panel/taurusvalue.py
@@ -99,11 +99,6 @@ class DefaultLabelWidget(TaurusLabel):
             config = self.taurusValueBuddy().getLabelConfig()
             TaurusLabel.setModel(self, '%s#%s' % (fullname, config))
         elif elementtype == TaurusElementType.Device:
-            # @TODO: tango-centric!
-            # TaurusLabel.setModel(self, '%s/state#dev_alias'%fullname)
-            #
-            # The following is a workaround to avoid tango-centricity, but
-            # it has the drawback that the model is not set (e.g., no tooltip)
             devName = self.taurusValueBuddy().getModelObj().getSimpleName()
             TaurusLabel.setModel(self, model)
             self.setText(devName)


### PR DESCRIPTION
Taurus form change label context menu option does not work
when the set model is a device URI.

Fix #786