### PR TITLE
Make TangoAttrValue copyable

### DIFF
--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -140,7 +140,16 @@ class TangoAttrValue(TaurusAttrValue):
         self.quality = quality_from_tango(p.quality)
 
     def __getattr__(self, name):
+        """
+        If the member `name` is not defined in this class, try to get it
+        from the TangoAttribute (configuration) or from the PyTango value
+        """
+        # Do not try to delegate special methods
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError("'%s' object has no attribute %s"
+                                 % (self.__class__.__name__, name))
         try:
+            # maybe name is defined in the TangoAttribute?
             try:
                 # Use the attr reference if the attr is still valid
                 ret = getattr(self._attrRef, name)
@@ -152,6 +161,7 @@ class TangoAttrValue(TaurusAttrValue):
                 ret = getattr(a, name)
         except AttributeError:
             try:
+                # maybe name is defined in the PyTango value?
                 ret = getattr(self._pytango_dev_attr, name)
             except AttributeError:
                 raise AttributeError("'%s' object has no attribute %s"


### PR DESCRIPTION
TangoAttrValue implements `__getattr__` to map some API from TangoAttribute and PyTango values. But the current implementation makes copy.copy() on a TangoAttrValue to fail because some special methods such as `__getstate__` are also mapped (which is not ok).

This can be reproduced with: 

```python
import taurus
import copy
v = taurus.Attribute('sys/tg_test/1/double_scalar').read()  # <-- TangoAttributeValue => FAILS
# v = taurus.Attribute('eval:1').read()  # <-- EvaluationAttrValue => OK
print(v)
w = copy.copy(v) 
```
The proposed solution is to limit the mapping of `__getattr__` to non-special methods.

Note: this was reported by @hayg25 in https://github.com/taurus-org/taurus_pyqtgraph/issues/3