### PR TITLE
Avoid redundant display of units in TaurusForm (Fixes #642)

### DIFF
--- a/lib/taurus/qt/qtgui/panel/taurusvalue.py
+++ b/lib/taurus/qt/qtgui/panel/taurusvalue.py
@@ -204,6 +204,15 @@ class CenteredLed(TaurusLed):
     DefaultAlignment = Qt.Qt.AlignHCenter | Qt.Qt.AlignVCenter
 
 
+class UnitLessLineEdit(TaurusValueLineEdit):
+    """A customised TaurusValueLineEdit that always shows the magnitude"""
+    def setModel(self, model):
+        if model is None or model == '':
+            return TaurusValueLineEdit.setModel(self, None)
+        return TaurusValueLineEdit.setModel(self, model + "#wvalue.magnitude")
+
+
+
 class DefaultUnitsWidget(TaurusLabel):
 
     FORMAT = "{}"
@@ -587,20 +596,20 @@ class TaurusValue(Qt.QWidget, TaurusBaseWidget):
         modelobj = self.getModelObj()
         if modelobj is None:
             if returnAll:
-                return [TaurusValueLineEdit]
+                return [UnitLessLineEdit]
             else:
-                return TaurusValueLineEdit
+                return UnitLessLineEdit
         modelType = modelobj.getType()
         if modelobj.data_format == DataFormat._0D:
             if modelType == DataType.Boolean:
                 result = [DefaultTaurusValueCheckBox, TaurusValueLineEdit]
             else:
-                result = [TaurusValueLineEdit,
+                result = [UnitLessLineEdit,
                           TaurusValueSpinBox, TaurusWheelEdit]
         elif modelobj.data_format == DataFormat._1D:
             if modelType in (DataType.Float, DataType.Integer):
                 result = [TaurusArrayEditorButton,
-                          TaurusValuesTableButton_W, TaurusValueLineEdit]
+                          TaurusValuesTableButton_W, UnitLessLineEdit]
             else:
                 result = [TaurusValuesTableButton_W, TaurusValueLineEdit]
         elif modelobj.data_format == DataFormat._2D:

--- a/lib/taurus/qt/qtgui/panel/test/test_taurusvalue.py
+++ b/lib/taurus/qt/qtgui/panel/test/test_taurusvalue.py
@@ -36,9 +36,7 @@ DEV_NAME = TangoSchemeTestLauncher.DEV_NAME
 
 @insertTest(helper_name="texts",
             model="tango:" + DEV_NAME + "/double_scalar",
-            expected=("double_scalar", "1.23", "0.00 mm", "mm"),
-            # expected=("double_scalar", "1.23", "0.0", "mm"),
-            # TODO: change taurusvalue's line edit to hide units
+            expected=("double_scalar", "1.23", "0.0", "mm")
             )
 class TaurusValueTest(TangoSchemeTestLauncher, BaseWidgetTestCase,
                       unittest.TestCase):

--- a/lib/taurus/qt/qtgui/panel/test/test_taurusvalue.py
+++ b/lib/taurus/qt/qtgui/panel/test/test_taurusvalue.py
@@ -36,7 +36,7 @@ DEV_NAME = TangoSchemeTestLauncher.DEV_NAME
 
 @insertTest(helper_name="texts",
             model="tango:" + DEV_NAME + "/double_scalar",
-            expected=("double_scalar", "1.23", "0.0", "mm")
+            expected=("double_scalar", "1.23", "0.00", "mm")
             )
 class TaurusValueTest(TangoSchemeTestLauncher, BaseWidgetTestCase,
                       unittest.TestCase):


### PR DESCRIPTION
TaurusForm uses TaurusValueLineEdit as a default write widget.
If the attribute is a numeric scalar, this shows the magnitude and the
units, which is redundant since the units are already displayed in the
units widget. Replace the default line edit in TarusValue by a
customized version that displays only the magnitude.

This is a (quick and dirty) fix for #642