### PR TITLE
fix for syntax error

### DIFF
--- a/lib/taurus/external/qt/QtWidgets.py
+++ b/lib/taurus/external/qt/QtWidgets.py
@@ -88,7 +88,7 @@ elif PYQT4:
 
 elif PYSIDE:
     __log.warning('Using QtWidgets with PySide is not supported and may fail '
-                  + 'in many cases. Use at your own risk
+                  + 'in many cases. Use at your own risk '
                   + '(or use a Qt5 binding)')
     from PySide.QtGui import *
     QStyleOptionViewItem = QStyleOptionViewItemV4


### PR DESCRIPTION
Hi,

When I try to install new taurus I get 
```
removing '/home/jkotan/testinst/lib/python2.7/site-packages/taurus-4.5.0a0-py2.7.egg' (and everything under it)
creating /home/jkotan/testinst/lib/python2.7/site-packages/taurus-4.5.0a0-py2.7.egg
Extracting taurus-4.5.0a0-py2.7.egg to /home/jkotan/testinst/lib/python2.7/site-packages
  File "/home/jkotan/testinst/lib/python2.7/site-packages/taurus-4.5.0a0-py2.7.egg/taurus/external/qt/QtWidgets.py", line 91
    + 'in many cases. Use at your own risk
                                         ^
SyntaxError: EOL while scanning string literal

```