### PR TITLE
Fix 929

### DIFF
--- a/lib/taurus/core/tango/tangodevice.py
+++ b/lib/taurus/core/tango/tangodevice.py
@@ -34,6 +34,7 @@ from taurus.core.taurusdevice import TaurusDevice
 from taurus.core.taurusbasetypes import (TaurusDevState, TaurusLockInfo,
                                          LockStatus, TaurusEventType)
 from taurus.core.util.log import taurus4_deprecation
+from taurus.core.tango.tangovalidator import TangoDeviceNameValidator
 
 
 __all__ = ["TangoDevice"]
@@ -206,7 +207,12 @@ class TangoDevice(TaurusDevice):
 
     def _createHWObject(self):
         try:
-            return DeviceProxy(self.getFullName())
+            v = TangoDeviceNameValidator()
+            g = v.getUriGroups(self.getFullName())
+            if g['authority'] != '//.dynamic_auth.':
+                return DeviceProxy(self.getFullName())
+            else:
+                return DeviceProxy(self.getSimpleName())
         except DevFailed as e:
             self.warning('Could not create HW object: %s' % (e.args[0].desc))
             self.traceback()

--- a/lib/taurus/core/tango/tangofactory.py
+++ b/lib/taurus/core/tango/tangofactory.py
@@ -276,7 +276,8 @@ class TangoFactory(Singleton, TaurusFactory, Logger):
         if name is None:
             if self.dft_db is None:
                 try:
-                    if self._default_tango_host is None:
+                    if (self._default_tango_host is None
+                            or self._default_tango_host == '.dynamic_auth.'):
                         self.dft_db = _Authority()
                     else:
                         name = self._default_tango_host

--- a/lib/taurus/core/tango/test/test_tangovalidator.py
+++ b/lib/taurus/core/tango/test/test_tangovalidator.py
@@ -48,8 +48,13 @@ __TANGO_HOST = "{0}:{1}".format(socket.getfqdn(host), port)
 # Tests for Tango Authority  name validation
 #=========================================================================
 @valid(name='tango://foo:10000')
+@valid(name='tango://foo:10000,foo:20000')
+@valid(name='tango://.dynamic_auth.')
 @invalid(name='tango:foo')
+@invalid(name='tango:foo,')
 @invalid(name='tango:foo:10000')
+@invalid(name='tango://foo:10000,')
+@invalid(name='tango://foo:10000,bar')
 @invalid(name='tango://foo:10000/')
 @invalid(name='tango://foo:10000/?')
 @invalid(name='tango://foo:bar')


### PR DESCRIPTION
Support Tango multi db URIs using a reserved work `.dynamic_auth.` to indicate taurus that the authority is to be resolved dynamically by PyTango.