### PR TITLE
Fix write TangoAttribute short spectrum

### DIFF
--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -417,6 +417,8 @@ class TangoAttribute(TaurusAttribute):
                 attrvalue = str(magnitude)
         elif fmt in (DataFormat._1D, DataFormat._2D):
             if PyTango.is_int_type(tgtype):
+                if not isinstance(magnitude, numpy.ndarray):
+                    magnitude = numpy.array(magnitude)
                 # cast to integer because the magnitude conversion gives floats
                 attrvalue = magnitude.astype('int64')
             elif tgtype == PyTango.CmdArgType.DevUChar:

--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -417,10 +417,8 @@ class TangoAttribute(TaurusAttribute):
                 attrvalue = str(magnitude)
         elif fmt in (DataFormat._1D, DataFormat._2D):
             if PyTango.is_int_type(tgtype):
-                if not isinstance(magnitude, numpy.ndarray):
-                    magnitude = numpy.array(magnitude)
                 # cast to integer because the magnitude conversion gives floats
-                attrvalue = magnitude.astype('int64')
+                attrvalue = numpy.array(magnitude, copy=False, dtype='int64')
             elif tgtype == PyTango.CmdArgType.DevUChar:
                 attrvalue = magnitude.view('uint8')
             else:


### PR DESCRIPTION
The TangoAttribute of short spectrum type fails when using a
list as input argument of the write method.

The encode method assumes internal use of numpy array
to do a cast and it raises an AttributeError exception when
it is not a numpy array.

Fix #914