### PR TITLE
Remove "taurus popup menu" feature and deprecate its API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ develop branch) won't be reflected in this file.
 
 ### Deprecated
 - `TaurusAttribute._(un)subscribeEvents` API
+- `TaurusBaseComponent` "taurus popup menu" API (#906)
 
 ## [4.5.1] - 2019-02-15
 

--- a/lib/taurus/qt/qtgui/container/taurusmainwindow.py
+++ b/lib/taurus/qt/qtgui/container/taurusmainwindow.py
@@ -272,6 +272,13 @@ class TaurusMainWindow(Qt.QMainWindow, TaurusBaseContainer):
         self.configurationAction.setEnabled(
             self.configurationDialog._tabwidget.count())
 
+    def contextMenuEvent(self, event):
+        """Reimplemented to avoid deprecation warning related to:
+        https://github.com/taurus-org/taurus/issues/905
+        """
+        # TODO: Remove this once the deprecation of the Popup menu is enforced
+        event.ignore()
+
     def addLoggerWidget(self, hidden=True):
         '''adds a QLoggingWidget as a dockwidget of the main window (and hides it by default)'''
         from taurus.qt.qtgui.table import QLoggingWidget


### PR DESCRIPTION
The default implementation of contextMenuEvent shows
the content of `self.taurusMenu` as a context menu. But this results in
buggy behaviour when the widget already implements its own context
menu (see #905 ).

Disable this feature and deprecate the "taurus popup menu" API.

The old behaviour can still be attained by explicitly reimplementing
the contextMenuEvent method as:
````python
   def contextMenuEvent(self, event):
       self.taurusMenu.exec_(event.globalPos())
```

Fixes #905
