### PR TITLE
Fix #909: expose more modules from qwt5 in qtgui.plot

### DIFF
--- a/lib/taurus/qt/qtgui/plot/__init__.py
+++ b/lib/taurus/qt/qtgui/plot/__init__.py
@@ -52,7 +52,17 @@ __log.deprecated(dep='taurus.qt.qtgui.plot', rel='4.5',
                  alt='taurus.qt.qtgui.tpg or taurus.qt.qtgui.qwt5')
 
 try:
+    # Import all from qwt5
     from taurus.qt.qtgui.qwt5 import *
+    # ...and patch sys.modules to expose all qwt5 submodules here
+    # (even those not in the public API). This fixes
+    # https://github.com/taurus-org/taurus/issues/909)
+    import sys
+    d = {}
+    for k, v in sys.modules.items():
+        if 'taurus.qt.qtgui.qwt5.' in k:
+            d[k.replace('taurus.qt.qtgui.qwt5.', 'taurus.qt.qtgui.plot.')] = v
+    sys.modules.update(d)
 except:
     try:
         from taurus.qt.qtgui.tpg import TaurusPlot, TaurusTrend


### PR DESCRIPTION
The `taurus.qt.qtgui.plot` module is a backwards-compatibility
implementation that exposes all public API from `taurus.qt.qtgui.qwt5`.

Unfortunately, in some cases, the non-public API is also needed for
backwards compat. One example is when loading old settings files
(created with v<4.5) that are based on pickles that end up calling
`import taurus.qt.qtgui.plot.curvesAppearanceChooserDlg`.

In order to provide better backwards compatibility, patch sys.modules
by injecting the submodules of `taurus.qt.qtgui.qwt5` as submodules of
`taurus.qt.qtgui.plot`.

Fixes #909 