### PR TITLE
Fix issue when setting compact mode before model

### DIFF
--- a/lib/taurus/qt/qtgui/panel/taurusvalue.py
+++ b/lib/taurus/qt/qtgui/panel/taurusvalue.py
@@ -389,7 +389,7 @@ class TaurusValue(Qt.QWidget, TaurusBaseWidget):
         itself.
         '''
         if followCompact and self.isCompact():
-            return self._readWidget.readWidget
+            return getattr(self._readWidget, 'readWidget', self._readWidget)
         return self._readWidget
 
     def writeWidget(self, followCompact=False):


### PR DESCRIPTION
Commit 86b79ea006 introduced a bug: the compact mode cannot be set
unless the model is set. This causes issues e.g. when loading a
configuration of a TaurusForm in which the form compact mode was
set to True.

The problem is due to an exception in TaurusValue.readWidget() and
can be reproduced with the following snippet:

```
app = TaurusApplication(cmd_line_parser=None)
w = TaurusForm()
w.setCompact(True)
w.setModel(['sys/tg_test/1/float_scalar'])
w.show()
sys.exit(app.exec_())
```

Make TaurusValue.readWidget() more robust.