### PR TITLE
Use PY_OBJECT for signal signatures

### DIFF
--- a/lib/taurus/external/qt/compat.py
+++ b/lib/taurus/external/qt/compat.py
@@ -41,4 +41,12 @@ getOpenFileName = getattr(QFileDialog, 'getOpenFileNameAndFilter',
 getOpenFileNames = getattr(QFileDialog, 'getOpenFileNamesAndFilter',
                           QFileDialog.getOpenFileNames)
 
-del QFileDialog
+# Provide a common constant for the PyObject name (to be used in signal
+# signatures)
+from taurus.external.qt import PYQT5, PYQT4
+if PYQT5 or PYQT4:
+    PY_OBJECT = 'PyQt_PyObject'
+else:
+    PY_OBJECT = 'PyObject'
+
+del QFileDialog, PYQT5, PYQT4

--- a/lib/taurus/qt/qtcore/communication/communication.py
+++ b/lib/taurus/qt/qtcore/communication/communication.py
@@ -29,7 +29,8 @@ comunications.py:
 
 from __future__ import print_function
 
-from taurus.external.qt import QtCore
+from taurus.external.qt import QtCore, compat
+
 import weakref
 
 _DEBUG = False
@@ -56,7 +57,7 @@ class DataModel(QtCore.QObject):
     DataModels are singletons.
     '''
 
-    dataChanged = QtCore.pyqtSignal(object)
+    dataChanged = QtCore.pyqtSignal(compat.PY_OBJECT)
 
     def __init__(self, parent, dataUID, defaultData=None):
         '''

--- a/lib/taurus/qt/qtgui/button/taurusbutton.py
+++ b/lib/taurus/qt/qtgui/button/taurusbutton.py
@@ -31,7 +31,7 @@ from builtins import map
 from builtins import str
 from future.utils import string_types
 
-from taurus.external.qt import Qt
+from taurus.external.qt import Qt, compat
 from taurus.core.taurusbasetypes import LockStatus, TaurusLockInfo
 from taurus.core.taurusdevice import TaurusDevice
 from taurus.qt.qtgui.base import TaurusBaseWidget
@@ -265,7 +265,7 @@ class TaurusCommandButton(Qt.QPushButton, TaurusBaseWidget):
     .. seealso:: :class:`TaurusCommandsForm` provides a good example of use of
                  TaurusCommandButton (including managing the return value) '''
     # TODO: tango-centric
-    commandExecuted = Qt.pyqtSignal(object)
+    commandExecuted = Qt.pyqtSignal(compat.PY_OBJECT)
 
     def __init__(self, parent=None, designMode=False, command=None,
                  parameters=None, icon=None, text=None,

--- a/lib/taurus/qt/qtgui/graphic/taurusgraphic.py
+++ b/lib/taurus/qt/qtgui/graphic/taurusgraphic.py
@@ -51,7 +51,7 @@ from taurus.core.util.log import Logger, deprecation_decorator
 from taurus.core.taurusdevice import TaurusDevice
 from taurus.core.taurusattribute import TaurusAttribute
 from taurus.core.util.enumeration import Enumeration
-from taurus.external.qt import Qt
+from taurus.external.qt import Qt, compat
 from taurus.qt.qtgui.base import TaurusBaseComponent
 from taurus.qt.qtgui.util import (QT_ATTRIBUTE_QUALITY_PALETTE, QT_DEVICE_STATE_PALETTE,
                                   ExternalAppAction, TaurusWidgetFactory)
@@ -110,7 +110,7 @@ def parseTangoUri(name):
 
 
 class QEmitter(Qt.QObject):
-    updateView = Qt.pyqtSignal(object)
+    updateView = Qt.pyqtSignal(compat.PY_OBJECT)
 
 
 class TaurusGraphicsUpdateThread(Qt.QThread):

--- a/lib/taurus/qt/qtgui/model/qbasemodel.py
+++ b/lib/taurus/qt/qtgui/model/qbasemodel.py
@@ -32,7 +32,7 @@ __all__ = ["QBaseModelWidget", "TaurusBaseModelWidget",
 
 __docformat__ = 'restructuredtext'
 
-from taurus.external.qt import Qt
+from taurus.external.qt import Qt, compat
 
 from taurus.qt.qtgui.util import ActionFactory
 from taurus.qt.qtgui.base import TaurusBaseWidget
@@ -275,10 +275,10 @@ class QBaseModelWidget(Qt.QMainWindow):
     KnownPerspectives = {}
     DftPerspective = None
 
-    itemClicked = Qt.pyqtSignal(object, int)
-    itemDoubleClicked = Qt.pyqtSignal(object, int)
+    itemClicked = Qt.pyqtSignal(compat.PY_OBJECT, int)
+    itemDoubleClicked = Qt.pyqtSignal(compat.PY_OBJECT, int)
     itemSelectionChanged = Qt.pyqtSignal()
-    currentItemChanged = Qt.pyqtSignal(object, object)
+    currentItemChanged = Qt.pyqtSignal(compat.PY_OBJECT, compat.PY_OBJECT)
 
     def __init__(self, parent=None, designMode=False, with_filter_widget=True,
                  with_selection_widget=True, with_refresh_widget=True,

--- a/lib/taurus/qt/qtgui/qwt5/curvesAppearanceChooserDlg.py
+++ b/lib/taurus/qt/qtgui/qwt5/curvesAppearanceChooserDlg.py
@@ -34,7 +34,7 @@ from __future__ import print_function
 from builtins import object
 import copy
 
-from taurus.external.qt import Qt, Qwt5
+from taurus.external.qt import Qt, Qwt5, compat
 from taurus.core.util.containers import CaselessDict
 from taurus.qt.qtgui.util.ui import UILoadable
 
@@ -106,7 +106,7 @@ class CurvesAppearanceChooser(Qt.QWidget):
     NAME_ROLE = Qt.Qt.UserRole
 
     controlChanged = Qt.pyqtSignal()
-    curveAppearanceChanged = Qt.pyqtSignal(object, list)
+    curveAppearanceChanged = Qt.pyqtSignal(compat.PY_OBJECT, list)
     CurveTitleEdited = Qt.pyqtSignal('QString', 'QString')
 
     def __init__(self, parent=None, curvePropDict={}, showButtons=False, autoApply=False, designMode=False):


### PR DESCRIPTION
Some signals use `object` in their signatures, but this may be
problematic when `object` is imported from builtins (futurize module), 
as in the following example:

```python
from builtins import object  # <-- if this is uncommented, the emit fails in py2 with "argument 1 has unexpected type 'tuple'"

from taurus.external.qt import Qt, compat


class B(Qt.QPushButton):
    s = Qt.pyqtSignal(object) 
    # s = Qt.pyqtSignal(compat.PY_OBJECT)  # <-- using this instead of the previous line fixes the issue and is Qt-binding agnostic...

    def __init__(self):
        super(B, self).__init__()
        self.clicked.connect(self.on_click)
        self.s.connect(self.on_s)
        self.setText("CLICK ME")

    def on_click(self):
        # (!) this emit does not match the signature in py2 if object was imported from builtins
        self.s.emit((1,2,3))  

    def on_s(self, a):
        print(a)


if __name__ == '__main__':
    import sys
    app = Qt.QApplication([])
    w = B()
    w.resize(300,300)
    w.show()
sys.exit(app.exec_())
```

To avoid it, create a new variable  `PY_OBJECT` in `taurus.external.qt.compat` wich takes value 'PyQt_PyObject' in PyQt or 'PyObject' in PySide/PySide2 and use it instead of `object` in all signatures.