### PR TITLE
Emit signal using new style

### DIFF
--- a/lib/taurus/qt/qtgui/panel/taurusmodellist.py
+++ b/lib/taurus/qt/qtgui/panel/taurusmodellist.py
@@ -318,6 +318,7 @@ class TaurusModelList(Qt.QListView):
     def _onDataChanged(self, *args):
         '''emits a signal containing the current data as a list of strings'''
         self.emit(Qt.SIGNAL("dataChanged"), self.getModelItems())
+        self.dataChangedSignal.emit(self.getModelItems())
         
     def contextMenuEvent(self, event):
         '''see :meth:`QWidget.contextMenuEvent`'''


### PR DESCRIPTION
TaurusModelList._onDataChanged emits the signal using old style.
It causes troubles in Sardana where the signals were adapted to new style.

Emit the signal in both modes.