### PR TITLE
Improve wheel edit handling of formats and digits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ develop branch) won't be reflected in this file.
 ### Changed
 ### Deprecated
 ### Fixed
+- Several issues in TaurusWheelEdit (#1010)
 
 ## [4.6.1] - 2019-08-19
 Hotfix for auto-deployment in PyPI with Travis. No other difference from 4.6.0.

--- a/lib/taurus/qt/qtgui/input/qwheel.py
+++ b/lib/taurus/qt/qtgui/input/qwheel.py
@@ -220,6 +220,10 @@ class QWheelEdit(Qt.QFrame):
         self._setValue(0)
 
         self._build()
+        self.setDigitCountAction = Qt.QAction("Change digits", self)
+        self.setDigitCountAction.triggered.connect(self._onSetDigitCount)
+        self.addAction(self.setDigitCountAction)
+        self.setContextMenuPolicy(Qt.Qt.ActionsContextMenu)
 
     def _getMinPossibleValue(self):
         """_getMinPossibleValue(self) -> None
@@ -547,6 +551,28 @@ class QWheelEdit(Qt.QFrame):
             self._setValue(self.getValue() + b._inc)
             self._updateValue()
 
+    def _onSetDigitCount(self):
+        text, ok = Qt.QInputDialog.getText(
+            self,
+            "Change digits",
+            "Enter digits as <int_nb>.<dec_nb>",
+            text="{:d}.{:d}".format(
+                self.getIntDigitCount(),
+                self.getDecDigitCount()
+            )
+        )
+        if ok:
+            try:
+                dc = list(map(int, text.split('.')))
+                self.setDigitCount(*dc)
+            except Exception as e:
+                Qt.QMessageBox.warning(
+                    self,
+                    "Invalid digit count specification",
+                    'Invalid specification: "{}"\nReason:{}'.format(text, e)
+                )
+                self._onSetDigitCount()
+
     def setDigitCount(self, int_nb, dec_nb):
         """setDigitCount(self, int_nb, dec_nb) -> None
 
@@ -775,7 +801,6 @@ class QWheelEdit(Qt.QFrame):
                                                                l.columnCount() - 1).bottomRight())
         ed.setGeometry(rect)
         ed.setAlignment(Qt.Qt.AlignRight)
-        ed.setMaxLength(self.getDigitCount() + 2)
         ed.setText(self.getValueStr())
         ed.selectAll()
         ed.setFocus()

--- a/lib/taurus/qt/qtgui/input/qwheel.py
+++ b/lib/taurus/qt/qtgui/input/qwheel.py
@@ -504,6 +504,8 @@ class QWheelEdit(Qt.QFrame):
         Sets value of this widget. If the given value exceeds any limit, the
         value is NOT set.
         """
+        if v is None:
+            return
         if self._roundFunc:
             v = self._roundFunc(v)
         if v > self._maxValue or v < self._minValue:

--- a/lib/taurus/qt/qtgui/input/qwheel.py
+++ b/lib/taurus/qt/qtgui/input/qwheel.py
@@ -179,7 +179,9 @@ class _NumericEditor(Qt.QLineEdit):
 
     def __init__(self, parent=None):
         Qt.QLineEdit.__init__(self, parent)
-        self.setValidator(Qt.QDoubleValidator(self))
+        validator = Qt.QDoubleValidator(self)
+        validator.setNotation(validator.StandardNotation)
+        self.setValidator(validator)
         self.setFrame(False)
 
 

--- a/lib/taurus/qt/qtgui/input/qwheel.py
+++ b/lib/taurus/qt/qtgui/input/qwheel.py
@@ -174,17 +174,6 @@ class _DigitLabel(Qt.QLabel):
     skin = Qt.pyqtProperty('QString', getSkin, setSkin, resetSkin)
 
 
-class _NumericEditor(Qt.QLineEdit):
-    """A private editor to be used by QWheelEdit widget"""
-
-    def __init__(self, parent=None):
-        Qt.QLineEdit.__init__(self, parent)
-        validator = Qt.QDoubleValidator(self)
-        validator.setNotation(validator.StandardNotation)
-        self.setValidator(validator)
-        self.setFrame(False)
-
-
 class QWheelEdit(Qt.QFrame):
     """A widget designed to handle numeric scalar values. It allows interaction
     based on single digit as well as normal value edition."""
@@ -217,6 +206,8 @@ class QWheelEdit(Qt.QFrame):
         self._hideEditWidget = True
         self._showArrowButtons = True
         self._forwardReturn = False
+        self._validator = Qt.QDoubleValidator(self)
+        self._validator.setNotation(self._validator.StandardNotation)
         self._setDigits(QWheelEdit.DefaultIntDigitCount,
                         QWheelEdit.DefaultDecDigitCount)
         self._setValue(0)
@@ -327,17 +318,19 @@ class QWheelEdit(Qt.QFrame):
         self._upButtons.buttonClicked.connect(self.buttonPressed)
         self._downButtons.buttonClicked.connect(self.buttonPressed)
 
-        ed = _NumericEditor(self)
+        ed = Qt.QLineEdit(self)
+        ed.setFrame(False)
         ed.returnPressed.connect(self.editingFinished)
         ed.editingFinished.connect(self.hideEditWidget)
         rect = Qt.QRect(l.cellRect(1, 0).topLeft(),
                         l.cellRect(1, l.columnCount() - 1).bottomRight())
         ed.setGeometry(rect)
         ed.setAlignment(Qt.Qt.AlignRight)
-        ed.validator().setRange(self.getMinValue(), self.getMaxValue(),
-                                self.getDecDigitCount())
+        ed.setValidator(self._validator)
         ed.setVisible(False)
         self._editor = ed
+
+        self._updateValidator()
 
         # set the minimum height for the widget
         # (otherwise the hints seem to be ignored by the layouts)
@@ -377,17 +370,6 @@ class QWheelEdit(Qt.QFrame):
         self._editor.destroy()
         self._editor = None
 
-    def _setMinMax(self, min, max):
-        """_setMinMax(self, min, max) -> None
-
-        Sets the minimum and maximum values for this widget
-
-        @param[in] min(float) minimum value
-        @param[in] max(float) maximum value
-        """
-        self._minValue = min
-        self._maxValue = max
-
     def _setDigits(self, int_nb=None, dec_nb=None):
         """_setDigits(self, int_nb=None, dec_nb=None) -> None
 
@@ -415,8 +397,7 @@ class QWheelEdit(Qt.QFrame):
         if self._decDigitCount > 0:
             total_chars += 1  # for dot
         self._valueFormat = '%%+0%d.%df' % (total_chars, self._decDigitCount)
-        self._setMinMax(self._getMinPossibleValue(),
-                        self._getMaxPossibleValue())
+        self._updateValidator()
         # we call setValue to update the self._value_str
         self._setValue(self.getValue())
 
@@ -510,13 +491,15 @@ class QWheelEdit(Qt.QFrame):
             return
         if self._roundFunc:
             v = self._roundFunc(v)
-        if v > self._maxValue or v < self._minValue:
+        if v > self._validator.top() or v < self._validator.bottom():
             Qt.QMessageBox.warning(
                 self,
                 "Invalid Value",
-                ("'{}' cannot be represented in current widget. \n"
-                 + "Tip: try changing the number of digits from context menu"
-                 ).format(v)
+                "'{}' is out of the allowed range ({}, {})".format(
+                    v,
+                    self._validator.bottom(),
+                    self._validator.top(),
+                )
             )
             return
         self._previous_value = self._value
@@ -712,17 +695,19 @@ class QWheelEdit(Qt.QFrame):
         @param[in] v (float) the new minimum allowed value
         """
         self._minValue = v
-        w = self.getEditWidget()
-        if not w is None:
-            w.validator().setRange(self._minValue, self._maxValue, self._decDigitCount)
+        self._updateValidator()
+
+    def _updateValidator(self):
+        min_ = max(self._minValue, self._getMinPossibleValue())
+        max_ = min(self._maxValue, self._getMaxPossibleValue())
+        self._validator.setRange(min_, max_, self._decDigitCount)
 
     def resetMinValue(self):
         """resetMinValue(self) -> None
 
-        Resets the minimum allowed value to the minimum possible according to
-        the current total number of digits
+        Resets the minimum allowed value to -inf
         """
-        self.setMinValue(self._getMinPossibleValue())
+        self.setMinValue(numpy.finfo('d').min)
 
     def getMaxValue(self):
         """getMaxValue(self) -> float
@@ -741,17 +726,14 @@ class QWheelEdit(Qt.QFrame):
         @param[in] v (float) the new maximum allowed value
         """
         self._maxValue = v
-        w = self.getEditWidget()
-        if not w is None:
-            w.validator().setRange(self._minValue, self._maxValue, self._decDigitCount)
+        self._updateValidator()
 
     def resetMaxValue(self):
         """resetMaxValue(self) -> None
 
-        Resets the maximum allowed value to the maximum possible according to
-        the current total number of digits
+        Resets the maximum allowed value to +inf
         """
-        self.setMaxValue(self._getMaxPossibleValue())
+        self.setMaxValue(numpy.finfo('d').max)
 
     def getAutoRepeat(self):
         return self._upButtons.buttons()[0].autoRepeat()

--- a/lib/taurus/qt/qtgui/input/qwheel.py
+++ b/lib/taurus/qt/qtgui/input/qwheel.py
@@ -511,6 +511,13 @@ class QWheelEdit(Qt.QFrame):
         if self._roundFunc:
             v = self._roundFunc(v)
         if v > self._maxValue or v < self._minValue:
+            Qt.QMessageBox.warning(
+                self,
+                "Invalid Value",
+                ("'{}' cannot be represented in current widget. \n"
+                 + "Tip: try changing the number of digits from context menu"
+                 ).format(v)
+            )
             return
         self._previous_value = self._value
         self._value = v

--- a/lib/taurus/qt/qtgui/input/tauruswheel.py
+++ b/lib/taurus/qt/qtgui/input/tauruswheel.py
@@ -56,42 +56,16 @@ class TaurusWheelEdit(QWheelEdit, TaurusBaseWritableWidget):
 
     def handleEvent(self, evt_src, evt_type, evt_value):
         if evt_type == TaurusEventType.Config and evt_value is not None:
-            import re
-            # match the format string to "%[width][.precision][f_type]"
             obj = self.getModelObj()
-            m = re.match(r'%([0-9]+)?(\.([0-9]+))?([df])', obj.format)
-            if m is None:
-                raise ValueError("'%s' format unsupported" % obj.format)
+            # set decimal digits
+            self.setDigitCount(int_nb=None, dec_nb=obj.precision)
+            # set min and max values
+            min_, max_ = obj.getRange()
+            if min_ is not None:
+                self.setMinValue(min_.magnitude)
+            if max_ is not None:
+                self.setMaxValue(max_.magnitude)
 
-            width, _, precision, f_type = m.groups()
-
-            if width is None:
-                width = self.DefaultIntDigitCount + \
-                    self.DefaultDecDigitCount + 1
-            else:
-                width = int(width)
-
-            if precision is None:
-                precision = self.DefaultDecDigitCount
-            else:
-                precision = int(precision)
-
-            dec_nb = precision
-
-            if dec_nb == 0 or f_type == 'd':
-                int_nb = width
-            else:
-                int_nb = width - dec_nb - 1  # account for decimal sep
-
-            self.setDigitCount(int_nb=int_nb, dec_nb=dec_nb)
-            try:
-                self.setMinValue(float(obj.min_value))
-            except:
-                pass
-            try:
-                self.setMaxValue(float(obj.max_value))
-            except:
-                pass
         TaurusBaseWritableWidget.handleEvent(
             self, evt_src, evt_type, evt_value)
 


### PR DESCRIPTION
This PR tackles 3 different issues related to the wheel edit widget:
- usage of tango-centric API
- poor synchronization between the wheel edit and its internal editor
- user cannot control (via GUI) the number of digits shown by the widget

## usage of tango-centric API

For example the following code: will raise an exception and deprecation warnings:

```python
from taurus.qt.qtgui.application import TaurusApplication
from taurus.qt.qtgui.panel import TaurusForm
from taurus.qt.qtgui.input import TaurusWheelEdit

if __name__ == '__main__':
    import sys
    app = TaurusApplication(cmd_line_parser=None)
    w = TaurusForm()
    w.setModel( ['sys/tg_test/1/ampli'])
    w[0].setWriteWidgetClass(TaurusWheelEdit)
    w.show()
    sys.exit(app.exec_())
```

Raises an exception:
```ValueError: '%6.2e' format unsupported```
And also a deprecation warning:
 ```DeprecationWarning: format is deprecated since 4.0.4. Use format_spec or precision instead```

This PR fixes it, **but in doing so, it removes the feature that the format is used to initialize the number of digits** (this is mitigated by the implementation of user-access to setting the number of digits, see below)

## poor synchronization between the wheel edit and its internal editor

The internal editor widget allows to type in values that cannot be represented by the wheel widget. When this occurs and return is pressed, the value is silently discarded, which can be confusing.

This is fixed by making the internal editor enforce the same limitations as the wheel when editing.

## user cannot control (via GUI) the number of digits shown by the widget

This PR adds an action (accessible via context menu of the wheel edit widget) that allows the user to set the digit count. 
