### PR TITLE
Fix TaurusImageDialog.setModel Qt slot in py2

### DIFF
--- a/lib/taurus/qt/qtgui/extra_guiqwt/plot.py
+++ b/lib/taurus/qt/qtgui/extra_guiqwt/plot.py
@@ -474,7 +474,7 @@ class TaurusImageDialog(ImageDialog, TaurusBaseWidget):
         '''reimplemented from :class:`TaurusBaseWidget`'''
         return taurus.core.taurusattribute.TaurusAttribute
 
-    @Qt.pyqtSlot(str)
+    @Qt.pyqtSlot("QString")
     def setModel(self, model):
         '''reimplemented from :class:`TaurusBaseWidget`'''
         if self.getUseParentModel():


### PR DESCRIPTION
The setModel slot of TaurusImageDialog is not exposed in py2 due to
a wrong py2-py3 compatibility definition. Use `"QString" ` instead of
`str` for defining the slot in a py2+3 compatible way.

Fixes #1023