### PR TITLE
Fix bytes/str issues in dropMimeData methods

### DIFF
--- a/lib/taurus/qt/qtgui/extra_guiqwt/curvesmodel.py
+++ b/lib/taurus/qt/qtgui/extra_guiqwt/curvesmodel.py
@@ -30,6 +30,7 @@ curvesmodel Model and view for new CurveItem configuration
 from __future__ import print_function
 from builtins import next
 from builtins import str
+from builtins import bytes
 from builtins import range
 from builtins import object
 
@@ -320,11 +321,12 @@ class TaurusCurveItemTableModel(Qt.QAbstractTableModel):
             else:
                 column = parent.columnCount()
         if data.hasFormat(TAURUS_ATTR_MIME_TYPE):
-            self.setData(self.index(row, column),
-                         value=str(data.data(TAURUS_ATTR_MIME_TYPE)))
+            model = bytes(data.data(TAURUS_ATTR_MIME_TYPE)).decode("utf-8")
+            self.setData(self.index(row, column), value=model)
             return True
         elif data.hasFormat(TAURUS_MODEL_LIST_MIME_TYPE):
-            models = str(data.data(TAURUS_MODEL_LIST_MIME_TYPE)).split()
+            d = bytes(data.data(TAURUS_MODEL_LIST_MIME_TYPE))
+            models = d.decode("utf-8").split()
             if len(models) == 1:
                 self.setData(self.index(row, column), value=models[0])
                 return True

--- a/lib/taurus/qt/qtgui/panel/taurusmodellist.py
+++ b/lib/taurus/qt/qtgui/panel/taurusmodellist.py
@@ -27,6 +27,7 @@
 itemsmodel Model and view for new CurveItem configuration
 """
 from builtins import object
+from builtins import bytes
 #raise UnimplementedError('Under Construction!')
 
 import copy
@@ -236,11 +237,12 @@ class TaurusModelModel(Qt.QAbstractListModel):
         if row == -1 and parent.isValid():
             row = parent.row()
         if data.hasFormat(TAURUS_ATTR_MIME_TYPE):
-            items = [str(data.data(TAURUS_ATTR_MIME_TYPE))]
+            items = [bytes(data.data(TAURUS_ATTR_MIME_TYPE)).decode("utf-8")]
         elif data.hasFormat(TAURUS_MODEL_MIME_TYPE):
-            items = [str(data.data(TAURUS_MODEL_MIME_TYPE))]
+            items = [bytes(data.data(TAURUS_MODEL_MIME_TYPE)).decode("utf-8")]
         elif data.hasFormat(TAURUS_MODEL_LIST_MIME_TYPE):
-            items = str(data.data(TAURUS_MODEL_LIST_MIME_TYPE)).split()
+            items = bytes(
+                data.data(TAURUS_MODEL_LIST_MIME_TYPE)).decode("utf-8").split()
         elif data.hasText():
             items = [str(data.text())]
         else:

--- a/lib/taurus/qt/qtgui/qwt5/curveprops.py
+++ b/lib/taurus/qt/qtgui/qwt5/curveprops.py
@@ -31,6 +31,7 @@ curveprops: Model and view for curve properties
 
 from __future__ import absolute_import
 from builtins import str
+from builtins import bytes
 from builtins import object
 
 import copy
@@ -294,11 +295,12 @@ class CurvesTableModel(Qt.QAbstractTableModel):
             else:
                 column = parent.columnCount()
         if data.hasFormat(TAURUS_ATTR_MIME_TYPE):
-            self.setData(self.index(row, column),
-                         value=str(data.data(TAURUS_ATTR_MIME_TYPE)))
+            model = bytes(data.data(TAURUS_ATTR_MIME_TYPE)).decode('utf-8')
+            self.setData(self.index(row, column), value=model)
             return True
         elif data.hasFormat(TAURUS_MODEL_LIST_MIME_TYPE):
-            models = str(data.data(TAURUS_MODEL_LIST_MIME_TYPE)).split()
+            d = bytes(data.data(TAURUS_MODEL_LIST_MIME_TYPE))
+            models = d.decode('utf-8').split()
             if len(models) == 1:
                 self.setData(self.index(row, column), value=models[0])
                 return True


### PR DESCRIPTION
Various implementations of dropMimeData in Taurus do casts of
QBytesArray to str which may be dangerous in py3. Use bytes and decode
instead.

This fixes , for example, the problem that can be reproduced by opening a model chooser and trying to drag&drop attributes from the tree to the list (it works in py2 but not in py3)