### PR TITLE
Update tests in travis (due to debian buster release)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ env:
     - secure: "CCVtBQ8xIrOwUJGXxd81wyD1ng72Hf6d9y2U+5X88aVGTrOa8/hut10C+Jmnyf0NTZmGh/49eVvoWRvLDhjpECFMuO/bLkiNtVjz0VtWAHT2W98QJYmeymPzx86tGa+iAZCwlgXeRQFJCw1eqQvBYnjumMZWb9kj3fqgpqpSRH5SWnuRCmbxOoelmtTTUC8YKkzasAHYs03faR0DCq0oBmDy9nU2cfcRN7oE5wXUfEnDwNaoHbiQA4wiJbzNpBV432bIDtzD7gsFdiIT6ExJVFHi1gWB32bGZdbiDPpej7I2fW5qunbzUXS5doVhoBU67qqhI241RJ+AOBVb+sQnF8gwwi9/5/mcORiSBX7yI59YsOXYwo2YW+8PGr3OlF3t0+z92Q3uPytUXysdtVO4dExnLbV8OEzgmWCkv2M3GIajjE3isYAaBItqSBJHJnRClza4nNg2WLwmqLPBgM4AuSUZEpB/8kbz9kTecVEb13WrlTCNc8KVRGR+EGa4KmWADwOOxurxeb/NsTteOnzdyfrP2TXKeGOkN2uqBGYJaI7OoefsgLG7VF/+Sz4MTETMs/gZojwpO6igKBS1sJlcXujz/kt125b8gcSnrAiU1TjbZIBew/D40H64tpBcuk+dqF6i6HCoV2QmZ1QEpHOSoDk9FEaKMlgKhQj59/cWcI8="
 
   matrix:
-  - DOCKER_IMG=cpascual/taurus-test:debian-jessie
   - DOCKER_IMG=cpascual/taurus-test:debian-stretch
   - DOCKER_IMG=cpascual/taurus-test:debian-buster
   - DOCKER_IMG=cpascual/taurus-test:debian-stretch-py3
@@ -24,9 +23,7 @@ env:
 
 matrix:
     allow_failures:
-        - env: DOCKER_IMG=cpascual/taurus-test:debian-jessie
         - env: DOCKER_IMG=cpascual/taurus-test:debian-stretch-py3
-        - env: DOCKER_IMG=cpascual/taurus-test:debian-buster
 
 before_install:
   - docker run -d --name=taurus-test -h taurus-test --volume=`pwd`:/taurus $DOCKER_IMG


### PR DESCRIPTION
Debian 10 (buster) release is announced for the 6th of july 2019. 
Update our test matrix accordingly:
- Stop testing for debian 8 (jessie)
- Continue testing for debian 9 (stretch)
- Do not allow failures for debian 10 (buster)