### PR TITLE
Taurus model selector

### DIFF
--- a/lib/taurus/qt/qtgui/panel/taurusmodelchooser.py
+++ b/lib/taurus/qt/qtgui/panel/taurusmodelchooser.py
@@ -43,7 +43,9 @@ from taurus.core.util.containers import CaselessList
 from .taurusmodellist import TaurusModelList
 
 __all__ = ["TaurusModelSelectorTree", "TaurusModelChooser",
-           "TaurusModelSelector", "TaurusModelSelectorItem"]
+           "TaurusModelSelector", "TaurusModelSelectorItem",
+           "TangoModelSelectorItem"]
+
 
 class TaurusModelSelector(Qt.QTabWidget):
     """TaurusModelSelector is a QTabWidget container for
@@ -134,10 +136,13 @@ class TaurusModelSelectorItem(TaurusWidget):
     # Reimplement this property
     default_model = property(fget=_get_default_model, fset=_set_default_model)
 
+
+class TaurusModelSelectorTree(TaurusModelSelectorItem):
+
     addModels = Qt.pyqtSignal('QStringList')
 
     def __init__(self, parent=None, selectables=None, buttonsPos=None, designMode=None):
-        TaurusWidget.__init__(self, parent)
+        TaurusModelSelectorItem.__init__(self, parent)
         if selectables is None:
             selectables = [taurus.core.taurusbasetypes.TaurusElementType.Attribute, taurus.core.taurusbasetypes.TaurusElementType.Member,
                            taurus.core.taurusbasetypes.TaurusElementType.Device]
@@ -227,6 +232,34 @@ class TaurusModelSelectorItem(TaurusWidget):
         ret['container'] = False
         ret['group'] = 'Taurus Views'
         return ret
+
+
+class TangoModelSelectorItem(TaurusModelSelectorTree):
+    """A taurus model selector item for Tango models
+    """
+    # TODO: Tango-centric (move to Taurus-Tango plugin)
+    def __init__(self, parent=None, selectables=None,
+                 buttonsPos=Qt.Qt.RightToolBarArea, designMode=None):
+        TaurusModelSelectorTree.__init__(
+            self, parent=parent, selectables=selectables,
+            buttonsPos=buttonsPos, designMode=designMode)
+
+    def onAddSelected(self):
+        """
+        Reimplemented from TaurusModelSelectorTree to emit modelsAdded
+        signal instead of addModels
+        """
+        self.modelsAdded.emit(self.getSelectedModels())
+
+    def _get_default_model(self):
+        """Reimplemented from TaurusModelSelectorItem"""
+        if self._default_model is None:
+            f = taurus.Factory('tango')
+            self._default_model = f.getAuthority().getFullName()
+        return self._default_model
+
+    default_model = property(fget=_get_default_model,
+                             fset=TaurusModelSelectorTree._set_default_model)
 
 
 class TaurusModelChooser(TaurusWidget):

--- a/lib/taurus/qt/qtgui/panel/taurusmodelchooser.py
+++ b/lib/taurus/qt/qtgui/panel/taurusmodelchooser.py
@@ -43,8 +43,7 @@ from taurus.core.util.containers import CaselessList
 from .taurusmodellist import TaurusModelList
 
 __all__ = ["TaurusModelSelectorTree", "TaurusModelChooser",
-           "TaurusModelSelector", "TaurusModelSelectorItem",
-           "TangoModelSelectorItem"]
+           "TaurusModelSelector", "TaurusModelSelectorItem"]
 
 
 class TaurusModelSelector(Qt.QTabWidget):
@@ -79,11 +78,15 @@ class TaurusModelSelector(Qt.QTabWidget):
 
     def __setTabItemModel(self):
         w = self.currentWidget()
-        if w.model == "":
-            self.setCursor(QtCore.Qt.WaitCursor)
-            print(w)
-            w.setModel(w.default_model)
-            self.setCursor(QtCore.Qt.ArrowCursor)
+        c = self.cursor()
+        try:
+            if not w.model:
+                self.setCursor(QtCore.Qt.WaitCursor)
+                w.setModel(w.default_model)
+        except Exception as e:
+            taurus.warning('Problem setting up selector: %r', e)
+        finally:
+            w.setCursor(c)
 
     def __addItem(self, widget, name, model=None):
         if model is not None:

--- a/setup.py
+++ b/setup.py
@@ -111,6 +111,8 @@ console_scripts = [
 ]
 
 entry_points = {'console_scripts': console_scripts,
+                'taurus.qt.qtgui.panel.TaurusModelSelector.items':
+                    ['Tango = taurus.qt.qtgui.panel:TangoModelSelectorItem',]
 }
 
 classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -110,10 +110,13 @@ console_scripts = [
     # TODO: taurusdoc,
 ]
 
-entry_points = {'console_scripts': console_scripts,
-                'taurus.qt.qtgui.panel.TaurusModelSelector.items':
-                    [('Tango = taurus.qt.qtgui.panel.taurusmodelchooser:'
-                      + 'TangoModelSelectorItem'),]
+model_selectors = [
+    'Tango = taurus.qt.qtgui.panel.taurusmodelchooser:TangoModelSelectorItem',
+]
+
+entry_points = {
+    'console_scripts': console_scripts,
+    'taurus.qt.qtgui.panel.TaurusModelSelector.items': model_selectors,
 }
 
 classifiers = [

--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,8 @@ console_scripts = [
 
 entry_points = {'console_scripts': console_scripts,
                 'taurus.qt.qtgui.panel.TaurusModelSelector.items':
-                    ['Tango = taurus.qt.qtgui.panel:TangoModelSelectorItem',]
+                    [('Tango = taurus.qt.qtgui.panel.taurusmodelchooser:'
+                      + 'TangoModelSelectorItem'),]
 }
 
 classifiers = [


### PR DESCRIPTION
This PR add new base classes to Taurus: TaurusModelSelector and TaurusModelSelectorItem
And implement the TangoModelSelectorItem specialization.

The TaurusModelSelector class defines an entry point where the ModelSelectorItem specialization can be registered via entry point (EP).

This EP is described in TEP13: https://github.com/taurus-org/taurus/blob/develop/doc/source/tep/TEP13.md#the-taurusmodelchooser-widget-support-for-non-tango-schemes
