### PR TITLE
Fix exception in TaurusModelChooser.getListedModels()

### DIFF
--- a/lib/taurus/qt/qtgui/panel/taurusmodelchooser.py
+++ b/lib/taurus/qt/qtgui/panel/taurusmodelchooser.py
@@ -355,12 +355,16 @@ class TaurusModelChooser(TaurusWidget):
             models = models[:1]
         if asMimeData:
             md = Qt.QMimeData()
-            md.setData(taurus.qt.qtcore.mimetypes.TAURUS_MODEL_LIST_MIME_TYPE, str(
-                "\r\n".join(models)))
+            md.setData(
+                taurus.qt.qtcore.mimetypes.TAURUS_MODEL_LIST_MIME_TYPE,
+                bytes("\r\n".join(models), encoding="utf8")
+            )
             md.setText(", ".join(models))
             if len(models) == 1:
                 md.setData(
-                    taurus.qt.qtcore.mimetypes.TAURUS_MODEL_MIME_TYPE, str(models[0]))
+                    taurus.qt.qtcore.mimetypes.TAURUS_MODEL_MIME_TYPE,
+                    bytes(models[0], encoding="utf8")
+                )
             return md
         return models
 


### PR DESCRIPTION
TaurusModelChooser.getListedModels raises an exception under python3
due to awrong usage of str instead of bytes. This is an oversight from
#886.

Thanks to Pierre Héricourt for spotting and suggesting the fix.

Fixes #997