### PR TITLE
Add method next

### DIFF
--- a/lib/taurus/core/util/containers.py
+++ b/lib/taurus/core/util/containers.py
@@ -498,6 +498,8 @@ class LoopList(object):
         self._index += 1
         return self.current()
 
+    next = __next__
+
     def previous(self):
         '''goes one item back in the list and returns it'''
         self._index -= 1


### PR DESCRIPTION
Add method next, which was removed when the code was adapted
to python3.

'next' is needed, as it is used in other code parts, including
other related projects as taurus-pyqtgraph.