### PR TITLE
(py3) Fix problems with qbase models

### DIFF
--- a/lib/taurus/qt/qtcore/model/taurusdatabasemodel.py
+++ b/lib/taurus/qt/qtcore/model/taurusdatabasemodel.py
@@ -84,10 +84,15 @@ def getDevStateToolTip(*args, **kwargs):
 class TaurusTreeDbBaseItem(TaurusBaseTreeItem):
     try:
         # TODO: tango-centric
-        from taurus.core.tango.tangodatabase import TangoInfo
-        DisplayFunc = TangoInfo.name
+        import taurus.core.tango
+
+        @staticmethod
+        def DisplayFunc(obj):
+            from taurus.core.tango.tangodatabase import TangoInfo
+            return TangoInfo.name(obj)
     except:
         pass
+
 
 class TaurusTreeDevicePartItem(TaurusTreeDbBaseItem):
     """A node designed to represent a 'part' (or totality) of a device name"""

--- a/lib/taurus/qt/qtgui/model/qbasemodel.py
+++ b/lib/taurus/qt/qtgui/model/qbasemodel.py
@@ -528,7 +528,7 @@ class QBaseModelWidget(Qt.QMainWindow):
         # reversed
         qmodel_class, qmodel_proxy_classes = qmodel_classes[
             -1], qmodel_classes[-2::-1]
-        qmodel = qmodel_class(self)
+        qmodel = qmodel_class(parent=self)
         qmodel_source = qmodel
         if self._proxyModel is None:  # applies the chain of proxies
             for qmodel_proxy_class in qmodel_proxy_classes:

--- a/lib/taurus/qt/qtgui/table/qlogtable.py
+++ b/lib/taurus/qt/qtgui/table/qlogtable.py
@@ -147,7 +147,7 @@ class QLoggingTableModel(Qt.QAbstractTableModel, logging.Handler):
     DftColSize = Qt.QSize(80, 20), Qt.QSize(200, 20), \
         Qt.QSize(300, 20), Qt.QSize(180, 20), Qt.QSize(240, 20),
 
-    def __init__(self, capacity=500000, freq=0.25):
+    def __init__(self, parent=None, capacity=500000, freq=0.25):
         super(Qt.QAbstractTableModel, self).__init__()
         logging.Handler.__init__(self)
         self._capacity = capacity
@@ -369,8 +369,7 @@ class LoggingToolBar(FilterToolBar):
         self._logLevelComboBox = logLevelComboBox = Qt.QComboBox()
         levels = "Trace", "Debug", "Info", "Warning", "Error", "Critical"
         for level in levels:
-            logLevelComboBox.addItem(
-                level, Qt.QVariant(getattr(taurus, level)))
+            logLevelComboBox.addItem(level, getattr(taurus, level))
         logLevelComboBox.setCurrentIndex(0)
         logLevelComboBox.currentIndexChanged.connect(self.onLogLevelChanged)
         logLevelComboBox.setToolTip("Filter by log level")


### PR DESCRIPTION
To reproduce, compare the behaviour of this snippet with py2 (ok) and py3 (fails):

```python
from taurus.qt.qtgui.application import TaurusApplication
from taurus.qt.qtgui.tree import TaurusDbTreeWidget
from taurus.core import TaurusElementType
from taurus.core.tango import TangoDatabase

if __name__ == '__main__':
    import sys
    print('PYVERSION', sys.version)
    app = TaurusApplication()

    w = TaurusDbTreeWidget(perspective=TaurusElementType.DeviceClass)

    model = TangoDatabase().fullname
    w.setModel(model)

    w.show()
    sys.exit(app.exec_())
```

