### PR TITLE
Add a getValidatorFromName method in TaurusFactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ develop branch) won't be reflected in this file.
 ### Added
 - `TaurusModelSelector` and `TaurusModelSelectorItem` classes and the
   (experimental) `"taurus.qt.qtgui.panel.TaurusModelSelector.items"` entry point (#869)
+- `TaurusFactory.getValidatorFromName` method
+- `getValidatorFromName` helper
 
 ### Deprecated
 - `TaurusAttribute._(un)subscribeEvents` API

--- a/lib/taurus/core/taurusfactory.py
+++ b/lib/taurus/core/taurusfactory.py
@@ -397,18 +397,15 @@ class TaurusFactory(object):
         return ret
 
     def getValidatorFromName(self, name):
-        """ Obtain the validator object corresponding to the given model
+        """
+        Obtain the validator object corresponding to the given model
         name. If the model name is not valid for any TaurusModel class,
-        it returns None"""
-        objclass = self.findObjectClass(name)
-        if issubclass(objclass, TaurusAttribute):
-            return self.getAttributeNameValidator()
-        elif issubclass(objclass, TaurusDevice):
-            return self.getDeviceNameValidator()
-        elif issubclass(objclass, TaurusAuthority):
-            return self.getAttributeNameValidator()
-        else:
+        it returns None
+        """
+        modeltypes = self.getValidTypesForName(name)
+        if not modeltypes:
             return None
+        return self.elementTypesMap[modeltypes[0]].getNameValidator()
 
     def findObjectClass(self, absolute_name):
         """

--- a/lib/taurus/core/taurusfactory.py
+++ b/lib/taurus/core/taurusfactory.py
@@ -396,6 +396,20 @@ class TaurusFactory(object):
             ret.append(TaurusElementType.Authority)
         return ret
 
+    def getValidatorFromName(self, name):
+        """ Obtain the validator object corresponding to the given model
+        name. If the model name is not valid for any TaurusModel class,
+        it returns None"""
+        objclass = self.findObjectClass(name)
+        if issubclass(objclass, TaurusAttribute):
+            return self.getAttributeNameValidator()
+        elif issubclass(objclass, TaurusDevice):
+            return self.getDeviceNameValidator()
+        elif issubclass(objclass, TaurusAuthority):
+            return self.getAttributeNameValidator()
+        else:
+            return None
+
     def findObjectClass(self, absolute_name):
         """
         Obtain the class object corresponding to the given name.

--- a/lib/taurus/core/taurushelper.py
+++ b/lib/taurus/core/taurushelper.py
@@ -137,8 +137,15 @@ def getSchemeFromName(name, implicit=True):
 
 def getValidatorFromName(name):
     """Helper for obtaining the validator object corresponding to the
-    given name"""
-    factory = Factory(scheme=getSchemeFromName(name))
+    given name.
+
+    :return: model name validator or None if name is not a supported model name
+    """
+
+    try:
+        factory = Factory(scheme=getSchemeFromName(name))
+    except:
+        return None
     return factory.getValidatorFromName(name)
 
 

--- a/lib/taurus/core/taurushelper.py
+++ b/lib/taurus/core/taurushelper.py
@@ -42,7 +42,8 @@ __all__ = ['check_dependencies', 'log_dependencies', 'getSchemeFromName',
            'resetLogLevel', 'resetLogFormat',
            'enableLogOutput', 'disableLogOutput',
            'log', 'trace', 'debug', 'info', 'warning', 'error', 'fatal',
-           'critical', 'deprecated', 'changeDefaultPollingPeriod']
+           'critical', 'deprecated', 'changeDefaultPollingPeriod',
+           'getValidatorFromName']
 
 __docformat__ = "restructuredtext"
 
@@ -132,6 +133,14 @@ def getSchemeFromName(name, implicit=True):
         return getattr(tauruscustomsettings, 'DEFAULT_SCHEME', "tango")
     else:
         return None
+
+
+def getValidatorFromName(name):
+    """Helper for obtaining the validator object corresponding to the
+    given name"""
+    factory = Factory(scheme=getSchemeFromName(name))
+    return factory.getValidatorFromName(name)
+
 
 
 def makeSchemeExplicit(name, default=None):

--- a/lib/taurus/core/test/test_taurushelper.py
+++ b/lib/taurus/core/test/test_taurushelper.py
@@ -466,5 +466,19 @@ class AttributeTestCase(unittest.TestCase):
                 self.assertTrue(chk, msg)
 
 
+class ValidatorFromName(unittest.TestCase):
+    """TestCase for the taurus.getValidatorFromName helper"""
+
+    def test_getValidatorFromName(self):
+        """check that getValidatorFromName returns the expected values"""
+
+        self.assertIsInstance(
+            taurus.getValidatorFromName('eval:@foo'),
+            taurus.core.evaluation.evalvalidator.EvaluationDeviceNameValidator
+        )
+        self.assertIsNone(taurus.getValidatorFromName('eval:@/'))
+        self.assertIsNone(taurus.getValidatorFromName('unsupported:scheme'))
+
+
 if __name__ == '__main__':
     pass


### PR DESCRIPTION
Add a new method in TaurusFactory to get the TaurusModel validator object from a model name.
Add a helper in taurushelper to get the TaurusModel validator object  from a model name.