### PR TITLE
Avoid filtering first change event

### DIFF
--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -836,6 +836,7 @@ class TangoAttribute(TaurusAttribute):
             # and the given timestamp is older than the timestamp
             # of the cache value
             if (self.__attr_value is not None
+                and self.__subscription_state == SubscriptionState.Subscribed
                 and filter_old_event
                 and time < self.__attr_value.time.totime()):
                 return [None, None]


### PR DESCRIPTION
If the FILTER_OLD_TANGO_EVENTS feature is enabled the first CHANGE_EVENT
could be rejected; even if the subscription state is Subscribing, causing
side effects.

Avoid dropping a valid change event checking the subscription state.

This is an alternative approach to that of #808 