### PR TITLE
Remove utf8 encodeing in JSONCodec

### DIFF
--- a/lib/taurus/core/util/codecs.py
+++ b/lib/taurus/core/util/codecs.py
@@ -79,7 +79,8 @@ from .log import Logger
 from .containers import CaselessDict
 
 __all__ = ["Codec", "NullCodec", "ZIPCodec", "BZ2Codec", "JSONCodec",
-           "FunctionCodec", "PlotCodec", "CodecPipeline", "CodecFactory"]
+           "Utf8Codec", "FunctionCodec", "PlotCodec", "CodecPipeline",
+           "CodecFactory"]
 
 __docformat__ = "restructuredtext"
 
@@ -376,6 +377,21 @@ class JSONCodec(Codec):
         for k, v in dct.items():
             newdict[self._transform_ascii(k)] = self._transform_ascii(v)
         return newdict
+
+
+class Utf8Codec(Codec):
+
+    def encode(self, data, *args, **kwargs):
+        format = 'utf8'
+        fmt, data = data
+        if len(fmt):
+            format += '_%s' % fmt
+        return format, str.encode(data)
+
+    def decode(self, data, *args, **kwargs):
+        fmt, data = data
+        fmt = fmt.partition('_')[2]
+        return fmt, bytes.decode(data)
 
 
 class BSONCodec(Codec):
@@ -864,6 +880,7 @@ class CodecFactory(Singleton, Logger):
     #: Default minimum map of registered codecs
     CODEC_MAP = CaselessDict({
         'json': JSONCodec,
+        'utf8': Utf8Codec,
         'bson': BSONCodec,
         'bz2': BZ2Codec,
         'zip': ZIPCodec,

--- a/lib/taurus/core/util/codecs.py
+++ b/lib/taurus/core/util/codecs.py
@@ -331,7 +331,7 @@ class JSONCodec(Codec):
             format += '_%s' % data[0]
         # make it compact by default
         kwargs['separators'] = kwargs.get('separators', (',', ':'))
-        return format, json.dumps(data[1], *args, **kwargs).encode('utf-8')
+        return format, json.dumps(data[1], *args, **kwargs)
 
     def decode(self, data, *args, **kwargs):
         """decodes the given data from a json string.
@@ -350,8 +350,6 @@ class JSONCodec(Codec):
 
         if isinstance(data[1], buffer_types):
             data = data[0], str(data[1])
-        elif isinstance(data[1], bytes):
-            data = data[0], data[1].decode('utf-8')
         
         data = json.loads(data[1])
         if ensure_ascii:

--- a/lib/taurus/core/util/codecs.py
+++ b/lib/taurus/core/util/codecs.py
@@ -413,7 +413,7 @@ class Utf8Codec(Codec):
         fmt, data = data
         if len(fmt):
             format += '_%s' % fmt
-        return format, str.encode(data)
+        return format, str(data).encode()
 
     def decode(self, data, *args, **kwargs):
         """decodes the given data from a bytes.
@@ -426,7 +426,7 @@ class Utf8Codec(Codec):
         """
         fmt, data = data
         fmt = fmt.partition('_')[2]
-        return fmt, bytes.decode(data)
+        return fmt, bytes(data).decode()
 
 
 class BSONCodec(Codec):

--- a/lib/taurus/core/util/codecs.py
+++ b/lib/taurus/core/util/codecs.py
@@ -63,7 +63,7 @@ A Taurus related example::
     >>> f, d = codec.decode((v.format, v.value))
 """
 from __future__ import absolute_import
-from builtins import str
+from builtins import str, bytes
 
 import copy
 

--- a/lib/taurus/core/util/codecs.py
+++ b/lib/taurus/core/util/codecs.py
@@ -172,7 +172,7 @@ class ZIPCodec(Codec):
         'Hello world\\nHello wo'"""
 
     def encode(self, data, *args, **kwargs):
-        """encodes the given data to a gzip string. The given data **must** be a string
+        """encodes the given data to gzip bytes. The given data **must** be bytes
 
         :param data: (sequence[str, obj]) a sequence of two elements where the first item is the encoding format of the second item object
 
@@ -184,7 +184,7 @@ class ZIPCodec(Codec):
         return format, zlib.compress(data[1])
 
     def decode(self, data, *args, **kwargs):
-        """decodes the given data from a gzip string.
+        """decodes the given data from a gzip bytes.
 
         :param data: (sequence[str, obj]) a sequence of two elements where the first item is the encoding format of the second item object
 
@@ -215,7 +215,7 @@ class BZ2Codec(Codec):
         'Hello world\\nHello wo'"""
 
     def encode(self, data, *args, **kwargs):
-        """encodes the given data to a bz2 string. The given data **must** be a string
+        """encodes the given data to bz2 bytes. The given data **must** be bytes
 
         :param data: (sequence[str, obj]) a sequence of two elements where the first item is the encoding format of the second item object
 
@@ -227,7 +227,7 @@ class BZ2Codec(Codec):
         return format, bz2.compress(data[1])
 
     def decode(self, data, *args, **kwargs):
-        """decodes the given data from a bz2 string.
+        """decodes the given data from bz2 bytes.
 
         :param data: (sequence[str, obj]) a sequence of two elements where the first item is the encoding format of the second item object
 
@@ -260,7 +260,7 @@ class PickleCodec(Codec):
         {'hello': 'world', 'goodbye': 1000}"""
 
     def encode(self, data, *args, **kwargs):
-        """encodes the given data to a pickle string. The given data **must** be
+        """encodes the given data to pickle bytes. The given data **must** be
         a python object that :mod:`pickle` is able to convert.
 
         :param data: (sequence[str, obj]) a sequence of two elements where the
@@ -380,8 +380,35 @@ class JSONCodec(Codec):
 
 
 class Utf8Codec(Codec):
+    """A codec able to encode/decode utf8 strings to/from bytes.
+    Useful to adapt i/o encodings in a codec pipe.
+
+    Example::
+
+        >>> from taurus.core.util.codecs import CodecFactory
+
+        >>> cf = CodecFactory()
+        >>> codec = cf.getCodec('zip_utf8_json')
+        >>>
+        >>> # first encode something
+        >>> data = { 'hello' : 'world', 'goodbye' : 1000 }
+        >>> format, encoded_data = codec.encode(("", data))
+        >>>
+        >>> # now decode it
+        >>> _, decoded_data = codec.decode((format, encoded_data))
+        >>> print decoded_data
+    """
 
     def encode(self, data, *args, **kwargs):
+        """
+        Encodes the given utf8 string to bytes.
+
+        :param data: (sequence[str, obj]) a sequence of two elements where the
+                     first item is the encoding format of the second item object
+
+        :return: (sequence[str, obj]) a sequence of two elements where the
+                 first item is the encoding format of the second item object
+        """
         format = 'utf8'
         fmt, data = data
         if len(fmt):
@@ -389,6 +416,14 @@ class Utf8Codec(Codec):
         return format, str.encode(data)
 
     def decode(self, data, *args, **kwargs):
+        """decodes the given data from a bytes.
+
+        :param data: (sequence[str, obj]) a sequence of two elements where the
+                     first item is the encoding format of the second item object
+
+        :return: (sequence[str, obj]) a sequence of two elements where the
+                 first item is the encoding format of the second item object
+        """
         fmt, data = data
         fmt = fmt.partition('_')[2]
         return fmt, bytes.decode(data)

--- a/lib/taurus/core/util/test/test_codecs.py
+++ b/lib/taurus/core/util/test/test_codecs.py
@@ -38,7 +38,7 @@ import numpy
 
 @insertTest(helper_name='encDec', cname='json', data=[1, 2, 3])
 @insertTest(helper_name='encDec', cname='zip', data=b'foobar')
-@insertTest(helper_name='encDec', cname='zip_json', data=[1, 2, 3])
+@insertTest(helper_name='encDec', cname='zip_utf8_json', data=[1, 2, 3])
 @insertTest(helper_name='encDec', cname='videoimage',
             data=numpy.ones((2, 2), dtype='uint8'))
 @insertTest(helper_name='encDec', cname='zip_null_zip_videoimage',


### PR DESCRIPTION
Taurus JSONCodec apart from JSON serialization encodes and decodes using
"utf-8". This in python 2 means that the API is based on strings and
in python 3 it is based on bytes.

In pure Python however json.dumps and json.loads works on strings
for both python 2 and 3.

Adapt Taurus JSONCodec to have the same behaviour than pure Python
library.

Solve  #945