### PR TITLE
Fix Tango authority did not manage connection failures

### DIFF
--- a/lib/taurus/core/tango/tangodatabase.py
+++ b/lib/taurus/core/tango/tangodatabase.py
@@ -683,7 +683,8 @@ class TangoAuthority(TaurusAuthority):
             self.dbObj = Database(host, port)
         except Exception as e:
             from taurus import warning
-            warning(e)
+            warning("Cannot connect with Tango DB: %r", e)
+            self.dbObj = None
 
         self._dbProxy = None
         self._dbCache = None

--- a/lib/taurus/core/tango/tangodatabase.py
+++ b/lib/taurus/core/tango/tangodatabase.py
@@ -679,8 +679,12 @@ class TangoAuthority(TaurusAuthority):
 
         # Set host to fqdn
         host = socket.getfqdn(host)
+        try:
+            self.dbObj = Database(host, port)
+        except Exception as e:
+            from taurus import warning
+            warning(e)
 
-        self.dbObj = Database(host, port)
         self._dbProxy = None
         self._dbCache = None
 


### PR DESCRIPTION
If the tango database did not exist or it can not be reacheable
the TangoAuthority returns None instead of an object.

Fix it, catching possible exceptions during PyTango Database creation.

Fix #853