### PR TITLE
Add protection in _updateValidator

### DIFF
--- a/lib/taurus/qt/qtgui/input/tauruslineedit.py
+++ b/lib/taurus/qt/qtgui/input/tauruslineedit.py
@@ -89,7 +89,7 @@ class TaurusValueLineEdit(Qt.QLineEdit, TaurusBaseWritableWidget):
     def _updateValidator(self, value):
         """This method sets a validator depending on the data type"""
         val = None
-        if isinstance(value.wvalue, Quantity):
+        if value is not None and isinstance(value.wvalue, Quantity):
             val = self.validator()
             if not isinstance(val, PintValidator):
                 val = PintValidator(self)


### PR DESCRIPTION
TaurusValueLineEdit._updateValidator method raises an AttributeError
when it is call with a `None` argument.

Fix it, checking that the given argument is not `None`.