### PR TITLE
Avoid resolving dns aliases in tangohost fqdn expansion

### DIFF
--- a/lib/taurus/core/tango/tangodatabase.py
+++ b/lib/taurus/core/tango/tangodatabase.py
@@ -34,7 +34,6 @@ from builtins import object
 import collections
 
 import os
-import socket
 import weakref
 
 from PyTango import (Database, DeviceProxy, DevFailed, ApiUtil)
@@ -43,6 +42,7 @@ from taurus.core.taurusbasetypes import TaurusDevState, TaurusEventType
 from taurus.core.taurusauthority import TaurusAuthority
 from taurus.core.util.containers import CaselessDict
 from taurus.core.util.log import taurus4_deprecation
+from taurus.core.util.fqdn import fqdn_no_alias
 
 
 __all__ = ["TangoInfo", "TangoAttrInfo", "TangoDevInfo", "TangoServInfo",
@@ -679,7 +679,7 @@ class TangoAuthority(TaurusAuthority):
                 warning("Error getting default Tango host")
 
         # Set host to fqdn
-        host = socket.getfqdn(host)
+        host = fqdn_no_alias(host)
 
         self.dbObj = Database(host, port)
         self._dbProxy = None

--- a/lib/taurus/core/tango/tangovalidator.py
+++ b/lib/taurus/core/tango/tangovalidator.py
@@ -30,10 +30,10 @@ __all__ = ["TangoAuthorityNameValidator", "TangoDeviceNameValidator",
 
 __docformat__ = "restructuredtext"
 
-import socket
 from taurus.core.taurusvalidator import (TaurusAttributeNameValidator,
                                          TaurusDeviceNameValidator,
                                          TaurusAuthorityNameValidator)
+from taurus.core.util.fqdn import fqdn_no_alias
 
 
 # todo: I do not understand the behaviour of getNames for Auth, Dev and Attr in
@@ -63,7 +63,7 @@ class TangoAuthorityNameValidator(TaurusAuthorityNameValidator):
         '''
         ret = TaurusAuthorityNameValidator.getUriGroups(self, name, strict)
         if ret is not None:
-            fqdn = socket.getfqdn(ret["host"])
+            fqdn = fqdn_no_alias(ret["host"])
             ret["host"] = fqdn
             ret["authority"] = "//{host}:{port}".format(**ret)
         return ret
@@ -97,7 +97,7 @@ class TangoDeviceNameValidator(TaurusDeviceNameValidator):
         '''
         ret = TaurusDeviceNameValidator.getUriGroups(self, name, strict)
         if ret is not None and ret.get("host", None) is not None:
-            fqdn = socket.getfqdn(ret["host"])
+            fqdn = fqdn_no_alias(ret["host"])
             ret["host"] = fqdn
             ret["authority"] = "//{host}:{port}".format(**ret)
         return ret
@@ -122,7 +122,7 @@ class TangoDeviceNameValidator(TaurusDeviceNameValidator):
             import PyTango
             host, port = PyTango.ApiUtil.get_env_var('TANGO_HOST').split(":")
             # Get the fully qualified domain name
-            host = socket.getfqdn(host)
+            host = fqdn_no_alias(host)
             default_authority = "//{0}:{1}".format(host, port)
 
         authority = groups.get('authority')
@@ -222,7 +222,7 @@ class TangoAttributeNameValidator(TaurusAttributeNameValidator):
         '''
         ret = TaurusAttributeNameValidator.getUriGroups(self, name, strict)
         if ret is not None and ret.get("host", None) is not None:
-            fqdn = socket.getfqdn(ret["host"])
+            fqdn = fqdn_no_alias(ret["host"])
             ret["host"] = fqdn
             ret["authority"] = "//{host}:{port}".format(**ret)
         return ret

--- a/lib/taurus/core/tango/test/test_tangovalidator.py
+++ b/lib/taurus/core/tango/test/test_tangovalidator.py
@@ -38,11 +38,11 @@ from taurus.core.tango.tangovalidator import (TangoAuthorityNameValidator,
                                               TangoAttributeNameValidator)
 
 import PyTango
-import socket
+from taurus.core.util.fqdn import fqdn_no_alias
 
 __PY_TANGO_HOST = PyTango.ApiUtil.get_env_var("TANGO_HOST")
 host, port = __PY_TANGO_HOST.split(':')
-__TANGO_HOST = "{0}:{1}".format(socket.getfqdn(host), port)
+__TANGO_HOST = "{0}:{1}".format(fqdn_no_alias(host), port)
 
 #=========================================================================
 # Tests for Tango Authority  name validation

--- a/lib/taurus/core/util/fqdn.py
+++ b/lib/taurus/core/util/fqdn.py
@@ -44,7 +44,6 @@ def fqdn_no_alias(hostname):
         real, aliases, _ = socket.gethostbyname_ex(hostname)
     except (socket.gaierror, socket.herror) as e:
         # return the given hostname in case of error
-        warning("fqdn_no_alias: problem resolving %s: %r", hostname, e)
         return hostname
 
     if aliases:

--- a/lib/taurus/core/util/fqdn.py
+++ b/lib/taurus/core/util/fqdn.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+
+#############################################################################
+##
+# This file is part of Taurus
+##
+# http://taurus-scada.org
+##
+# Copyright 2011 CELLS / ALBA Synchrotron, Bellaterra, Spain
+##
+# Taurus is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+##
+# Taurus is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+##
+# You should have received a copy of the GNU Lesser General Public License
+# along with Taurus.  If not, see <http://www.gnu.org/licenses/>.
+##
+#############################################################################
+"""
+This module contains provides the fqdn_no_alias function.
+"""
+
+import socket
+from taurus import warning
+
+
+def fqdn_no_alias(hostname):
+    """
+    Normalize hostname so that it is a full name (including domain name).
+
+    .. note:: this is similar to socket.getfqdn, but it avoids translating
+              aliases into their "real" address.
+    """
+    if hostname == "localhost" or "." in hostname:
+        # optimization: leave localhost or names including domain as they are
+        return hostname
+
+    try:
+        real, aliases, _ = socket.gethostbyname_ex(hostname)
+    except (socket.gaierror, socket.herror) as e:
+        # return the given hostname in case of error
+        warning("fqdn_no_alias: problem resolving %s: %r", hostname, e)
+        return hostname
+
+    if aliases:
+        # return alias if it exists
+        if len(aliases) > 1:
+            # warn in the (unusual) case that there is more than 1 alias
+            warning("fqdn_no_alias: %s has %d aliases. Using the first one",
+                    hostname,
+                    len(aliases)
+                    )
+        return aliases[0]
+    else:
+        # if there are no aliases, return real
+        return real
+
+
+if __name__ == '__main__':
+
+    # TODO: convert this into a pytest test
+    #       (but need to figure out how to generalize the "www" test)
+
+    # test nonexistent
+    assert fqdn_no_alias("NONEXISTENT") == "NONEXISTENT"
+    # test localhost
+    assert fqdn_no_alias("localhost") == "localhost"
+    # test with an existent host in your domain (with just host name)
+    # TODO: this is domain-specific! it needs to be generalized somehow
+    print(socket.gethostbyname_ex('www'))  # use something in your domain
+    print("socket.getfqdn:", socket.getfqdn("www"))
+    assert fqdn_no_alias("www") == "www.cells.es"
+    # test with an aliased full hostname+domain (the alias is not resolved!)
+    print(socket.gethostbyname_ex('mail.google.com'))
+    print("socket.getfqdn:", socket.getfqdn("mail.google.com"))
+    assert fqdn_no_alias("mail.google.com") == "mail.google.com"
+


### PR DESCRIPTION
taurus.core.tango expands the tangohost names using socket.getfqdn()
in order to normalize PQDN names into FQDN when generating the model
full names. This has the unwanted side-effect that if the host name is
defined as an alias in the ressolv chain, the target of the alias is
returned.
This causes problems with events tango events (the DB name
in the client does not match that of the DB itself and the events are
lost).
It can also cause trouble if the expanded model names are stored in
some persistent media and the target of the alias is changed in the
meanwhile (e.g. if the Tango DB is served from a cloud provider that
dynamically changes the actual machine running it).

Fix these issues by replacing socket.getfqdn() by an alternative that
behaves like it except in that it honors the aliases.