### PR TITLE
Fix cyclic import when importing TaurusGui

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -56,7 +56,8 @@ def _build_doc_api():
     auto_rst4api = imp.load_module(name, *data)
     API_Creator = auto_rst4api.Auto_rst4API_Creator
     # prepare api creator
-    excl = ['_[^\.]*[^_]',
+    excl = ['.*\._[^\.]+[^_]',  # exclude private objects
+            '.*\.(object|zip|str)',  # avoid warnings from builtins
             '.*\.test',
             'taurus\.external',
             'taurus\.qt\.qtgui\.extra_sardana',
@@ -64,11 +65,11 @@ def _build_doc_api():
             'taurus\.qt\.qtgui\.extra_macroexecutor',
             'taurus\.qt\.qtgui\.resource',
             'taurus\.qt\.qtgui\.taurusgui\.conf',
+            'taurus\.qt\.qtgui\.qwt5\.taurusplotconf',  # Under Construction
             ]
     if sys.version_info.major > 2:
         excl += [
             'taurus\.qt\.qtgui\.qwt5',  # qwt5 not available in PY3
-            '.*\.(object|zip|str)',  # avoid warnings from builtins
             ]
 
     rstCreator = API_Creator(exclude_patterns=excl,
@@ -298,8 +299,8 @@ inheritance_graph_attrs = dict(rankdir="UD", ratio='compress')
 
 intersphinx_mapping = {
     'python': ('https://docs.python.org/dev', None),
-    'numpy': ('http://www.numpy.org', None),
+    'numpy': ('https://numpy.org', 'numpy.inv'),  # work around err 403
     'sardana': ('https://sardana-controls.org', None),
-    'pint': ('http://pint.readthedocs.io/en/stable/', None),
-    'PyTango': ('http://pytango.readthedocs.io/en/stable/', None),
+    'pint': ('https://pint.readthedocs.io/en/stable/', None),
+    'PyTango': ('https://pytango.readthedocs.io/en/stable/', None),
 }

--- a/doc/source/numpy.inv
+++ b/doc/source/numpy.inv
@@ -1,0 +1,5 @@
+# Sphinx inventory version 2
+# Project: NumPy
+# Version: 
+# The remainder of this file is compressed using zlib.
+xÚuŽË‚0D÷ýŠ&ºÅÄ­;ãÊ…J¢{R{¯@ìƒPšÈß´…ÖÇªÍÌœ;Ãµ”VÕ]OM;Ðœf[Êƒ¸©:)è­Bz¶2ïƒp­Àò.¥&É1.Ð€T?†w²J°;ŠOnµþC–¨jøJÑ ºÎãø%KÌïŠÓm"jŽÊ`œñR¼ÝKIz.Žóóæ@H?¶6}WsÒ`úÕZ@ÁÚ–õEÃø“•hâyß®;q€-ÝÍ½C²–Wi¹Ótu~>„É>ç´î

--- a/lib/taurus/core/resource/resvalidator.py
+++ b/lib/taurus/core/resource/resvalidator.py
@@ -29,8 +29,8 @@ from taurus.core.taurusvalidator import (TaurusAttributeNameValidator,
                                          TaurusAuthorityNameValidator)
 from taurus.core.taurushelper import getSchemeFromName, Factory
 
-__all__ = ['ResDeviceNameValidator',
-           'ResAttributeNameValidator']
+__all__ = ['ResourceAuthorityNameValidator', 'ResourceDeviceNameValidator',
+           'ResourceAttributeNameValidator']
 
 # Pattern for python variables
 PY_VAR = r'(?<![\.a-zA-Z0-9_])[a-zA-Z_][a-zA-Z0-9_]*'

--- a/lib/taurus/core/util/console.py
+++ b/lib/taurus/core/util/console.py
@@ -34,8 +34,7 @@ __docformat__ = "restructuredtext"
 
 def make_color_table(in_class, use_name=False, fake=False):
     """Build a set of color attributes in a class.
-
-    Helper function for building the *TermColors classes."""
+    Helper function for building the TermColors classes."""
     color_templates = (
         ("Black", "0;30"),
         ("Red", "0;31"),

--- a/lib/taurus/core/util/constant.py
+++ b/lib/taurus/core/util/constant.py
@@ -69,5 +69,7 @@ class _consttype(object):
     def __del__(self):
         self.__dict__.clear()
 
-import sys
-sys.modules[__name__] = _consttype()
+
+if __name__ == '__main__':
+    import sys
+    sys.modules[__name__] = _consttype()

--- a/lib/taurus/core/util/decorator/__init__.py
+++ b/lib/taurus/core/util/decorator/__init__.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+
+#############################################################################
+##
+# This file is part of Taurus
+##
+# http://taurus-scada.org
+##
+# Copyright 2011 CELLS / ALBA Synchrotron, Bellaterra, Spain
+##
+# Taurus is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+##
+# Taurus is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+##
+# You should have received a copy of the GNU Lesser General Public License
+# along with Taurus.  If not, see <http://www.gnu.org/licenses/>.
+##
+#############################################################################
+
+"""
+This module provides a few convenience decorators
+"""

--- a/lib/taurus/core/util/decorator/decorator.py
+++ b/lib/taurus/core/util/decorator/decorator.py
@@ -23,36 +23,10 @@
 ##
 #############################################################################
 
-"""\
-Allow to use decorator either with arguments or not. Example::
-
-    @decorator
-    def apply(func, *args, **kw):
-        return func(*args, **kw)
-
-    @decorator
-    class apply:
-        def __init__(self, *args, **kw):
-            self.args = args
-            self.kw   = kw
-
-        def __call__(self, func):
-            return func(*self.args, **self.kw)
-
-    #
-    # Usage in both cases:
-    #
-    @apply
-    def test():
-        return 'test'
-
-    assert test == 'test'
-
-    @apply(2, 3)
-    def test(a, b):
-        return a + b
-
-    assert test == 5"""
+"""
+Provides a decorator to decorate decorators so that they can be used both
+with and without args
+"""
 
 __all__ = ["decorator"]
 
@@ -63,7 +37,8 @@ import inspect
 
 
 def decorator(func):
-    """Allow to use decorator either with arguments or not. Example::
+    """
+    Allow to use decorator either with arguments or not. Example::
 
         @decorator
         def apply(func, *args, **kw):
@@ -92,6 +67,7 @@ def decorator(func):
             return a + b
 
         assert test == 5
+
     """
 
     def isFuncArg(*args, **kw):

--- a/lib/taurus/core/util/decorator/typecheck.py
+++ b/lib/taurus/core/util/decorator/typecheck.py
@@ -26,12 +26,15 @@
 """
 One of three degrees of enforcement may be specified by passing
 the 'debug' keyword argument to the decorator:
-    0 -- NONE:   No type-checking. Decorators disabled.
-    1 -- MEDIUM: Print warning message to stderr. (Default)
-    2 -- STRONG: Raise TypeError with message.
+
+    - 0 -- NONE:   No type-checking. Decorators disabled.
+    - 1 -- MEDIUM: Print warning message to stderr. (Default)
+    - 2 -- STRONG: Raise TypeError with message.
+
 If 'debug' is not passed to the decorator, the default level is used.
 
-Example usage:
+Example usage::
+
     >>> NONE, MEDIUM, STRONG = 0, 1, 2
     >>>
     >>> @accepts(int, int, int)
@@ -47,7 +50,7 @@ Example usage:
     TypeWarning:  'average' method returns (float), but result is (int)
     15
 
-Needed to cast params as floats in function def (or simply divide by 2.0).
+Needed to cast params as floats in function def (or simply divide by 2.0)::
 
     >>> TYPE_CHECK = STRONG
     >>> @accepts(int, debug=TYPE_CHECK)
@@ -71,15 +74,12 @@ __all__ = ["accepts", "returns"]
 __docformat__ = "restructuredtext"
 
 def accepts(*types, **kw):
-    """ Function decorator. Checks that inputs given to decorated function
+    """
+    Function decorator. Checks that inputs given to decorated function
     are of the expected type.
 
-    Parameters:
-    types -- The expected types of the inputs to the decorated function.
-             Must specify type for each parameter.
-    kw    -- Optional specification of 'debug' level (this is the only valid
-             keyword argument, no other should be given).
-             debug = ( 0 | 1 | 2 )
+    :param types: The expected type of the decorated function's return value
+    :param debug: Optional specification of 'debug' level (0 | 1 | 2)
 
     """
     if not kw:
@@ -111,15 +111,12 @@ def accepts(*types, **kw):
 
 
 def returns(ret_type, **kw):
-    """ Function decorator. Checks that return value of decorated function
+    """
+    Function decorator. Checks that return value of decorated function
     is of the expected type.
 
-    Parameters:
-    ret_type -- The expected type of the decorated function's return value.
-                Must specify type for each parameter.
-    kw       -- Optional specification of 'debug' level (this is the only valid
-                keyword argument, no other should be given).
-                debug=(0 | 1 | 2)
+    :param ret_type: The expected type of the decorated function's return value.
+    :param debug: Optional specification of 'debug' level (0 | 1 | 2)
 
     """
     try:

--- a/lib/taurus/core/util/event.py
+++ b/lib/taurus/core/util/event.py
@@ -106,7 +106,8 @@ def CallableRef(object, del_cb=None):
     :type del_cb: callable object or None
 
     :return: a weak reference for the given callable
-    :rtype: BoundMethodWeakref or weakref.ref"""
+    :rtype: taurus.core.util.BoundMethodWeakref or weakref.ref
+    """
     im_self = None
     if hasattr(object, '__self__'):
         im_self = object.__self__

--- a/lib/taurus/core/util/parse_args.py
+++ b/lib/taurus/core/util/parse_args.py
@@ -33,10 +33,10 @@ def parse_args(s, strip_pars=False):
     corresponding args and kwargs.
 
     :param s: string representing arguments to a method
-    :type strip_pars: (bool) If True, expect s to include surrounding
-    parenthesis
+    :param strip_pars: (bool) If True, expect s to include surrounding
+          parenthesis
     :return: args, kwargs (a list of positional arguments and a dict of keyword
-    arguments)
+             arguments)
     """
     s = s.strip()
     if strip_pars:

--- a/lib/taurus/core/util/property_parser.py
+++ b/lib/taurus/core/util/property_parser.py
@@ -101,7 +101,7 @@ def t_STRING(t):
 
 
 def t_KEY(t):
-    r'[a-zA-Z0-9_\.\/]+'
+    r'[a-zA-Z0-9/_\.\/]+'
     t.type = reserved.get(t.value, 'KEY')    # Check for reserved words
     return t
 

--- a/lib/taurus/core/util/tablepprint.py
+++ b/lib/taurus/core/util/tablepprint.py
@@ -41,23 +41,21 @@ __docformat__ = "restructuredtext"
 def indent(rows, hasHeader=False, headerChar='-', delim=' | ', justify='left',
            separateRows=False, prefix='', postfix='', wrapfunc=lambda x: x):
     """Indents a table by column.
-       - rows: A sequence of sequences of items, one sequence per row.
-       - hasHeader: True if the first row consists of the columns' names.
-       - headerChar: Character to be used for the row separator line
-         (if hasHeader==True or separateRows==True).
-       - delim: The column delimiter.
-       - justify: Determines how are data justified in their column.
-         Valid values are 'left','right' and 'center'.
-       - separateRows: True if rows are to be separated by a line
-         of 'headerChar's.
-       - prefix: A string prepended to each printed row.
-       - postfix: A string appended to each printed row.
-       - wrapfunc: A function f(text) for wrapping text; each element in
-         the table is first wrapped by this function.
-
-        Returns a list of strings. One for each row of the table
+    :param rows: A sequence of sequences of items, one sequence per row.
+    :param hasHeader: True if the first row consists of the columns' names.
+    :param headerChar: Character to be used for the row separator line
+    (if hasHeader==True or separateRows==True).
+    :param delim: The column delimiter.
+    :param justify: Determines how are data justified in their column.
+    Valid values are 'left','right' and 'center'.
+    :param separateRows: True if rows are to be separated by a line of
+    'headerChar's.
+    :param prefix: A string prepended to each printed row.
+    :param postfix: A string appended to each printed row.
+    :param wrapfunc: A function f(text) for wrapping text;
+    each element in the table is first wrapped by this function.
+    :return: a list of strings. One for each row of the table
     """
-
     # closure for breaking logical rows to physical, using wrapfunc
     def rowWrapper(row):
         newRows = [wrapfunc(item).split('\n') for item in row]
@@ -102,10 +100,9 @@ def indent(rows, hasHeader=False, headerChar='-', delim=' | ', justify='left',
 
 
 def wrap_onspace(text, width):
-    """
-    A word-wrap function that preserves existing line breaks
+    """A word-wrap function that preserves existing line breaks
     and most spaces in the text. Expects that existing line
-    breaks are posix newlines (\n).
+    breaks are posix newlines (\\\\n).
     """
     return reduce(lambda line, word, width=width: '%s%s%s' %
                   (line,

--- a/lib/taurus/external/qt/QtWebKit.py
+++ b/lib/taurus/external/qt/QtWebKit.py
@@ -29,16 +29,16 @@ from . import PYQT5, PYQT4, PYSIDE, PYSIDE2, PythonQtError
 
 
 if PYQT5:
-    from PyQt5.WebKit import *
+    from PyQt5.QtWebKit import *
     # import * from QtWebkitWidgets for PyQt4 style compat
-    from PyQt5.WebKitWidgets import *
+    from PyQt5.QtWebKitWidgets import *
 elif PYSIDE2:
-    from PySide2.WebKit import *
+    from PySide2.QtWebKit import *
     # import * from QtWebkitWidgets for PyQt4 style compat
-    from PySide2.WebKitWidgets import *
+    from PySide2.QtWebKitWidgets import *
 elif PYQT4:
-    from PyQt4.WebKit import *
+    from PyQt4.QtWebKit import *
 elif PYSIDE:
-    from PySide.WebKit import *
+    from PySide.QtWebKit import *
 else:
     raise PythonQtError('No Qt bindings could be found')

--- a/lib/taurus/qt/qtcore/taurusqlistener.py
+++ b/lib/taurus/qt/qtcore/taurusqlistener.py
@@ -31,7 +31,7 @@ __all__ = ["QTaurusBaseListener", "QObjectTaurusListener"]
 
 __docformat__ = 'restructuredtext'
 
-from taurus.qt.qtcore.util.signal import baseSignal
+from taurus.qt.qtcore.util import baseSignal
 from taurus.core.util.log import deprecation_decorator
 from taurus.core.tauruslistener import TaurusListener
 from taurus.external.qt import Qt

--- a/lib/taurus/qt/qtcore/util/__init__.py
+++ b/lib/taurus/qt/qtcore/util/__init__.py
@@ -27,5 +27,6 @@
 from __future__ import absolute_import
 
 from .tauruslog import *
+from .signal import baseSignal
 
 __docformat__ = 'restructuredtext'

--- a/lib/taurus/qt/qtcore/util/emitter.py
+++ b/lib/taurus/qt/qtcore/util/emitter.py
@@ -91,9 +91,6 @@ class QEmitter(Qt.QObject):
 
 class TaurusEmitterThread(Qt.QThread):
     """
-    The TaurusEmitterThread Class
-    ==========================
-
     This object get items from a python Queue and performs a thread safe 
     operation on them.
     It is useful to serialize Qt tasks in a background thread.
@@ -106,8 +103,7 @@ class TaurusEmitterThread(Qt.QThread):
     :param cursor: if True or QCursor a custom cursor is set while 
         the Queue is not empty
 
-    How TaurusEmitterThread works
-    --------------------------
+    How TaurusEmitterThread works:
 
     TaurusEmitterThread is a worker thread that processes a queue of iterables 
     passed as arguments to the specified method every time that  
@@ -126,7 +122,7 @@ class TaurusEmitterThread(Qt.QThread):
         to ``self.todo queue``
       + every time that a *somethingDone* signal arrives ``next()`` is called.
       + ``next()`` can be called also externally to ensure that the main queue 
-      is being processed.
+        is being processed.
       + the queue can be accessed externally using ``getQueue()``
       + ``getQueue().qsize()`` returns number of remaining objects in queue.
       + while there are objects in queue the ``.next()`` method will 
@@ -139,8 +135,7 @@ class TaurusEmitterThread(Qt.QThread):
       - if an object is found, it is sent in a *doSomething* signal.
       - if *"exit"* is found the loop exits.
 
-    Usage example
-    -------------
+    Usage example:
 
     .. code-block:: python
 

--- a/lib/taurus/qt/qtcore/util/properties.py
+++ b/lib/taurus/qt/qtcore/util/properties.py
@@ -117,17 +117,21 @@ COMMON_PROPERTIES = (
 )
 
 
-def set_property_methods(obj, name, type_="QString", default=None, getter=None, setter=None, reset=None, get_callback=None, set_callback=None, reset_callback=None, qt=False, config=False):
+def set_property_methods(obj, name, type_="QString", default=None, getter=None,
+                         setter=None, reset=None, get_callback=None,
+                         set_callback=None, reset_callback=None, qt=False,
+                         config=False):
     """
-    This method allows to add QProperties dynamically with calls like:
-    <pre>
+    This method allows to add QProperties dynamically with calls like::
+
         set_property_methods(self,'Filters','QString',default='',
             set_callback=lambda s=self:s.loadTree(s.getFilters(),clear=True),
             reset_callback=lambda s=self:s.loadTree('',clear=True)
             )
-    </pre>
 
-    @TODO: This method should be refactored using python descriptors/properties and types.MethodType
+
+    .. todo: This method should be refactored using python
+             descriptors/properties and types.MethodType
     """
     klass = obj.__class__
     mname = '%s%s' % (name[0].upper(), name[1:])

--- a/lib/taurus/qt/qtcore/util/signal.py
+++ b/lib/taurus/qt/qtcore/util/signal.py
@@ -1,3 +1,27 @@
+#############################################################################
+##
+# This file is part of Taurus
+##
+# http://taurus-scada.org
+##
+# Copyright 2011 CELLS / ALBA Synchrotron, Bellaterra, Spain
+##
+# Taurus is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+##
+# Taurus is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+##
+# You should have received a copy of the GNU Lesser General Public License
+# along with Taurus.  If not, see <http://www.gnu.org/licenses/>.
+##
+#############################################################################
+
+
 """Provide a Signal class for non-QObject objects"""
 from __future__ import print_function
 

--- a/lib/taurus/qt/qtdesigner/containerplugin.py
+++ b/lib/taurus/qt/qtdesigner/containerplugin.py
@@ -23,17 +23,21 @@
 ##
 #############################################################################
 
-""" Every TaurusWidget should have the following Qt Designer extended capabilities:
+"""
+Every TaurusWidget should have the following Qt Designer extended
+capabilities:
 
   - Task menu:
     it means when you right click on the widget in the designer, it will have
     the following additional items:
-    - 'Edit model...' - opens a customized dialog for editing the widget model
+
+    - 'Edit model...': opens a customized dialog for editing the widget model
 
   - Property Sheet:
     it means that in the Qt Designer property sheet it will have the following
     properties customized:
-    - 'model' - will have a '...' button that will open a customized dialog for
+
+    - 'model': will have a '...' button that will open a customized dialog for
       editing the widget model (same has 'Edit model...' task menu item
 """
 
@@ -103,8 +107,7 @@ class QGroupWidgetExtensionFactory(QtDesigner.QExtensionFactory):
 
 
 def create_plugin():
-    #from .taurusplugin.taurusplugin import TaurusWidgetPlugin # - after futurize stage1
-    from taurusplugin.taurusplugin import TaurusWidgetPlugin # + after futurize stage1
+    from .taurusplugin.taurusplugin import TaurusWidgetPlugin
 
     class QGroupWidgetPlugin(TaurusWidgetPlugin):
 

--- a/lib/taurus/qt/qtdesigner/tauruspluginplugin.py
+++ b/lib/taurus/qt/qtdesigner/tauruspluginplugin.py
@@ -32,8 +32,7 @@ from taurus.external.qt import QtDesigner
 
 
 def build_qtdesigner_widget_plugin(klass):
-    #from . import taurusplugin # - after futurize stage 1
-    import taurusplugin.taurusplugin as taurusplugin # + after futurize stage 1
+    from .taurusplugin import taurusplugin
 
     class Plugin(taurusplugin.TaurusWidgetPlugin):
         WidgetClass = klass

--- a/lib/taurus/qt/qtgui/base/taurusbase.py
+++ b/lib/taurus/qt/qtgui/base/taurusbase.py
@@ -47,7 +47,7 @@ from taurus.core.tauruslistener import TaurusListener, TaurusExceptionListener
 from taurus.core.taurusoperation import WriteAttrOperation
 from taurus.core.util.eventfilters import filterEvent
 from taurus.core.util.log import deprecation_decorator
-from taurus.qt.qtcore.util.signal import baseSignal
+from taurus.qt.qtcore.util import baseSignal
 from taurus.qt.qtcore.configuration import BaseConfigurableClass
 from taurus.qt.qtcore.mimetypes import TAURUS_ATTR_MIME_TYPE
 from taurus.qt.qtcore.mimetypes import TAURUS_DEV_MIME_TYPE

--- a/lib/taurus/qt/qtgui/display/test/test_tauruslabel.py
+++ b/lib/taurus/qt/qtgui/display/test/test_tauruslabel.py
@@ -34,6 +34,8 @@ from taurus.qt.qtgui.container import TaurusWidget
 from taurus.core.tango.test import TangoSchemeTestLauncher
 import functools
 from taurus.core.util.colors import ATTRIBUTE_QUALITY_DATA, DEVICE_STATE_DATA
+from pint import UnitRegistry as ur
+import numpy
 
 DEV_NAME = TangoSchemeTestLauncher.DEV_NAME
 
@@ -102,7 +104,9 @@ testOldFgroles = functools.partial(insertTest, helper_name='text', maxdepr=1,
 # ------------------------------------------------------------------------------
 @insertTest(helper_name='text',
             model='tango:' + DEV_NAME + '/double_image#rvalue[1,::2]',
-            expected='[ 1.23  1.23] mm')
+            expected='{:~}'.format(numpy.array([1.23,1.23])*ur().mm)
+            # expected is not explicit to support pint v<0.8 particularities
+            )
 @insertTest(helper_name='text',
             model='tango:' + DEV_NAME + '/double_spectrum#rvalue[1]',
             expected='1.23 mm')

--- a/lib/taurus/qt/qtgui/extra_guiqwt/curve.py
+++ b/lib/taurus/qt/qtgui/extra_guiqwt/curve.py
@@ -30,7 +30,7 @@ from builtins import next
 
 from taurus.external.qt import Qt
 from taurus.qt.qtgui.base import TaurusBaseComponent
-from taurus.qt.qtcore.util.signal import baseSignal
+from taurus.qt.qtcore.util import baseSignal
 import taurus
 from guiqwt.curve import CurveItem
 from taurus.qt.qtgui.extra_guiqwt.styles import TaurusCurveParam, TaurusTrendParam

--- a/lib/taurus/qt/qtgui/extra_guiqwt/image.py
+++ b/lib/taurus/qt/qtgui/extra_guiqwt/image.py
@@ -33,7 +33,7 @@ __all__ = ["TaurusImageItem", "TaurusRGBImageItem", "TaurusTrend2DItem",
 from taurus.core.units import Quantity
 from taurus.external.qt import Qt
 from taurus.qt.qtgui.base import TaurusBaseComponent
-from taurus.qt.qtcore.util.signal import baseSignal
+from taurus.qt.qtcore.util import baseSignal
 import taurus.core
 from taurus.core.util.containers import ArrayBuffer
 

--- a/lib/taurus/qt/qtgui/panel/taurusconfigeditor.py
+++ b/lib/taurus/qt/qtgui/panel/taurusconfigeditor.py
@@ -85,7 +85,8 @@ class QConfigEditorModel(Qt.QStandardItemModel):
         self._file = tempfile.NamedTemporaryFile()
         self._temporaryFile = str(self._file.name)
 
-        shutil.copyfile(self.originalFile, self._temporaryFile)
+        with open(self.originalFile, 'rb') as fo:
+            self._file.write(fo.read())
 
         self._settings = Qt.QSettings(
             self._temporaryFile, Qt.QSettings.IniFormat)

--- a/lib/taurus/qt/qtgui/panel/taurusdevicepanel.py
+++ b/lib/taurus/qt/qtgui/panel/taurusdevicepanel.py
@@ -28,7 +28,6 @@ TaurusDevicePanel.py:
 """
 
 from builtins import str
-from future.utils import string_types
 
 import re
 import traceback

--- a/lib/taurus/qt/qtgui/panel/taurusdevicepanel.py
+++ b/lib/taurus/qt/qtgui/panel/taurusdevicepanel.py
@@ -583,24 +583,9 @@ class TaurusDevPanel(TaurusGui):
 
     def setDevice(self, devname):
         """set the device to be shown by the commands and attr forms"""
-        # try to connect with the device
         self.setModel(devname)
-        dev = self.getModelObj()
-        state = dev.state
-        # test the connection
-        if state == TaurusDevState.Ready:
-            msg = 'Connected to "%s"' % devname
-            self.statusBar().showMessage(msg)
-            self._ui.attrDW.setWindowTitle('Attributes - %s' % devname)
-            self._ui.commandsDW.setWindowTitle('Commands - %s' % devname)
-        else:
-            # reset the model if the connection failed
-            msg = 'Connection to "%s" failed (state = %s)' % (devname,
-                                                              state.name)
-            self.statusBar().showMessage(msg)
-            self.info(msg)
-            Qt.QMessageBox.warning(self, "Device unreachable", msg)
-            self.setModel('')
+        self._ui.attrDW.setWindowTitle('Attributes - %s' % devname)
+        self._ui.commandsDW.setWindowTitle('Commands - %s' % devname)
 
     def setModel(self, name):
         """Reimplemented to delegate model to the commands and attrs forms"""

--- a/lib/taurus/qt/qtgui/panel/taurusform.py
+++ b/lib/taurus/qt/qtgui/panel/taurusform.py
@@ -866,21 +866,22 @@ class TaurusAttrForm(TaurusWidget):
     def _updateAttrWidgets(self):
         '''Populates the form with an item for each of the attributes shown
         '''
-        dev = self.getModelObj()
-        if dev is None or dev.state != TaurusDevState.Ready:
+        try:
+            dev = self.getModelObj()
+            attrlist = sorted(dev.attribute_list_query(), key=self._sortKey)
+            for f in self.getViewFilters():
+                attrlist = list(filter(f, attrlist))
+            attrnames = []
+            devname = self.getModelName()
+            for a in attrlist:
+                # ugly hack . But setUseParentModel does not work well
+                attrnames.append("%s/%s" % (devname, a.name))
+            self.debug('Filling with attribute list: %s'
+                       % ("; ".join(attrnames)))
+            self._form.setModel(attrnames)
+        except:
             self.debug('Cannot connect to device')
             self._form.setModel([])
-            return
-        attrlist = sorted(dev.attribute_list_query(), key=self._sortKey)
-        for f in self.getViewFilters():
-            attrlist = list(filter(f, attrlist))
-        attrnames = []
-        devname = self.getModelName()
-        for a in attrlist:
-            # ugly hack . But setUseParentModel does not work well
-            attrnames.append("%s/%s" % (devname, a.name))
-        self.debug('Filling with attribute list: %s' % ("; ".join(attrnames)))
-        self._form.setModel(attrnames)
 
     def setViewFilters(self, filterlist):
         '''sets the filters to be applied when displaying the attributes

--- a/lib/taurus/qt/qtgui/qwt5/taurusplot.py
+++ b/lib/taurus/qt/qtgui/qwt5/taurusplot.py
@@ -52,7 +52,7 @@ from taurus.core.taurusbasetypes import DataFormat
 # TODO: Tango-centric
 from taurus.core.util.containers import LoopList, CaselessDict, CaselessList
 from taurus.core.util.safeeval import SafeEvaluator
-from taurus.qt.qtcore.util.signal import baseSignal
+from taurus.qt.qtcore.util import baseSignal
 from taurus.qt.qtcore.mimetypes import TAURUS_MODEL_LIST_MIME_TYPE, TAURUS_ATTR_MIME_TYPE
 from taurus.qt.qtgui.base import TaurusBaseComponent, TaurusBaseWidget
 from taurus.qt.qtgui.qwt5 import TaurusPlotConfigDialog, FancyScaleDraw,\

--- a/lib/taurus/qt/qtgui/taurusgui/paneldescriptionwizard.py
+++ b/lib/taurus/qt/qtgui/taurusgui/paneldescriptionwizard.py
@@ -35,7 +35,6 @@ import weakref
 from taurus.qt.qtgui.taurusgui.utils import PanelDescription
 from taurus.qt.qtgui.icon import getCachedPixmap
 from taurus.qt.qtgui.input import GraphicalChoiceWidget
-from taurus.qt.qtgui.panel import TaurusModelChooser
 from taurus.qt.qtgui.base import TaurusBaseComponent, TaurusBaseWidget
 from taurus.qt.qtcore.communication import SharedDataManager
 from taurus.qt.qtcore.mimetypes import TAURUS_MODEL_LIST_MIME_TYPE
@@ -46,6 +45,11 @@ import copy
 
 
 __all__ = ["PanelDescriptionWizard"]
+
+
+def modelChooserDlg(*args, **kwargs):
+    from taurus.qt.qtgui.panel import TaurusModelChooser
+    return TaurusModelChooser.modelChooserDlg(*args, **kwargs)
 
 
 class ExpertWidgetChooserDlg(Qt.QDialog):
@@ -429,8 +433,7 @@ class AdvSettingsPage(Qt.QWizardPage):
         self.commLV.setItemDelegate(self.itemDelegate)
 
     def showModelChooser(self):
-        models, ok = TaurusModelChooser.modelChooserDlg(
-            parent=self, asMimeData=True)
+        models, ok = modelChooserDlg(parent=self, asMimeData=True)
         if not ok:
             return
         self.models = str(models.data(TAURUS_MODEL_LIST_MIME_TYPE))

--- a/lib/taurus/qt/qtgui/taurusgui/paneldescriptionwizard.py
+++ b/lib/taurus/qt/qtgui/taurusgui/paneldescriptionwizard.py
@@ -47,11 +47,6 @@ import copy
 __all__ = ["PanelDescriptionWizard"]
 
 
-def modelChooserDlg(*args, **kwargs):
-    from taurus.qt.qtgui.panel import TaurusModelChooser
-    return TaurusModelChooser.modelChooserDlg(*args, **kwargs)
-
-
 class ExpertWidgetChooserDlg(Qt.QDialog):
     CHOOSE_TYPE_TXT = '(choose type)'
 
@@ -433,7 +428,9 @@ class AdvSettingsPage(Qt.QWizardPage):
         self.commLV.setItemDelegate(self.itemDelegate)
 
     def showModelChooser(self):
-        models, ok = modelChooserDlg(parent=self, asMimeData=True)
+        from taurus.qt.qtgui.panel import TaurusModelChooser
+        models, ok = TaurusModelChooser.modelChooserDlg(
+            parent=self, asMimeData=True)
         if not ok:
             return
         self.models = str(models.data(TAURUS_MODEL_LIST_MIME_TYPE))

--- a/lib/taurus/qt/qtgui/taurusgui/taurusgui.py
+++ b/lib/taurus/qt/qtgui/taurusgui/taurusgui.py
@@ -25,6 +25,8 @@
 
 """This package provides the TaurusGui class"""
 
+from __future__ import absolute_import
+
 from builtins import str
 import os
 import sys
@@ -54,16 +56,6 @@ from taurus.qt.qtgui.taurusgui.utils import ExternalAppAction
 __all__ = ["DockWidgetPanel", "TaurusGui"]
 
 __docformat__ = 'restructuredtext'
-
-
-def QDoubleListDlg(*args, **kwargs):
-    from taurus.qt.qtgui.panel import QDoubleListDlg
-    return QDoubleListDlg(*args, **kwargs)
-
-
-def ExternalAppEditor(*args, **kwargs):
-    from taurus.qt.qtgui.taurusgui.appsettingswizard import ExternalAppEditor
-    return ExternalAppEditor(*args, **kwargs)
 
 
 @UILoadable(with_ui='ui')
@@ -513,6 +505,7 @@ class TaurusGui(TaurusMainWindow):
 
     def createExternalApp(self):
         '''Add a new external application on execution time'''
+        from .appsettingswizard import ExternalAppEditor
         app_editor = ExternalAppEditor(self)
         name, xml, ok = app_editor.getDialog()
         if name in self._external_app_names:
@@ -774,6 +767,7 @@ class TaurusGui(TaurusMainWindow):
         temp = [n for n, p in self.__panels.items() if (
             p.isCustom() and not p.isPermanent())]
         if len(temp) > 0 or showAlways:
+            from taurus.qt.qtgui.panel import QDoubleListDlg
             dlg = QDoubleListDlg(winTitle='Stored panels',
                                  mainLabel='Select which of the panels should be stored',
                                  label1='Temporary (to be discarded)', label2='Permanent (to be stored)',
@@ -802,6 +796,7 @@ class TaurusGui(TaurusMainWindow):
         # be made permanent
         #permanet_ext_app = list(self._external_app_names)
         if len(self.__external_app) > 0 or showAlways:
+            from taurus.qt.qtgui.panel import QDoubleListDlg
             msg = 'Select which of the external applications should be stored'
             dlg = QDoubleListDlg(winTitle='Stored external applications',
                                  mainLabel=msg,
@@ -1656,6 +1651,7 @@ class TaurusGui(TaurusMainWindow):
                 xmlroot, "PanelDescriptions")
 
         # Get all custom panels
+        from taurus.qt.qtgui.panel import QDoubleListDlg
         dlg = QDoubleListDlg(winTitle='Export Panels to XML',
                              mainLabel='Select which of the custom panels you want to export as xml configuration',
                              label1='Not Exported', label2='Exported',

--- a/lib/taurus/qt/qtgui/taurusgui/taurusgui.py
+++ b/lib/taurus/qt/qtgui/taurusgui/taurusgui.py
@@ -47,8 +47,6 @@ from taurus.qt.qtgui.container import TaurusMainWindow
 from taurus.qt.qtgui.taurusgui.utils import (ExternalApp, PanelDescription,
                                              ToolBarDescription,
                                              AppletDescription)
-from taurus.qt.qtgui.taurusgui.appsettingswizard import ExternalAppEditor
-from taurus.qt.qtgui.panel import QDoubleListDlg
 from taurus.qt.qtgui.util.ui import UILoadable
 from taurus.qt.qtgui.taurusgui.utils import ExternalAppAction
 
@@ -56,6 +54,16 @@ from taurus.qt.qtgui.taurusgui.utils import ExternalAppAction
 __all__ = ["DockWidgetPanel", "TaurusGui"]
 
 __docformat__ = 'restructuredtext'
+
+
+def QDoubleListDlg(*args, **kwargs):
+    from taurus.qt.qtgui.panel import QDoubleListDlg
+    return QDoubleListDlg(*args, **kwargs)
+
+
+def ExternalAppEditor(*args, **kwargs):
+    from taurus.qt.qtgui.taurusgui.appsettingswizard import ExternalAppEditor
+    return ExternalAppEditor(*args, **kwargs)
 
 
 @UILoadable(with_ui='ui')

--- a/lib/taurus/test/test_import.py
+++ b/lib/taurus/test/test_import.py
@@ -49,7 +49,10 @@ class TaurusImportTestCase(unittest.TestCase):
         on module importing
         """
         exclude_patterns = [r'taurus\.qt\.qtgui\.extra_.*',
-                            r'taurus\.qt\.qtgui\.qwt5']
+                            r'taurus\.qt\.qtgui\.qwt5',
+                            r'taurus\.external\.qt\.QtUiTools',
+                            r'taurus\.external\.qt\.Qwt5',
+                            ]
 
         try:
             import PyTango
@@ -64,7 +67,7 @@ class TaurusImportTestCase(unittest.TestCase):
                                        exclude_patterns=exclude_patterns)
         msg = None
         if wrn:
-            msg = '\n%s' % '\n'.join(zip(*wrn)[1])
+            msg = '\n%s' % '\n'.join(list(zip(*wrn))[1])
         self.assertEqual(len(wrn), 0, msg=msg)
 
 


### PR DESCRIPTION
Create helper functions in order to fix cyclic import appearing
when importing:
from taurus.qt.qtgui.taurusgui import TaurusGui

This problem affects the launching of newly created Taurus Guis.

This commit fixes it.

Fixes #947 