### PR TITLE
Fix config editor broken in #950

### DIFF
--- a/lib/taurus/qt/qtgui/panel/taurusconfigeditor.py
+++ b/lib/taurus/qt/qtgui/panel/taurusconfigeditor.py
@@ -33,11 +33,11 @@ standard_library.install_aliases()
 from taurus.external.qt import Qt, compat
 import pickle
 import os
+import shutil
 import tempfile
 import click
 from taurus.qt.qtcore.configuration import BaseConfigurableClass
 from taurus.qt.qtgui.container import TaurusWidget
-import shutil
 
 
 __all__ = ["QConfigEditor"]
@@ -81,12 +81,9 @@ class QConfigEditorModel(Qt.QStandardItemModel):
 
         :param iniFileName: (str)
         '''
-        self.originalFile = str(iniFileName)
-        self._file = tempfile.NamedTemporaryFile()
-        self._temporaryFile = str(self._file.name)
-
-        with open(self.originalFile, 'rb') as fo:
-            self._file.write(fo.read())
+        self.originalFile = iniFileName
+        self._temporaryFile = tempfile.NamedTemporaryFile(delete=False).name
+        shutil.copyfile(self.originalFile, self._temporaryFile)
 
         self._settings = Qt.QSettings(
             self._temporaryFile, Qt.QSettings.IniFormat)
@@ -348,7 +345,7 @@ class QConfigEditorModel(Qt.QStandardItemModel):
         '''
         result = None
         qstate = self._settings.value(key)
-        if qstate is not None and not qstate.isNull():
+        if qstate is not None:
             try:
                 result = pickle.loads(qstate.data())
             except Exception as e:
@@ -368,6 +365,8 @@ class QConfigEditorModel(Qt.QStandardItemModel):
         '''
         if self.markedItems == []:
             return
+        self._settings.sync()
+
         shutil.copyfile(self._temporaryFile, self.originalFile)
         self.clearChanges()
         # self.reloadFile()
@@ -397,7 +396,7 @@ class QConfigEditorModel(Qt.QStandardItemModel):
         '''
         if self.markedItems == []:
             return
-        shutil.copyfile(self.originalFile, self._temporaryFile)
+
         self.reloadFile()
 
     def clearChanges(self):


### PR DESCRIPTION
PR #950 fixed a file access issue on Win, but
broke the config editor.

Fix both issues by not deleting the temporary
settings file.