### PR TITLE
Print exception message only instead of the whole repr when error while loading settings

### DIFF
--- a/lib/taurus/qt/qtgui/container/taurusmainwindow.py
+++ b/lib/taurus/qt/qtgui/container/taurusmainwindow.py
@@ -641,7 +641,7 @@ class TaurusMainWindow(Qt.QMainWindow, TaurusBaseContainer):
             ba = settings.value("TaurusConfig") or Qt.QByteArray()
             self.applyQConfig(ba)
         except Exception as e:
-            msg = 'Problem loading configuration from "%s". Some settings may not be restored.\n Details: %s' % (
+            msg = 'Problem loading configuration from "%s". Some settings may not be restored.\nDetails: %s' % (
                 str(settings.fileName()), e)
             self.error(msg)
             Qt.QMessageBox.warning(

--- a/lib/taurus/qt/qtgui/container/taurusmainwindow.py
+++ b/lib/taurus/qt/qtgui/container/taurusmainwindow.py
@@ -642,7 +642,7 @@ class TaurusMainWindow(Qt.QMainWindow, TaurusBaseContainer):
             self.applyQConfig(ba)
         except Exception as e:
             msg = 'Problem loading configuration from "%s". Some settings may not be restored.\n Details: %s' % (
-                str(settings.fileName()), repr(e))
+                str(settings.fileName()), e)
             self.error(msg)
             Qt.QMessageBox.warning(
                 self, 'Error Loading settings', msg, Qt.QMessageBox.Ok)

--- a/lib/taurus/qt/qtgui/container/taurusmainwindow.py
+++ b/lib/taurus/qt/qtgui/container/taurusmainwindow.py
@@ -641,8 +641,10 @@ class TaurusMainWindow(Qt.QMainWindow, TaurusBaseContainer):
             ba = settings.value("TaurusConfig") or Qt.QByteArray()
             self.applyQConfig(ba)
         except Exception as e:
-            msg = 'Problem loading configuration from "%s". Some settings may not be restored.\nDetails: %s' % (
-                str(settings.fileName()), e)
+            msg = ('Problem loading configuration from "{}". '
+                   + 'Some settings may not be restored.\n'
+                   + ' Reason: {}'
+                   ).format(str(settings.fileName()), e)
             self.error(msg)
             Qt.QMessageBox.warning(
                 self, 'Error Loading settings', msg, Qt.QMessageBox.Ok)


### PR DESCRIPTION
This is a cosmetic and trivial change. I think it helps in the readability of the error message.