### PR TITLE
Add unit to taurus.core `__init__.py`

### DIFF
--- a/lib/taurus/core/init_bkcomp.py
+++ b/lib/taurus/core/init_bkcomp.py
@@ -42,6 +42,7 @@ from .taurusmanager import *
 from .taurusoperation import *
 from .tauruspollingtimer import *
 from .taurusvalidator import *
+from .units import *
 
 # enable compatibility code with tau V1 if tauv1 package is present
 try:

--- a/lib/taurus/core/units.py
+++ b/lib/taurus/core/units.py
@@ -27,6 +27,7 @@ This module provides a pint unit registry instance (`UR`) to be used by all
 taurus objects. It also provides the `Quantity` factory from that registry
 (also aliased as `Q_`).
 """
+__all__ = ['UR', 'Quantity', 'Q_']
 
 from pint import UnitRegistry
 


### PR DESCRIPTION
The `taurus.core.units` module is not imported in `taurus.core` and
therefore it does not appear in the API docs. Import it.