### PR TITLE
Set TANGO_SERIALIZATION_MODE to TangoSerial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,8 +47,8 @@ develop branch) won't be reflected in this file.
 ### Added
 - Support fragment-based slicing of attributes ([TEP15])
 - New serialization mode in which events are serialized by a Taurus
-  internal queue (the former "Serial" mode that was tango-centric is
-  now deprecated and renamed "TangoSerial") (#738)
+  internal queue (the former "Serial" mode that was tango-centric has
+  been renamed to "TangoSerial") (#738)
 
 ### Changed
 - Serialization mode now is explicitly set to Serial in the case

--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -613,9 +613,6 @@ class TangoAttribute(TaurusAttribute):
            ):
             sm = self._serialization_mode
             if sm == TaurusSerializationMode.TangoSerial:
-                self.deprecated(dep='TaurusSerializationMode.TangoSerial mode',
-                                alt='TaurusSerializationMode.Serial',
-                                rel='4.3.2')
                 self.__fireRegisterEvent((listener,))
             else:
                 Manager().enqueueJob(self.__fireRegisterEvent,
@@ -820,9 +817,6 @@ class TangoAttribute(TaurusAttribute):
             listeners = tuple(self._listeners)
             sm = self._serialization_mode
             if sm == TaurusSerializationMode.TangoSerial:
-                self.deprecated(dep='TaurusSerializationMode.TangoSerial mode',
-                                alt="TaurusSerializationMode.Serial",
-                                rel='4.3.2')
                 self.fireEvent(etype, evalue, listeners=listeners)
             else:
                 manager.enqueueJob(self.fireEvent, job_args=(etype, evalue),

--- a/lib/taurus/core/tango/tangofactory.py
+++ b/lib/taurus/core/tango/tangofactory.py
@@ -114,7 +114,7 @@ class TangoFactory(Singleton, TaurusFactory, Logger):
         self.scheme = 'tango'
         self._serialization_mode = TaurusSerializationMode.get(
             getattr(tauruscustomsettings, 'TANGO_SERIALIZATION_MODE',
-                    'Serial'))
+                    'TangoSerial'))
 
     def reInit(self):
         """Reinitialize the singleton"""

--- a/lib/taurus/tauruscustomsettings.py
+++ b/lib/taurus/tauruscustomsettings.py
@@ -93,8 +93,8 @@ EXTRA_SCHEME_MODULES = []
 pass
 
 #: Default serialization mode **for the tango scheme**. Possible values are:
-#: 'Serial' (default), 'Concurrent', or 'TangoSerial' (deprecated)
-TANGO_SERIALIZATION_MODE = 'Serial'
+#: 'Serial', 'Concurrent', or 'TangoSerial' (default)
+TANGO_SERIALIZATION_MODE = 'TangoSerial'
 
 #: PLY (lex/yacc) optimization: 1=Active (default) , 0=disabled.
 #: Set PLY_OPTIMIZE = 0 if you are getting yacc exceptions while loading


### PR DESCRIPTION
Set the default TANGO_SERIALIZATION_MODE to TangoSerial
and remove deprecation warnings.

With this change the notification keeps the same behavior
than the previous Release.