### PR TITLE
Accept unknown kwargs in taurus mixin class constructors

### DIFF
--- a/lib/taurus/qt/qtcore/configuration/configuration.py
+++ b/lib/taurus/qt/qtcore/configuration/configuration.py
@@ -137,7 +137,7 @@ class BaseConfigurableClass(object):
     # the latest element of this list is considered the current version
     _supportedConfigVersions = ("__UNVERSIONED__",)
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         self.resetConfigurableItems()
 
     @staticmethod

--- a/lib/taurus/qt/qtgui/base/taurusbase.py
+++ b/lib/taurus/qt/qtgui/base/taurusbase.py
@@ -110,7 +110,7 @@ class TaurusBaseComponent(TaurusListener, BaseConfigurableClass):
 
     taurusEvent = baseSignal('taurusEvent', object, object, object)
 
-    def __init__(self, name='', parent=None, designMode=False):
+    def __init__(self, name='', parent=None, designMode=False, **kwargs):
         """Initialization of TaurusBaseComponent"""
         self.modelObj = None
         self.modelName = ''
@@ -1335,7 +1335,7 @@ class TaurusBaseWidget(TaurusBaseComponent):
 
     _dragEnabled = False
 
-    def __init__(self, name='', parent=None, designMode=False):
+    def __init__(self, name='', parent=None, designMode=False, **kwargs):
         self._disconnect_on_hide = False
         self._supportedMimeTypes = None
         self._autoTooltip = True
@@ -1939,7 +1939,8 @@ class TaurusBaseWritableWidget(TaurusBaseWidget):
 
     applied = baseSignal('applied')
 
-    def __init__(self, name='', taurus_parent=None, designMode=False):
+    def __init__(self, name='', taurus_parent=None, designMode=False,
+                 **kwargs):
         self.call__init__(TaurusBaseWidget, name,
                           parent=taurus_parent, designMode=designMode)
 


### PR DESCRIPTION
BaseConfigurableClass, TaurusBaseComponent, TaurusBaseWidget and TaurusBaseWritableWidget are used as mixin classes, mostly with QtObject-derived classes.

In order to support cooperative multiple inheritance with the super() statement, they need to be able to accept unknown kwargs in their constructors. 
See: https://www.riverbankcomputing.com/static/Docs/PyQt5/multiinheritance.html

This allows the following pattern:

```python
class Foo(QObject, TaurusBaseComponent):
    def __init__(self, bar=None, **kwargs):
        super(Foo, self).__init__(**kwargs)  # <- py2+py3
        # super().__init__(**kwargs)  # <- py3 only

        self.bar = bar
```