### PR TITLE
Do not keep a device alive just because an attribute is polled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ develop branch) won't be reflected in this file.
 - Several issues affecting synoptics (#1005, #1029)
 - Support dns aliases for the authority name in tango model names (#998)
 - Py3 exception in `TaurusModelChooser.getListedModels()` (#1008)
+- Thread safety issues in `TaurusPollingTimer`'s add/remove attributes API (#1022, #999)
 - (for py2) Improved backwards compatibility of `taurus.qt.qtgui.plot` (#1027)
 - Exception in DelayedSubscriber (#1030)
 - Compatibility issue in deprecated TangoAttribute's `isScalar()` and `isSpectrum()` (#1034)

--- a/lib/taurus/core/tango/tangodevice.py
+++ b/lib/taurus/core/tango/tangodevice.py
@@ -340,7 +340,7 @@ class TangoDevice(TaurusDevice):
                 v, err = None, DevFailed(*da.get_err_stack())
             else:
                 v, err = da, None
-            attr = attrs[da.name]
+            attr = attrs[da.name.lower()]
             attr.poll(single=False, value=v, error=err, time=ts)
 
     def __pollAsynch(self, attrs):

--- a/lib/taurus/core/tango/tangodevice.py
+++ b/lib/taurus/core/tango/tangodevice.py
@@ -340,7 +340,7 @@ class TangoDevice(TaurusDevice):
                 v, err = None, DevFailed(*da.get_err_stack())
             else:
                 v, err = da, None
-            attr = attrs[da.name.lower()]
+            attr = attrs[da.name]
             attr.poll(single=False, value=v, error=err, time=ts)
 
     def __pollAsynch(self, attrs):

--- a/lib/taurus/core/tango/test/test_tangofactory.py
+++ b/lib/taurus/core/tango/test/test_tangofactory.py
@@ -81,9 +81,28 @@ def test_cleanup_after_polling():
     """
     Ensure that polling a Tango attribute does not keep device alive
     See Bug #999
+    (Also check case insensitivity)
     """
     polling_period = .1  # seconds
-    a = taurus.Attribute('sys/tg_test/1/float_scalar')
+    a = taurus.Attribute('sys/TG_test/1/FLOAT_scalar')
+    f = a.factory()
+    a.activatePolling(polling_period * 1000, force=True)
+    assert len(list(f.tango_attrs.keys())) == 1
+    assert len(list(f.tango_devs.keys())) == 1
+    a = None
+    time.sleep(polling_period)
+    assert len(list(f.tango_attrs.keys())) == 0
+    assert len(list(f.tango_devs.keys())) == 0
+
+
+def test_cleanup_state_after_polling():
+    """
+    Ensure that polling the state Tango attribute does not keep device alive
+    See Bug #999
+    (Also check case insensitivity)
+    """
+    polling_period = .1  # seconds
+    a = taurus.Attribute('sys/TG_TEST/1/STate')
     f = a.factory()
     a.activatePolling(polling_period * 1000, force=True)
     assert len(list(f.tango_attrs.keys())) == 1

--- a/lib/taurus/core/tango/test/test_tangofactory.py
+++ b/lib/taurus/core/tango/test/test_tangofactory.py
@@ -26,6 +26,7 @@
 """Tests for taurus.core.tango.tangofactory"""
 
 
+import time
 import taurus
 
 from taurus.external.unittest import TestCase
@@ -74,3 +75,38 @@ class TestFactoryGarbageCollection(TangoSchemeTestLauncher, TestCase):
 
     def tearDown(self):
         self.factory = None
+
+def test_cleanup_after_polling_1():
+    """
+    Ensure that polling a Tango attribute does not keep device alive
+    """
+    polling_period = .1  # seconds
+    a = taurus.Attribute('sys/tg_test/1/float_scalar')
+    f = a.factory()
+    a.activatePolling(polling_period * 1000, force=True)
+    assert len(f.tango_attrs.keys()) == 1
+    assert len(f.tango_devs.keys()) == 1
+    a.disablePolling()
+    a = None
+    assert len(f.tango_attrs.keys()) == 0
+    assert len(f.tango_devs.keys()) == 0
+
+
+def test_cleanup_after_polling_2():
+    """
+    Ensure that polling a Tango attribute does not keep device alive
+    See Bug #999
+    """
+    polling_period = .1  # seconds
+    a = taurus.Attribute('sys/tg_test/1/float_scalar')
+    f = a.factory()
+    a.activatePolling(polling_period * 1000, force=True)
+    assert len(f.tango_attrs.keys()) == 1
+    assert len(f.tango_devs.keys()) == 1
+    a = None
+    assert len(f.tango_attrs.keys()) == 0
+    assert len(f.tango_devs.keys()) == 1
+    time.sleep(polling_period)
+    assert len(f.tango_attrs.keys()) == 0
+    assert len(f.tango_devs.keys()) == 0
+

--- a/lib/taurus/core/tango/test/test_tangofactory.py
+++ b/lib/taurus/core/tango/test/test_tangofactory.py
@@ -88,6 +88,7 @@ def test_cleanup_after_polling_1():
     assert len(f.tango_devs.keys()) == 1
     a.disablePolling()
     a = None
+    time.sleep(polling_period)
     assert len(f.tango_attrs.keys()) == 0
     assert len(f.tango_devs.keys()) == 0
 
@@ -105,7 +106,6 @@ def test_cleanup_after_polling_2():
     assert len(f.tango_devs.keys()) == 1
     a = None
     assert len(f.tango_attrs.keys()) == 0
-    assert len(f.tango_devs.keys()) == 1
     time.sleep(polling_period)
     assert len(f.tango_attrs.keys()) == 0
     assert len(f.tango_devs.keys()) == 0

--- a/lib/taurus/core/tango/test/test_tangofactory.py
+++ b/lib/taurus/core/tango/test/test_tangofactory.py
@@ -76,24 +76,8 @@ class TestFactoryGarbageCollection(TangoSchemeTestLauncher, TestCase):
     def tearDown(self):
         self.factory = None
 
-def test_cleanup_after_polling_1():
-    """
-    Ensure that polling a Tango attribute does not keep device alive
-    """
-    polling_period = .1  # seconds
-    a = taurus.Attribute('sys/tg_test/1/float_scalar')
-    f = a.factory()
-    a.activatePolling(polling_period * 1000, force=True)
-    assert len(f.tango_attrs.keys()) == 1
-    assert len(f.tango_devs.keys()) == 1
-    a.disablePolling()
-    a = None
-    time.sleep(polling_period)
-    assert len(f.tango_attrs.keys()) == 0
-    assert len(f.tango_devs.keys()) == 0
 
-
-def test_cleanup_after_polling_2():
+def test_cleanup_after_polling():
     """
     Ensure that polling a Tango attribute does not keep device alive
     See Bug #999
@@ -102,11 +86,11 @@ def test_cleanup_after_polling_2():
     a = taurus.Attribute('sys/tg_test/1/float_scalar')
     f = a.factory()
     a.activatePolling(polling_period * 1000, force=True)
-    assert len(f.tango_attrs.keys()) == 1
-    assert len(f.tango_devs.keys()) == 1
+    assert len(list(f.tango_attrs.keys())) == 1
+    assert len(list(f.tango_devs.keys())) == 1
     a = None
-    assert len(f.tango_attrs.keys()) == 0
+    assert len(list(f.tango_attrs.keys())) == 0
     time.sleep(polling_period)
-    assert len(f.tango_attrs.keys()) == 0
-    assert len(f.tango_devs.keys()) == 0
+    assert len(list(f.tango_attrs.keys())) == 0
+    assert len(list(f.tango_devs.keys())) == 0
 

--- a/lib/taurus/core/tango/test/test_tangofactory.py
+++ b/lib/taurus/core/tango/test/test_tangofactory.py
@@ -89,7 +89,6 @@ def test_cleanup_after_polling():
     assert len(list(f.tango_attrs.keys())) == 1
     assert len(list(f.tango_devs.keys())) == 1
     a = None
-    assert len(list(f.tango_attrs.keys())) == 0
     time.sleep(polling_period)
     assert len(list(f.tango_attrs.keys())) == 0
     assert len(list(f.tango_devs.keys())) == 0

--- a/lib/taurus/core/taurusfactory.py
+++ b/lib/taurus/core/taurusfactory.py
@@ -340,7 +340,8 @@ class TaurusFactory(object):
         """Activates the polling (client side) for the given attribute with the
            given period (seconds).
 
-           :param attribute: (taurus.core.tango.TaurusAttribute) attribute name.
+           :param attribute: (taurus.core.taurusattribute.TaurusAttribute)
+                             the attribute to be added
            :param period: (float) polling period (in seconds)
            :param unsubscribe_evts: (bool) whether or not to unsubscribe from events
         """
@@ -352,7 +353,8 @@ class TaurusFactory(object):
         """Deactivate the polling (client side) for the given attribute. If the
            polling of the attribute was not previously enabled, nothing happens.
 
-           :param attribute: (str) attribute name.
+           :param attribute: (taurus.core.taurusattribute.TaurusAttribute)
+                             the attribute to be removed
         """
         timers = dict(self.polling_timers)
         for period, timer in timers.items():

--- a/lib/taurus/core/taurusfactory.py
+++ b/lib/taurus/core/taurusfactory.py
@@ -340,7 +340,7 @@ class TaurusFactory(object):
         """Activates the polling (client side) for the given attribute with the
            given period (seconds).
 
-           :param attribute: (taurus.core.tango.TangoAttribute) attribute name.
+           :param attribute: (taurus.core.tango.TaurusAttribute) attribute name.
            :param period: (float) polling period (in seconds)
            :param unsubscribe_evts: (bool) whether or not to unsubscribe from events
         """
@@ -354,15 +354,11 @@ class TaurusFactory(object):
 
            :param attribute: (str) attribute name.
         """
-        p = None
-        for period, timer in self.polling_timers.items():
-            if timer.containsAttribute(attribute):
-                timer.removeAttribute(attribute)
-                if timer.getAttributeCount() == 0:
-                    p = period
-                break
-        if p:
-            del self.polling_timers[period]
+        timers = dict(self.polling_timers)
+        for period, timer in timers.items():
+            timer.removeAttribute(attribute)
+            if not timer.dev_dict:
+                del self.polling_timers[period]
 
     def __str__(self):
         return '{0}()'.format(self.__class__.__name__)

--- a/lib/taurus/core/tauruspollingtimer.py
+++ b/lib/taurus/core/tauruspollingtimer.py
@@ -29,7 +29,7 @@ import weakref
 import threading
 
 from .util.log import Logger
-from .util.containers import CaselessWeakValueDict
+from .util.containers import CaselessWeakValueDict, CaselessDict
 from .util.timer import Timer
 
 __all__ = ["TaurusPollingTimer"]
@@ -138,7 +138,10 @@ class TaurusPollingTimer(Logger):
         dev_dict = {}
         with self.lock:
             for dev, attrs in self.dev_dict.items():
-                dev_dict[dev] = dict(attrs)
+                if dev.factory().caseSensitive:
+                    dev_dict[dev] = dict(attrs)
+                else:
+                    dev_dict[dev] = CaselessDict(attrs)
 
         for dev, attrs in dev_dict.items():
             try:

--- a/lib/taurus/core/tauruspollingtimer.py
+++ b/lib/taurus/core/tauruspollingtimer.py
@@ -93,21 +93,22 @@ class TaurusPollingTimer(Logger):
                               that it should startup as soon as there is at least
                               one attribute registered.
         """
-        dev, attr_name = attribute.getParentObj(), attribute.getSimpleName()
-        attr_dict = self.dev_dict.get(dev)
-        if attr_dict is None:
-            if attribute.factory().caseSensitive:
-                self.dev_dict[dev] = attr_dict = weakref.WeakValueDictionary()
+        with self.lock:
+            dev, attr_name = attribute.getParentObj(), attribute.getSimpleName()
+            attr_dict = self.dev_dict.get(dev)
+            if attr_dict is None:
+                if attribute.factory().caseSensitive:
+                    self.dev_dict[dev] = attr_dict = weakref.WeakValueDictionary()
+                else:
+                    self.dev_dict[dev] = attr_dict = CaselessWeakValueDict()
+            if attr_name not in attr_dict:
+                attr_dict[attr_name] = attribute
+                self.attr_nb += 1
+            if self.attr_nb == 1 and auto_start:
+                self.start()
             else:
-                self.dev_dict[dev] = attr_dict = CaselessWeakValueDict()
-        if attr_name not in attr_dict:
-            attr_dict[attr_name] = attribute
-            self.attr_nb += 1
-        if self.attr_nb == 1 and auto_start:
-            self.start()
-        else:
-            import taurus
-            taurus.Manager().enqueueJob(attribute.poll)
+                import taurus
+                taurus.Manager().enqueueJob(attribute.poll)
 
     def removeAttribute(self, attribute):
         """Unregisters the attribute from this polling. If the number of registered
@@ -116,32 +117,40 @@ class TaurusPollingTimer(Logger):
 
            :param attribute: (taurus.core.taurusattribute.TaurusAttribute) the attribute to be added
         """
-        dev, attr_name = attribute.getParentObj(), attribute.getSimpleName()
-        attr_dict = self.dev_dict.get(dev)
-        if attr_dict is None:
-            return
-        if attr_name in attr_dict:
-            del attr_dict[attr_name]
+        with self.lock:
+            dev, attr_name = attribute.getParentObj(), attribute.getSimpleName()
+            attr_dict = self.dev_dict.get(dev)
+            if attr_dict is None:
+                return
+            if attr_name in attr_dict:
+                del attr_dict[attr_name]
+                self.attr_nb -= 1
             if not attr_dict:
                 del self.dev_dict[dev]
-            self.attr_nb -= 1
-        if self.attr_nb < 1:
-            self.stop()
+            if not self.dev_dict:
+                self.stop()
 
     def _pollAttributes(self):
         """Polls the registered attributes. This method is called by the timer
            when it is time to poll. Do not call this method directly
         """
         req_ids = {}
-        for dev, attrs in self.dev_dict.items():
+        dev_dict = {}
+        with self.lock:
+            for dev, attrs in self.dev_dict.items():
+                dev_dict[dev] = dict(attrs)
+
+        for dev, attrs in dev_dict.items():
             try:
                 req_id = dev.poll(attrs, asynch=True)
                 req_ids[dev] = attrs, req_id
             except Exception as e:
                 self.error("poll_asynch error")
                 self.debug("Details:", exc_info=1)
+
         for dev, (attrs, req_id) in req_ids.items():
             try:
                 dev.poll(attrs, req_id=req_id)
             except Exception as e:
-                self.error("poll_reply error")
+                self.error("poll_reply error %r", e)
+

--- a/lib/taurus/core/tauruspollingtimer.py
+++ b/lib/taurus/core/tauruspollingtimer.py
@@ -58,9 +58,9 @@ class TaurusPollingTimer(Logger):
         """ Starts the polling timer """
         self.timer.start()
 
-    def stop(self):
+    def stop(self, sync=False):
         """ Stop the polling timer"""
-        self.timer.stop()
+        self.timer.stop(sync=sync)
 
     def containsAttribute(self, attribute):
         """Determines if the polling timer already contains this attribute
@@ -128,7 +128,7 @@ class TaurusPollingTimer(Logger):
             if not attr_dict:
                 del self.dev_dict[dev]
             if not self.dev_dict:
-                self.stop()
+                self.stop(sync=True)
 
     def _pollAttributes(self):
         """Polls the registered attributes. This method is called by the timer

--- a/lib/taurus/core/util/containers.py
+++ b/lib/taurus/core/util/containers.py
@@ -254,9 +254,15 @@ class CaselessDict(dict):
     def __init__(self, other=None):
         if other:
             # Doesn't do keyword args
-            if isinstance(other, dict):
+
+            # -------------------------------------------------------
+            # TODO: when we drop py2 support, change this to
+            #       `if isinstance(other, collections.abc.Mapping)`
+            #
+            if hasattr(other, 'items'):
                 for k, v in other.items():
                     dict.__setitem__(self, k.lower(), v)
+            # -------------------------------------------------------
             else:
                 for k, v in other:
                     dict.__setitem__(self, k.lower(), v)

--- a/lib/taurus/core/util/timer.py
+++ b/lib/taurus/core/util/timer.py
@@ -76,12 +76,14 @@ class Timer(Logger):
         finally:
             self.__lock.release()
 
-    def stop(self):
+    def stop(self, sync=False):
         """ Stop Timer Object """
         self.debug("Timer::stop()")
         self.__lock.acquire()
         self.__loop = False
         self.__lock.release()
+        if sync and self.__thread is not None:
+            self.__thread.join()
 
     def __run(self):
         """ Private Thread Function """


### PR DESCRIPTION
The TaurusPollingTimer keeps device strong references
for creating the  weakref dictionary of polled attributes.
The removeAttribute does not cleanup the structures and
many of TaurusPollingTimer methods are not thread-safe.

Fix removeAttribute implementation to delete unreferenced
elements.
Protect the methods using the lock or making copy of the
iterated containers.

Fix #999

