### PR TITLE
Avoid infinite recursion in TangoDevice.__getattr__

### DIFF
--- a/lib/taurus/core/tango/tangodevice.py
+++ b/lib/taurus/core/tango/tangodevice.py
@@ -75,7 +75,7 @@ class TangoDevice(TaurusDevice):
     # This way we can call for example read_attribute on an object of this
     # class
     def __getattr__(self, name):
-        if self._deviceObj is not None:
+        if name != "_deviceObj" and self._deviceObj is not None:
             return getattr(self._deviceObj, name)
         cls_name = self.__class__.__name__
         raise AttributeError("'%s' has no attribute '%s'" % (cls_name, name))


### PR DESCRIPTION
In some cases (it manifest from time to time in Sardana spock
[sardana-org/sardana#1035](https://github.com/sardana-org/sardana/issues/1035)) we get maximum recursion errors, most probably
because self._deviceObj is not yet assigned (maybe in the middle of the
TangoDevice object construction). Avoid this type of errors what most
probably will fallback into AttributeError.