### PR TITLE
Relax TaurusDevPanel state checking

### DIFF
--- a/lib/taurus/qt/qtgui/panel/taurusdevicepanel.py
+++ b/lib/taurus/qt/qtgui/panel/taurusdevicepanel.py
@@ -589,7 +589,7 @@ class TaurusDevPanel(TaurusGui):
         dev = self.getModelObj()
         state = dev.state
         # test the connection
-        if state == TaurusDevState.Ready:
+        if state != TaurusDevState.Undefined:
             msg = 'Connected to "%s"' % devname
             self.statusBar().showMessage(msg)
             self._ui.attrDW.setWindowTitle('Attributes - %s' % devname)

--- a/lib/taurus/qt/qtgui/panel/taurusdevicepanel.py
+++ b/lib/taurus/qt/qtgui/panel/taurusdevicepanel.py
@@ -584,24 +584,9 @@ class TaurusDevPanel(TaurusGui):
 
     def setDevice(self, devname):
         """set the device to be shown by the commands and attr forms"""
-        # try to connect with the device
         self.setModel(devname)
-        dev = self.getModelObj()
-        state = dev.state
-        # test the connection
-        if state != TaurusDevState.Undefined:
-            msg = 'Connected to "%s"' % devname
-            self.statusBar().showMessage(msg)
-            self._ui.attrDW.setWindowTitle('Attributes - %s' % devname)
-            self._ui.commandsDW.setWindowTitle('Commands - %s' % devname)
-        else:
-            # reset the model if the connection failed
-            msg = 'Connection to "%s" failed (state = %s)' % (devname,
-                                                              state.name)
-            self.statusBar().showMessage(msg)
-            self.info(msg)
-            Qt.QMessageBox.warning(self, "Device unreachable", msg)
-            self.setModel('')
+        self._ui.attrDW.setWindowTitle('Attributes - %s' % devname)
+        self._ui.commandsDW.setWindowTitle('Commands - %s' % devname)
 
     def setModel(self, name):
         """Reimplemented to delegate model to the commands and attrs forms"""

--- a/lib/taurus/qt/qtgui/panel/taurusform.py
+++ b/lib/taurus/qt/qtgui/panel/taurusform.py
@@ -867,7 +867,7 @@ class TaurusAttrForm(TaurusWidget):
         '''Populates the form with an item for each of the attributes shown
         '''
         dev = self.getModelObj()
-        if dev is None or dev.state != TaurusDevState.Ready:
+        if dev is None or dev.state == TaurusDevState.Undefined:
             self.debug('Cannot connect to device')
             self._form.setModel([])
             return

--- a/lib/taurus/qt/qtgui/panel/taurusform.py
+++ b/lib/taurus/qt/qtgui/panel/taurusform.py
@@ -866,21 +866,22 @@ class TaurusAttrForm(TaurusWidget):
     def _updateAttrWidgets(self):
         '''Populates the form with an item for each of the attributes shown
         '''
-        dev = self.getModelObj()
-        if dev is None or dev.state == TaurusDevState.Undefined:
+        try:
+            dev = self.getModelObj()
+            attrlist = sorted(dev.attribute_list_query(), key=self._sortKey)
+            for f in self.getViewFilters():
+                attrlist = list(filter(f, attrlist))
+            attrnames = []
+            devname = self.getModelName()
+            for a in attrlist:
+                # ugly hack . But setUseParentModel does not work well
+                attrnames.append("%s/%s" % (devname, a.name))
+            self.debug('Filling with attribute list: %s'
+                       % ("; ".join(attrnames)))
+            self._form.setModel(attrnames)
+        except:
             self.debug('Cannot connect to device')
             self._form.setModel([])
-            return
-        attrlist = sorted(dev.attribute_list_query(), key=self._sortKey)
-        for f in self.getViewFilters():
-            attrlist = list(filter(f, attrlist))
-        attrnames = []
-        devname = self.getModelName()
-        for a in attrlist:
-            # ugly hack . But setUseParentModel does not work well
-            attrnames.append("%s/%s" % (devname, a.name))
-        self.debug('Filling with attribute list: %s' % ("; ".join(attrnames)))
-        self._form.setModel(attrnames)
 
     def setViewFilters(self, filterlist):
         '''sets the filters to be applied when displaying the attributes


### PR DESCRIPTION
TaurusDevPanel is not able to show attributes and command panels
of given device if it is not in `Ready` state.

This is not coherence with other tools such Jive and Taurus form.

Show these panels in TaurusDevPanel unless the state is `Undefined`.

Fix #882