### PR TITLE
Fix Qt API collision in taurusnexuswidget

### DIFF
--- a/lib/taurus/qt/qtgui/extra_nexus/taurusnexuswidget.py
+++ b/lib/taurus/qt/qtgui/extra_nexus/taurusnexuswidget.py
@@ -32,8 +32,8 @@ __all__ = ["TaurusNexusBrowser"]
 import numpy
 import posixpath
 
-from PyMca5.PyMcaGui.io.hdf5 import HDF5Widget, HDF5Info, HDF5DatasetTable
 from taurus.external.qt import Qt
+from PyMca5.PyMcaGui.io.hdf5 import HDF5Widget, HDF5Info, HDF5DatasetTable
 
 from taurus.qt.qtgui.container import TaurusWidget
 from taurus.qt.qtgui.plot import TaurusPlot


### PR DESCRIPTION
running `cd <taurus>/lib/taurus/qt/qtgui/extra_nexus/;python -m taurusnexuswidget` fails
because the early import of PyMCA sets the Qt API to 1. Do the
taurus.external.qt import before to avoid it.