### PR TITLE
 Remove _{un,}subscribeEvents API in TaurusAttribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ develop branch) won't be reflected in this file.
 - `TaurusModelSelector` and `TaurusModelSelectorItem` classes and the
   (experimental) `"taurus.qt.qtgui.panel.TaurusModelSelector.items"` entry point (#869)
 
+### Deprecated
+- `TaurusAttribute._(un)subscribeEvents` API
 
 ## [4.5.1] - 2019-02-15
 

--- a/lib/taurus/core/epics/epicsattribute.py
+++ b/lib/taurus/core/epics/epicsattribute.py
@@ -226,14 +226,6 @@ class EpicsAttribute(TaurusAttribute):
 
     def isUsingEvents(self):
         return True  # TODO: implement this
-
-    def _subscribeEvents(self):
-        raise NotImplementedError("Not allowed to call AbstractClass" +
-                                  " TaurusAttribute._subscribeEvents")
-
-    def _unsubscribeEvents(self):
-        raise NotImplementedError("Not allowed to call AbstractClass" +
-                                  " TaurusAttribute._unsubscribeEvents")
 # ------------------------------------------------------------------------------
 
     def factory(self):

--- a/lib/taurus/core/evaluation/evalattribute.py
+++ b/lib/taurus/core/evaluation/evalattribute.py
@@ -445,12 +445,6 @@ class EvaluationAttribute(TaurusAttribute):
         v = self.read(cache=False)
         self.fireEvent(TaurusEventType.Periodic, v)
 
-    def _subscribeEvents(self):
-        pass
-
-    def _unsubscribeEvents(self):
-        pass
-
     def isUsingEvents(self):
         # if this attributes depends from others, then we consider it uses
         # events

--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -324,6 +324,7 @@ class TangoAttribute(TaurusAttribute):
     def cleanUp(self):
         self.trace("[TangoAttribute] cleanUp")
         self._unsubscribeConfEvents()
+        self._unsubscribeChangeEvents()
         TaurusAttribute.cleanUp(self)
         self.__dev_hw_obj = None
         self._pytango_attrinfoex = None
@@ -600,7 +601,7 @@ class TangoAttribute(TaurusAttribute):
         assert len(listeners) >= 1
 
         if self.__subscription_state == SubscriptionState.Unsubscribed and len(listeners) == 1:
-            self._subscribeEvents()
+            self._subscribeChangeEvents()
 
         # if initial_subscription_state == SubscriptionState.Subscribed:
         if (len(listeners) > 1
@@ -630,7 +631,7 @@ class TangoAttribute(TaurusAttribute):
             return ret
 
         if self.__subscription_state != SubscriptionState.Unsubscribed:
-            self._unsubscribeEvents()
+            self._unsubscribeChangeEvents()
 
         return ret
 
@@ -654,7 +655,7 @@ class TangoAttribute(TaurusAttribute):
     def _process_event_exception(self, ex):
         pass
 
-    def _subscribeEvents(self):
+    def _subscribeChangeEvents(self):
         """ Enable subscription to the attribute events. If change events are
             not supported polling is activated """
             
@@ -705,7 +706,7 @@ class TangoAttribute(TaurusAttribute):
         
         return self.__chg_evt_id
                 
-    def _unsubscribeEvents(self):
+    def _unsubscribeChangeEvents(self):
         # Careful in this method: This is intended to be executed in the cleanUp
         # so we should not access external objects from the factory, like the
         # parent object

--- a/lib/taurus/core/taurusattribute.py
+++ b/lib/taurus/core/taurusattribute.py
@@ -79,7 +79,11 @@ class TaurusAttribute(TaurusModel):
 
     def cleanUp(self):
         self.trace("[TaurusAttribute] cleanUp")
-        self._unsubscribeEvents()
+        if hasattr(self, '_unsuscribeEvents'):
+            self.deprecated(
+                dep='TaurusAttribute._unsuscribeEvents API',
+                alt='If you need it called in cleanUp, re-implement cleanUp')
+            self._unsuscribeEvents()
         TaurusModel.cleanUp(self)
 
     #-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-
@@ -145,14 +149,6 @@ class TaurusAttribute(TaurusModel):
     def poll(self):
         raise NotImplementedError("Not allowed to call AbstractClass" +
                                   " TaurusAttribute.poll")
-
-    def _subscribeEvents(self):
-        raise NotImplementedError("Not allowed to call AbstractClass" +
-                                  " TaurusAttribute._subscribeEvents")
-
-    def _unsubscribeEvents(self):
-        raise NotImplementedError("Not allowed to call AbstractClass" +
-                                  " TaurusAttribute._unsubscribeEvents")
 
     def isUsingEvents(self):
         raise NotImplementedError("Not allowed to call AbstractClass" +


### PR DESCRIPTION
The TaurusAttribute. _{un,}subscribeEvents API is a leftover of Tango
implementation. Remove it maintaining backwards comp.
    
Clean tango, epics and eval schemes usage of these API.
    
Equivalent changes to h5py, pandas, and tgarch schemes will be done in
their respective repos.