### PR TITLE
Fix #834-Remove problematic findCaller implementation

### DIFF
--- a/lib/taurus/core/util/log.py
+++ b/lib/taurus/core/util/log.py
@@ -414,41 +414,6 @@ class LogExceptHook(BaseExceptHook):
         self._log.log(self._level, "Unhandled exception:\n%s", text)
 
 
-class _Logger(logging.Logger):
-
-
-    def findCaller(self, stack_info=False):
-        """
-        Find the stack frame of the caller so that we can note the source
-        file name, line number and function name.
-        """
-        f = currentframe()
-        # On some versions of IronPython, currentframe() returns None if
-        # IronPython isn't run with -X:Frames.
-        if f is not None:
-            f = f.f_back
-        rv = "(unknown file)", 0, "(unknown function)", None
-        while hasattr(f, "f_code"):
-            co = f.f_code
-            filename = os.path.normcase(co.co_filename)
-            if filename in (_srcfile, logging._srcfile):
-                f = f.f_back
-                continue
-            
-            sinfo = None
-            if stack_info:
-                sio = io.StringIO()
-                sio.write('Stack (most recent call last):\n')
-                traceback.print_stack(f, file=sio)
-                sinfo = sio.getvalue()
-                if sinfo[-1] == '\n':
-                    sinfo = sinfo[:-1]
-                sio.close()
-            rv = (co.co_filename, f.f_lineno, co.co_name, sinfo)
-            break
-        return rv
-
-
 class Logger(Object):
     """The taurus logger class. All taurus pertinent classes should inherit
     directly or indirectly from this class if they need taurus logging
@@ -662,7 +627,7 @@ class Logger(Object):
     def _getLogger(name=None):
         orig_logger_class = logging.getLoggerClass()
         try:
-            logging.setLoggerClass(_Logger)
+            logging.setLoggerClass(logging.Logger)
             ret = logging.getLogger(name)
             return ret
         finally:


### PR DESCRIPTION
Fix #834:

`taurus.core.util.log` reimplements `logging.Logger` class to overwrite
the findCaller method. This reimplementation is not simultaneously
py2+py3 compatible and it is almost identical to the py3
implementation, breaking things on py2.
Remove our reimplementation and use the logging ones (py2 or py3)
instead.