### PR TITLE
Avoid circular references in Serial Mode in Tango (Issue 846)

### DIFF
--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -47,11 +47,7 @@ from taurus.core.taurusbasetypes import (TaurusEventType,
                                          SubscriptionState, TaurusAttrValue,
                                          DataFormat, DataType)
 from taurus.core.taurusoperation import WriteAttrOperation
-from taurus.core.util.event import EventListener
-# -------------------------------------------------------------------------
-# TODO: remove this when PyTango's bug 185 is fixed
-from taurus.core.util.event import _BoundMethodWeakrefWithCall
-# -------------------------------------------------------------------------
+from taurus.core.util.event import EventListener, _BoundMethodWeakrefWithCall
 from taurus.core.util.log import (debug, taurus4_deprecation,
                                   deprecation_decorator)
 
@@ -618,7 +614,8 @@ class TangoAttribute(TaurusAttribute):
                                 rel='4.3.2')
                 self.__fireRegisterEvent((listener,))
             else:
-                Manager().enqueueJob(self.__fireRegisterEvent,
+                job = _BoundMethodWeakrefWithCall(self.__fireRegisterEvent)
+                Manager().enqueueJob(job,
                                      job_args=((listener,),),
                                      serialization_mode=sm)
         return ret
@@ -825,7 +822,8 @@ class TangoAttribute(TaurusAttribute):
                                 rel='4.3.2')
                 self.fireEvent(etype, evalue, listeners=listeners)
             else:
-                manager.enqueueJob(self.fireEvent, job_args=(etype, evalue),
+                job = _BoundMethodWeakrefWithCall(self.fireEvent)
+                manager.enqueueJob(job, job_args=(etype, evalue),
                                    job_kwargs={'listeners': listeners},
                                    serialization_mode=sm)
 

--- a/lib/taurus/core/tango/test/test_tangofactory.py
+++ b/lib/taurus/core/tango/test/test_tangofactory.py
@@ -40,14 +40,17 @@ class TestFactoryGarbageCollection(TangoSchemeTestLauncher, TestCase):
 
     def setUp(self):
         self.factory = taurus.Factory()
+
+    @expectedFailure
     def test_authority(self):
+        old_len = len(self.factory.tango_db)
+
         def create():
             taurus.Authority()
+
         create()
         msg = "factory is polluted with authority "
-        # TODO: uncomment this line whenever TangoFactory starts recycling
-        # authorities
-        # self.assertEqual(len(taurus.Factory().tango_auths), 0, msg)
+        self.assertEqual(len(self.factory.tango_db), old_len, msg)
 
     def test_device(self):
         old_len = len(self.factory.tango_devs)

--- a/lib/taurus/core/tango/test/test_tangofactory.py
+++ b/lib/taurus/core/tango/test/test_tangofactory.py
@@ -28,7 +28,7 @@
 
 import taurus
 
-from taurus.external.unittest import TestCase
+from taurus.external.unittest import TestCase, expectedFailure
 from taurus.core.tango.test.tgtestds import TangoSchemeTestLauncher
 
 

--- a/lib/taurus/core/tango/test/test_tangofactory.py
+++ b/lib/taurus/core/tango/test/test_tangofactory.py
@@ -41,16 +41,16 @@ class TestFactoryGarbageCollection(TangoSchemeTestLauncher, TestCase):
     def setUp(self):
         self.factory = taurus.Factory()
 
-    def test_authority(self):
-        old_len = len(self.factory.tango_db)
-
-        def create():
-            taurus.Authority()
-
-        create()
-        msg = "factory is polluted with authority "
-        # Uncomment this line whenever tango factory recycles authority
-        # self.assertEqual(len(self.factory.tango_db), old_len, msg)
+    # TODO: Uncomment this test when tango factory recycles authority
+    # def test_authority(self):
+    #     old_len = len(self.factory.tango_db)
+    # 
+    #     def create():
+    #         taurus.Authority()
+    # 
+    #     create()
+    #     msg = "factory is polluted with authority "
+    #     self.assertEqual(len(self.factory.tango_db), old_len, msg)
 
     def test_device(self):
         old_len = len(self.factory.tango_devs)

--- a/lib/taurus/core/tango/test/test_tangofactory.py
+++ b/lib/taurus/core/tango/test/test_tangofactory.py
@@ -29,10 +29,17 @@
 import taurus
 
 from taurus.external.unittest import TestCase
+from taurus.core.tango.test.tgtestds import TangoSchemeTestLauncher
 
 
-class TestFactoryGarbageCollection(TestCase):
+class TestFactoryGarbageCollection(TangoSchemeTestLauncher, TestCase):
 
+    # in order to not interfere with the following tests this device should
+    # not be used in another tests
+    DEV_NAME = 'TangoSchemeTest/unittest/temp-tfgc-1'
+
+    def setUp(self):
+        self.factory = taurus.Factory()
     def test_authority(self):
         def create():
             taurus.Authority()
@@ -43,15 +50,24 @@ class TestFactoryGarbageCollection(TestCase):
         # self.assertEqual(len(taurus.Factory().tango_auths), 0, msg)
 
     def test_device(self):
+        old_len = len(self.factory.tango_devs)
+
         def create():
-            taurus.Device("sys/tg_test/1")
+            taurus.Device(self.DEV_NAME)
+
         create()
         msg = "factory is polluted with device"
-        self.assertEqual(len(taurus.Factory().tango_devs), 0, msg)
+        self.assertEqual(len(self.factory.tango_devs), old_len, msg)
 
     def test_attribute(self):
+        old_len = len(self.factory.tango_attrs)
+
         def create():
-            taurus.Attribute("sys/tg_test/1/state")
+            taurus.Attribute(self.DEV_NAME + "/state")
+
         create()
         msg = "factory is polluted with attribute"
-        self.assertEqual(len(taurus.Factory().tango_attrs), 0, msg)
+        self.assertEqual(len(self.factory.tango_attrs), old_len, msg)
+
+    def tearDown(self):
+        self.factory = None

--- a/lib/taurus/core/tango/test/test_tangofactory.py
+++ b/lib/taurus/core/tango/test/test_tangofactory.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+
+#############################################################################
+##
+# This file is part of Taurus
+##
+# http://taurus-scada.org
+##
+# Copyright 2011 CELLS / ALBA Synchrotron, Bellaterra, Spain
+##
+# Taurus is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+##
+# Taurus is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+##
+# You should have received a copy of the GNU Lesser General Public License
+# along with Taurus.  If not, see <http://www.gnu.org/licenses/>.
+##
+#############################################################################
+
+"""Tests for taurus.core.tango.tangofactory"""
+
+
+import taurus
+
+from taurus.external.unittest import TestCase
+
+
+class TestFactoryGarbageCollection(TestCase):
+
+    def test_authority(self):
+        def create():
+            taurus.Authority()
+        create()
+        msg = "factory is polluted with authority "
+        # TODO: uncomment this line whenever TangoFactory starts recycling
+        # authorities
+        # self.assertEqual(len(taurus.Factory().tango_auths), 0, msg)
+
+    def test_device(self):
+        def create():
+            taurus.Device("sys/tg_test/1")
+        create()
+        msg = "factory is polluted with device"
+        self.assertEqual(len(taurus.Factory().tango_devs), 0, msg)
+
+    def test_attribute(self):
+        def create():
+            taurus.Attribute("sys/tg_test/1/state")
+        create()
+        msg = "factory is polluted with attribute"
+        self.assertEqual(len(taurus.Factory().tango_attrs), 0, msg)

--- a/lib/taurus/core/tango/test/test_tangofactory.py
+++ b/lib/taurus/core/tango/test/test_tangofactory.py
@@ -28,7 +28,7 @@
 
 import taurus
 
-from taurus.external.unittest import TestCase, expectedFailure
+from taurus.external.unittest import TestCase
 from taurus.core.tango.test.tgtestds import TangoSchemeTestLauncher
 
 
@@ -41,7 +41,6 @@ class TestFactoryGarbageCollection(TangoSchemeTestLauncher, TestCase):
     def setUp(self):
         self.factory = taurus.Factory()
 
-    @expectedFailure
     def test_authority(self):
         old_len = len(self.factory.tango_db)
 
@@ -50,7 +49,8 @@ class TestFactoryGarbageCollection(TangoSchemeTestLauncher, TestCase):
 
         create()
         msg = "factory is polluted with authority "
-        self.assertEqual(len(self.factory.tango_db), old_len, msg)
+        # Uncomment this line whenever tango factory recycles authority
+        # self.assertEqual(len(self.factory.tango_db), old_len, msg)
 
     def test_device(self):
         old_len = len(self.factory.tango_devs)


### PR DESCRIPTION
This tests demonstrate #846, so they should fail currently.