### PR TITLE
Allow disable some TaurusGui parts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,14 @@ develop branch) won't be reflected in this file.
   (experimental) `"taurus.qt.qtgui.panel.TaurusModelSelector.items"` entry point (#869)
 - `TaurusFactory.getValidatorFromName` method
 - `getValidatorFromName` helper
+- New options API for TaurusMainWindow and TaurusGui (#858)
 
 ### Deprecated
 - `TaurusAttribute._(un)subscribeEvents` API
 - `TaurusBaseComponent` "taurus popup menu" API (#906)
-
+- `TaurusMainWindow` old option names (`_heartbeat`, `_show*Menu`, `_showLogger`, `_supportUserPerspectives`, 
+  `_splashLogo`, `_splashMessage`) 
+  
 ## [4.5.1] - 2019-02-15
 
 Together with [4.5.0], they cover the [Jan19 milestone](https://github.com/taurus-org/taurus/milestone/12)

--- a/doc/source/tep/TEP14.md
+++ b/doc/source/tep/TEP14.md
@@ -230,6 +230,6 @@ Changes
 [mrosanes](https://github.com/sagiss/) Adapt TEP format and URL according TEP16
 
 2019-04-03
-[mrosanes](https://github.com/cpascual/) Update outdated sf.net links
+[cpascual](https://github.com/cpascual/) Update outdated sf.net links
 
 [TEP3]: http://www.taurus-scada.org/tep?TEP3.md

--- a/doc/source/tep/TEP14.md
+++ b/doc/source/tep/TEP14.md
@@ -158,7 +158,7 @@ Summary of API changes
 
 The deprecations introduced by this proposal can be identified in the code by the use of the `@tep14_deprecation` decorator and the calls to the `deprecated` function with the `rel='tep14'` argument.
 
-The [Taurus4-API_changes](https://sourceforge.net/p/tauruslib/wiki/Taurus4-API_changes/) document is an attempt to explicitly list all the changes (it is not considered part of this TEP because it is likely to be modified to include more comments or missing changes)
+The [Taurus4-API_changes](http://taurus-scada.org/devel/taurus3to4.html#api-changes) document is an attempt to explicitly list all the changes (it is not considered part of this TEP because it is likely to be modified to include more comments or missing changes)
 
 
 Links to more details and discussions
@@ -215,18 +215,21 @@ Changes
 
 
 2015-04-28
-[cpascual](http://sf.net/u/cpascual/) First draft based on parts moved from [TEP3][] and previous discussions with [tiagocoutinho](http://sf.net/u/tiagocoutinho/), [cfalcon](https://sf.net/u/cmft/) and [zreszela](http://sf.net/u/zreszela/)
+[cpascual](https://github.com/cpascual/) First draft based on parts moved from [TEP3][] and previous discussions with [tiagocoutinho](http://sf.net/u/tiagocoutinho/), [cfalcon](https://sf.net/u/cmft/) and [zreszela](http://sf.net/u/zreszela/)
 
 2015-11-23
-[cpascual](http://sf.net/u/cpascual/) Implementation proposal uploaded to taurus4-preview branch of official repo
+[cpascual](https://github.com/cpascual/) Implementation proposal uploaded to taurus4-preview branch of official repo
 
 2016-03-11
-[cpascual](http://sf.net/u/cpascual/) Completed missing sections, rewritted existing ones and passed to CANDIDATE
+[cpascual](https://github.com/cpascual/) Completed missing sections, rewritted existing ones and passed to CANDIDATE
 
 2016-03-16
-[cpascual](http://sf.net/u/cpascual/) Passing to  ACCEPTED
+[cpascual](https://github.com/cpascual/) Passing to  ACCEPTED
 
 2016-11-16
 [mrosanes](https://github.com/sagiss/) Adapt TEP format and URL according TEP16
+
+2016-11-16
+[mrosanes](https://github.com/cpascual/) Adapt TEP format and URL according TEP16
 
 [TEP3]: http://www.taurus-scada.org/tep?TEP3.md

--- a/doc/source/tep/TEP14.md
+++ b/doc/source/tep/TEP14.md
@@ -229,7 +229,7 @@ Changes
 2016-11-16
 [mrosanes](https://github.com/sagiss/) Adapt TEP format and URL according TEP16
 
-2016-11-16
-[mrosanes](https://github.com/cpascual/) Adapt TEP format and URL according TEP16
+2019-04-03
+[mrosanes](https://github.com/cpascual/) Update outdated sf.net links
 
 [TEP3]: http://www.taurus-scada.org/tep?TEP3.md

--- a/lib/taurus/qt/qtgui/container/taurusmainwindow.py
+++ b/lib/taurus/qt/qtgui/container/taurusmainwindow.py
@@ -253,7 +253,7 @@ class TaurusMainWindow(Qt.QMainWindow, TaurusBaseContainer):
         self.helpManualBrowser = None
 
         if self.HELP_MENU_ENABLED:
-        self.resetHelpManualURI()
+            self.resetHelpManualURI()
 
         # Heartbeat
         if self.HEARTBEAT is not None:
@@ -290,9 +290,9 @@ class TaurusMainWindow(Qt.QMainWindow, TaurusBaseContainer):
 
         # View Toolbar
         if self.FULLSCREEN_TOOLBAR_ENABLED:
-        self.viewToolBar = self.addToolBar("View")
-        self.viewToolBar.setObjectName("viewToolBar")
-        self.viewToolBar.addAction(self.toggleFullScreenAction)
+            self.viewToolBar = self.addToolBar("View")
+            self.viewToolBar.setObjectName("viewToolBar")
+            self.viewToolBar.addAction(self.toggleFullScreenAction)
 
         # Perspectives Toolbar
         if self.USER_PERSPECTIVES_ENABLED:

--- a/lib/taurus/qt/qtgui/taurusgui/taurusgui.py
+++ b/lib/taurus/qt/qtgui/taurusgui/taurusgui.py
@@ -214,7 +214,7 @@ class DockWidgetPanel(Qt.QDockWidget, TaurusBaseWidget):
 
 
 class TaurusGui(TaurusMainWindow):
-    '''
+    """
     This is main class for constructing the dynamic GUIs. TaurusGui is a
     specialised TaurusMainWindow which is able to handle "panels" and load
     configuration files.
@@ -272,7 +272,7 @@ class TaurusGui(TaurusMainWindow):
             gui.show()
             app.exec_()
 
-    '''
+    """
 
     SelectedInstrument = Qt.pyqtSignal('QString')
     doorNameChanged = Qt.pyqtSignal('QString')
@@ -281,20 +281,12 @@ class TaurusGui(TaurusMainWindow):
 
     IMPLICIT_ASSOCIATION = '__[IMPLICIT]__'
 
-    ENABLED_SHARE_DATA_CONNECTIONS = True
-
-    # Menus
-    ENABLE_PANELS_MENU = True
-    ENABLE_TOOLS_MENU = True
-    ENABLE_TAURUS_MENU = True
-
-    # ToolBars
-    ENABLE_APPLETS_TOOLBAR = True
-    ENABLE_FULLSCREEN_TOOLBAR = True
-    ENABLE_PERSPECTIVE_TOOLBAR = True
-    ENABLE_QUICK_ACCESS_TOOLBAR = True
-
-    ENABLE_USER_PERSPECTIVES = True
+    #: Whether to show user actions related to shared data connections
+    PANELS_MENU_ENABLED = True
+    #: Whether to show the applets toolbar
+    APPLETS_TOOLBAR_ENABLED = True
+    #: wether to add the Quick access Toolbar (empty by default)
+    QUICK_ACCESS_TOOLBAR_ENABLED = True
 
     def __init__(self, parent=None, confname=None, configRecursionDepth=None):
         TaurusMainWindow.__init__(self, parent, False, True)
@@ -327,19 +319,29 @@ class TaurusGui(TaurusMainWindow):
         # Create a global SharedDataManager
         Qt.qApp.SDM = SharedDataManager(self)
 
-        if self.ENABLE_PANELS_MENU:
+        # Initialize menus & toolbars
+        if self.PANELS_MENU_ENABLED:
             self.__initPanelsMenu()
             self.__initPanelsToolBar()
-        if self.ENABLE_QUICK_ACCESS_TOOLBAR:
+        if self.QUICK_ACCESS_TOOLBAR_ENABLED:
             self.__initQuickAccessToolBar()
-        if self.ENABLE_APPLETS_TOOLBAR:
+        if self.APPLETS_TOOLBAR_ENABLED:
             self.__initJorgBar()
-        if self.ENABLED_SHARE_DATA_CONNECTIONS:
-            self.__initSharedDataConnections()
-        if self.ENABLE_TOOLS_MENU:
+
+        self.__initSharedDataConnections()
+
+        if self.TOOLS_MENU_ENABLED:
             self.__initToolsMenu()
 
-        self.__initViewMenu()
+        # Create lockview actions
+        self._lockviewAction = Qt.QAction(Qt.QIcon.fromTheme(
+            "system-lock-screen"), "Lock View", self)
+        self._lockviewAction.setCheckable(True)
+        self._lockviewAction.toggled.connect(self.setLockView)
+        self._lockviewAction.setChecked(not self.isModifiableByUser())
+
+        if self.VIEW_MENU_ENABLED:
+            self.__initViewMenu()
 
         self.loadConfiguration(confname)
 
@@ -391,7 +393,11 @@ class TaurusGui(TaurusMainWindow):
     def __initPanelsMenu(self):
         # Panels menu
         self.__panelsMenu = Qt.QMenu('Panels', self)
-        self.menuBar().insertMenu(self.helpMenu.menuAction(), self.__panelsMenu)
+        try:  # insert the panels menu before the help menu
+            self.menuBar().insertMenu(self.helpMenu.menuAction(),
+                                      self.__panelsMenu)
+        except AttributeError:  # Or just add it if help menu is not shown
+            self.menuBar().addMenu(self.__panelsMenu)
         self.hideAllPanelsAction = self.__panelsMenu.addAction(
             Qt.QIcon('actions:hide.svg'), "Hide all panels", self.hideAllPanels)
         self.showAllPanelsAction = self.__panelsMenu.addAction(
@@ -421,11 +427,6 @@ class TaurusGui(TaurusMainWindow):
         self.viewMenu.addSeparator()
         # view locking
         self.viewMenu.addSeparator()
-        self._lockviewAction = Qt.QAction(Qt.QIcon.fromTheme(
-            "system-lock-screen"), "Lock View", self)
-        self._lockviewAction.setCheckable(True)
-        self._lockviewAction.toggled.connect(self.setLockView)
-        self._lockviewAction.setChecked(not self.isModifiableByUser())
         self.viewMenu.addAction(self._lockviewAction)
 
     def __initPanelsToolBar(self):
@@ -433,15 +434,18 @@ class TaurusGui(TaurusMainWindow):
         self.panelsToolBar = self.addToolBar("Panels")
         self.panelsToolBar.setObjectName("PanelsToolbar")
         self.panelsToolBar.addAction(self.newPanelAction)
-        self.viewToolBarsMenu.addAction(self.panelsToolBar.toggleViewAction())
+        if self.VIEW_MENU_ENABLED:
+            self.viewToolBarsMenu.addAction(self.panelsToolBar.toggleViewAction())
 
     def __initQuickAccessToolBar(self):
         self.quickAccessToolBar = self.addToolBar("Quick Access")
         self.quickAccessToolBar.setObjectName("quickAccessToolbar")
         self.quickAccessToolBar.setToolButtonStyle(
             Qt.Qt.ToolButtonTextBesideIcon)
-        self.viewToolBarsMenu.addAction(
-            self.quickAccessToolBar.toggleViewAction())
+        if self.VIEW_MENU_ENABLED:
+            self.viewToolBarsMenu.addAction(
+                self.quickAccessToolBar.toggleViewAction()
+            )
 
     def __initJorgBar(self):
         # Fancy Stuff ToolBar (aka Jorg's Bar ;) )
@@ -871,8 +875,10 @@ class TaurusGui(TaurusMainWindow):
         synopticpanel = self.createPanel(synoptic, name, permanent=True,
                                          icon=Qt.QIcon.fromTheme(
                                              'image-x-generic'))
-        toggleSynopticAction = synopticpanel.toggleViewAction()
-        self.quickAccessToolBar.addAction(toggleSynopticAction)
+
+        if self.QUICK_ACCESS_TOOLBAR_ENABLED:
+            toggleSynopticAction = synopticpanel.toggleViewAction()
+            self.quickAccessToolBar.addAction(toggleSynopticAction)
 
     def createConsole(self, kernels):
         msg = ('createConsole() and the "CONSOLE" configuration key are ' +
@@ -1094,7 +1100,7 @@ class TaurusGui(TaurusMainWindow):
         self.setWindowTitle(APPNAME)
         self.setWindowIcon(customIcon)
 
-        if self.ENABLE_APPLETS_TOOLBAR:
+        if self.APPLETS_TOOLBAR_ENABLED:
             self.jorgsBar.addAction(organizationIcon, ORGNAME)
             self.jorgsBar.addAction(customIcon, APPNAME)
 
@@ -1115,8 +1121,9 @@ class TaurusGui(TaurusMainWindow):
                                                   taurus.Release.url))
         self.setHelpManualURI(MANUAL_URI)
 
-        self.createPanel(self.helpManualBrowser, 'Manual', permanent=True,
-                         icon=Qt.QIcon.fromTheme('help-browser'))
+        if self.HELP_MENU_ENABLED:
+            self.createPanel(self.helpManualBrowser, 'Manual', permanent=True,
+                             icon=Qt.QIcon.fromTheme('help-browser'))
 
         # configure the macro infrastructure
         MACROSERVER_NAME = getattr(conf, 'MACROSERVER_NAME', self.__getVarFromXML(
@@ -1361,10 +1368,14 @@ class TaurusGui(TaurusMainWindow):
             panel.toggleViewAction().setEnabled(modifiable)
             panel.setFeatures(dwfeat)
 
-        if self.ENABLE_PANELS_MENU:
+        if self.PANELS_MENU_ENABLED:
             for action in (self.newPanelAction, self.showAllPanelsAction,
                            self.hideAllPanelsAction,
-                           self.addExternalApplicationAction,
+                        ):
+                action.setEnabled(modifiable)
+
+        if self.TOOLS_MENU_ENABLED:
+            for action in (self.addExternalApplicationAction,
                            self.removeExternalApplicationAction,
                         ):
                 action.setEnabled(modifiable)
@@ -1688,4 +1699,3 @@ def main(confname=None):
 
 if __name__ == "__main__":
     main()
-    # xmlTest()


### PR DESCRIPTION
The purpose of this PR is to lighten TaurusGui, allowing disabling programmatically parts of the TaurusGui not needed.

### TaurusGui class attributes added:

#### The bar on the right:
_enableJorgsBar(True)_: allow to disable the JorgsBar.

#### For tool bars:
_enableFullScreenToolBar(True)_: Allow to disable the FullScreen tool bar.
_enablePerspectivesToolBar(True)_: Allow to disable the perspectives tool bar.
_enableQuickAccessToolBar(True)_: Allow to disable the Quick Access tool bar.

Disabling all of these toolbars, the TaurusGui upper toolbar disappears.

#### For menus:
_enablePanelsMenu(True)_: Allow to disable the "panel" menu in the gui.
_enableViewMenu(True)_: Allow to disable the "view" menu in the gui.
_enableTaurusMenu(True)_: Allow to disable the "Taurus" menu in the gui.

#### Others:
_enableSharedDataConnections(True)_: Allow to disable the Shared Data connections procedure.
