### PR TITLE
Fix taurusfactory.getAttribute method

### DIFF
--- a/lib/taurus/core/taurusfactory.py
+++ b/lib/taurus/core/taurusfactory.py
@@ -217,7 +217,8 @@ class TaurusFactory(object):
         try:
             # this works only if the devname is present in the attr full name
             # (not all schemes are constructed in this way)
-            devname = v.getUriGroups(fullname)['devname']
+            groups = v.getUriGroups(fullname)
+            devname = '{0}:{1}'.format(groups['scheme'], groups['devname'])
             dev = self.getDevice(devname)
         except:
             self.debug('Cannot get attribute parent from name "%s"', fullname)


### PR DESCRIPTION
getAttribute method assumes the scheme for creating the device.
It fails when you do not use the default scheme.

Fix it, composing the device name URI with the tuple scheme
and devname.