### PR TITLE
Hotfix 4.6.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,7 +3,7 @@ commit = True
 message = Bump version {current_version} to {new_version}
 tag = False
 tag_name = {new_version}
-current_version = 4.6.0
+current_version = 4.6.1
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?
 serialize = 
 	{major}.{minor}.{patch}-{release}

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,10 +53,14 @@ doctr:
   sync: true
   built-docs: build/sphinx/html/
 
+before_deploy: 
+  - docker exec -t taurus-test /bin/bash -c "cd /taurus ; python setup.py sdist"
+
 deploy:
   # deploy to pypi when a version tag is pushed to the official repo
   - provider: pypi
     user: taurus_bot
+    skip_existing: true
     password:
       secure: "QjqutDroKg1ZcSXUAEGtaut9kwxHifSQKkisE+Pvd8UXElr6+inJqUbtLGkBRDDJsjVrSZi4TeLu/NfZyey/9kTQvwqrSHio80KgQ7HzuktgdmnFKfU4TWFEt4wd8LzYF4O5ljtYj4/k6txQ0zMVsLN5/SAQl44E0KSRBZBifrbeEXL3k9YI6nhw7cBiV+9XVFJBuBP5IVGhk4mOAFDT0UGyuCpMBKacfmtgDtZnYqb1SnRkFb9vT2kSPy8j3ZfZ3YPfZECwVWZtvG98/ujz1S6+mZKyErGNZc5RocBNdQFAG6AP8Epl05k+UmHO0mtHkSC+Mmh3J2grZXCKmojqcsrgJ/oP82WOQQtzZvLjYylIBC6tJ8GI0AJxUa7yukXS+x7ihkK3Xd9SoUuQri6dRlbE7iEJr7z6ZqwoiossY0feqN/v03fyJgze3KOsZ/sR1jQ2A8jdN62NzzM674w+UGhK7Q7hRRsiaODNzNrwcOrhYh4mjIXk9T8Iij223AjTixSJ29l2GUMyFgFU3KsgEUhgx8ZcL4G0olirokoMAn3wnqCbocQt7nWwUFGvQE384Br27iW598mka2njvAuww05xGCW6+/n3/aPXZYoE+DgMtYQLF8yHy7Ucvc+8mVfkrlNSkPzCF5W05JgkvVpNYznIMvnzjRcO5yoXdVUDcRM="
     on:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Note: changes in the [support-3.x] branch (which was split from
 the master branch after [3.7.1] and maintained in parallel to the 
 develop branch) won't be reflected in this file.
 
+## [4.6.1] - 2019-08-19
+Hotfix for auto-deployment in PyPI with Travis. No other difference from 4.6.0.
+
+### Fixed
+- Travis not deploying tar.gz (#990)
+
 ## [4.6.0] - 2019-08-19
 [Jul19 milestone](https://github.com/taurus-org/taurus/milestone/13)
 
@@ -465,6 +471,7 @@ and several other places](https://sf.net/p/tauruslib/tickets/milestone/Jul15/)
 [TEP14]: http://www.taurus-scada.org/tep/?TEP14.md
 [TEP15]: http://www.taurus-scada.org/tep/?TEP15.md
 [Unreleased]: https://github.com/taurus-org/taurus/tree/develop
+[4.6.1]: https://github.com/taurus-org/taurus/tree/release-4.6.1
 [4.6.0]: https://github.com/taurus-org/taurus/tree/release-4.6.0
 [4.5.1]: https://github.com/taurus-org/taurus/tree/release-4.5.1
 [4.5.0]: https://github.com/taurus-org/taurus/tree/release-4.5.0

--- a/lib/taurus/core/release.py
+++ b/lib/taurus/core/release.py
@@ -47,7 +47,7 @@ name = 'taurus'
 
 # we use semantic versioning (http://semver.org/) and we update it using the
 # bumpversion script (https://github.com/peritus/bumpversion)
-version = '4.6.0'
+version = '4.6.1'
 
 # generate version_info and revision (**deprecated** since version 4.0.2-dev).
 if '-' in version:


### PR DESCRIPTION
Travis is currently only deploying egg files to pypi.
Fix this by forcing the sdist to be built before deploy.

This hotfix only affects CI (i.e. for a user v4.6.1 is completely
equivalent to v4.6.0)

Note: this is a second attempt to hotfix the same. 
The previous one was #989 which was applied but which will be overwritten (after a forced-push to revert)