### PR TITLE
Fix isValidName helper

### DIFF
--- a/lib/taurus/core/taurushelper.py
+++ b/lib/taurus/core/taurushelper.py
@@ -200,7 +200,7 @@ def isValidName(name, etypes=None, strict=None):
     for e in etypes:
         if e in validtypes:
             return True
-        return False
+    return False
 
 
 def Manager():


### PR DESCRIPTION
According the doc if `etypes` is passed, it returns True
only if name is valid for at least one of the given the
element types.

The method returns false when several `etypes` are given
if the first does not match.

Fix it.