### PR TITLE
Avoid depending on tango for taurusgui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ develop branch) won't be reflected in this file.
 - `TaurusMainWindow` old option names (`_heartbeat`, `_show*Menu`, `_showLogger`, `_supportUserPerspectives`, 
   `_splashLogo`, `_splashMessage`) 
   
+### Fixed
+- taurusgui does not run if tango not installed (#912)
+  
 ## [4.5.1] - 2019-02-15
 
 Together with [4.5.0], they cover the [Jan19 milestone](https://github.com/taurus-org/taurus/milestone/12)

--- a/lib/taurus/qt/qtgui/taurusgui/appsettingswizard.py
+++ b/lib/taurus/qt/qtgui/taurusgui/appsettingswizard.py
@@ -50,7 +50,6 @@ from taurus.external.qt import Qt, compat
 import taurus.qt.qtgui.panel
 import taurus.qt.qtgui.taurusgui.paneldescriptionwizard
 import taurus.qt.qtgui.input
-from taurus.core.tango.tangovalidator import TangoDeviceNameValidator
 from taurus.core.util.enumeration import Enumeration
 from taurus.qt.qtgui.util import ExternalAppAction
 
@@ -726,6 +725,8 @@ class MacroServerInfoPage(BasePage):
 
     def _getMacroServerName(self):
         if (self._macroGroupBox.isChecked()) and len(self._confWidget.macroServerComboBox.currentText()):
+            from taurus.core.tango.tangovalidator import (
+                TangoDeviceNameValidator)
             ms_name = str(self._confWidget.macroServerComboBox.currentText())
             complete_name, _, _ = TangoDeviceNameValidator().getNames(ms_name)
             return complete_name
@@ -735,6 +736,8 @@ class MacroServerInfoPage(BasePage):
     def _getDoorName(self):
         if (self._macroGroupBox.isChecked()) and len(self._confWidget.macroServerComboBox.currentText()):
             door_name = str(self._confWidget.doorComboBox.currentText())
+            from taurus.core.tango.tangovalidator import (
+                TangoDeviceNameValidator)
             complete_name, _, _ = TangoDeviceNameValidator().getNames(
                 door_name)
             return complete_name

--- a/lib/taurus/qt/qtgui/taurusgui/appsettingswizard.py
+++ b/lib/taurus/qt/qtgui/taurusgui/appsettingswizard.py
@@ -45,7 +45,7 @@ import datetime
 import glob
 from lxml import etree
 
-from taurus import tauruscustomsettings
+from taurus import tauruscustomsettings, warning
 from taurus.external.qt import Qt, compat
 import taurus.qt.qtgui.panel
 import taurus.qt.qtgui.taurusgui.paneldescriptionwizard
@@ -725,8 +725,12 @@ class MacroServerInfoPage(BasePage):
 
     def _getMacroServerName(self):
         if (self._macroGroupBox.isChecked()) and len(self._confWidget.macroServerComboBox.currentText()):
-            from taurus.core.tango.tangovalidator import (
-                TangoDeviceNameValidator)
+            try: # TODO: tango-centric
+                from taurus.core.tango.tangovalidator import (
+                    TangoDeviceNameValidator)
+            except ImportError:
+                warning('Cannot import tango (needed for sardana integration)')
+                return None
             ms_name = str(self._confWidget.macroServerComboBox.currentText())
             complete_name, _, _ = TangoDeviceNameValidator().getNames(ms_name)
             return complete_name
@@ -736,8 +740,12 @@ class MacroServerInfoPage(BasePage):
     def _getDoorName(self):
         if (self._macroGroupBox.isChecked()) and len(self._confWidget.macroServerComboBox.currentText()):
             door_name = str(self._confWidget.doorComboBox.currentText())
-            from taurus.core.tango.tangovalidator import (
-                TangoDeviceNameValidator)
+            try: # TODO: tango-centric
+                from taurus.core.tango.tangovalidator import (
+                    TangoDeviceNameValidator)
+            except ImportError:
+                warning('Cannot import tango (needed for sardana integration)')
+                return None
             complete_name, _, _ = TangoDeviceNameValidator().getNames(
                 door_name)
             return complete_name


### PR DESCRIPTION
taurusgui fails to import if tango is not installed due to an import
of TangoDeviceNameValidator in appsettingswizard.py . Fix it by delaying
the import.

Fixes #911