### PR TITLE
Fix TaurusValueComboBox does not show set value

### DIFF
--- a/lib/taurus/qt/qtgui/input/tauruscombobox.py
+++ b/lib/taurus/qt/qtgui/input/tauruscombobox.py
@@ -115,7 +115,7 @@ class TaurusValueComboBox(Qt.QComboBox, TaurusBaseWritableWidget):
         Set the value for the widget to display, not the value of the
         attribute.
         """
-        index = self.findData(value)
+        index = self.findData(str(value))
         self._setCurrentIndex(index)
 
     def updateStyle(self):

--- a/lib/taurus/qt/qtgui/input/tauruscombobox.py
+++ b/lib/taurus/qt/qtgui/input/tauruscombobox.py
@@ -36,6 +36,7 @@ from taurus.core import DataType, TaurusEventType
 from taurus.core.taurusattribute import TaurusAttribute
 from taurus.qt.qtgui.base import TaurusBaseWidget, TaurusBaseWritableWidget
 from taurus.core.util import eventfilters
+import numpy
 
 
 class TaurusValueComboBox(Qt.QComboBox, TaurusBaseWritableWidget):
@@ -115,8 +116,26 @@ class TaurusValueComboBox(Qt.QComboBox, TaurusBaseWritableWidget):
         Set the value for the widget to display, not the value of the
         attribute.
         """
-        index = self.findData(str(value))
+        index = self.findData(value, pymatch=True)
         self._setCurrentIndex(index)
+
+    def findData(self, data, **kwargs):
+        """
+        Reimplemented from :meth:`Qt.QComboBox.findData` to accept
+        the extra `pymatch` keyword arg. If `pymatch` is True, the
+        match will be attempted using python's `==` operator.
+        This is required to bypass some limitations imposed by C++'s QVariant .
+        By default, pymatch is False and behaves just as
+        :meth:`Qt.QComboBox.findData`
+        """
+        pymatch = kwargs.pop("pymatch", False)
+        index = Qt.QComboBox.findData(self, data, **kwargs)
+        if pymatch and index == -1:
+            for i in range(self.count()):
+                if numpy.all(self.itemData(i) == data):
+                    index = i
+                    break
+        return index
 
     def updateStyle(self):
         '''reimplemented from :class:`TaurusBaseWritableWidget`'''

--- a/lib/taurus/qt/qtgui/input/test/__init__.py
+++ b/lib/taurus/qt/qtgui/input/test/__init__.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+
+#############################################################################
+##
+# This file is part of Taurus
+##
+# http://taurus-scada.org
+##
+# Copyright 2011 CELLS / ALBA Synchrotron, Bellaterra, Spain
+##
+# Taurus is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+##
+# Taurus is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+##
+# You should have received a copy of the GNU Lesser General Public License
+# along with Taurus.  If not, see <http://www.gnu.org/licenses/>.
+##
+#############################################################################

--- a/lib/taurus/qt/qtgui/input/test/test_tauruscombobox.py
+++ b/lib/taurus/qt/qtgui/input/test/test_tauruscombobox.py
@@ -1,0 +1,63 @@
+from taurus.qt.qtgui.application import TaurusApplication
+from taurus.qt.qtgui.input import TaurusValueComboBox
+import taurus
+
+def test_TaurusValueCombobox():
+    """Check that the TaurusValueComboBox is started with the right display
+    See https://github.com/taurus-org/taurus/pull/1032
+    """
+    # TODO: Parameterize this test
+    app = TaurusApplication.instance()
+    if app is None:
+        app = TaurusApplication(cmd_line_parser=None)
+
+    # test with a pint quantity
+    model = 'sys/tg_test/1/short_scalar'
+    a = taurus.Attribute(model)
+    units = a.write(123).wvalue.units
+    w = TaurusValueComboBox()
+    names = [("A", 1234), ("B", "123"), ("C", 123 * units), ("E", -123)]
+    w.addValueNames(names)
+    w.setModel(model)
+    assert(w.currentText() == "C")
+
+    # test with a boolean (using quantities)
+    model = 'sys/tg_test/1/boolean_scalar'
+    a = taurus.Attribute(model)
+    a.write(False)
+    w = TaurusValueComboBox()
+    w.addValueNames([("N", None), ("F", False), ("T", True)])
+    w.setModel(model)
+    assert (w.currentText() == "F")
+
+    # test with a spectrum
+    model = 'sys/tg_test/1/boolean_spectrum'
+    a = taurus.Attribute(model)
+    a.write([False, True, False])
+    w = TaurusValueComboBox()
+    w.addValueNames([
+        ("A", False),
+        ("B", [False, False, False]),
+        ("C", [False, True, False]),
+    ])
+    w.setModel(model)
+    assert (w.currentText() == "C")
+
+    # test with strings
+    model = 'sys/tg_test/1/string_scalar'
+    a = taurus.Attribute(model)
+    a.write("foobar")
+    w = TaurusValueComboBox()
+    w.addValueNames([("A", "foobarbaz"), ("B", "FOOBAR"), ("C", "foobar")])
+    w.setModel(model)
+    assert (w.currentText() == "C")
+
+    # test non-match
+    model = 'sys/tg_test/1/string_scalar'
+    a = taurus.Attribute(model)
+    a.write("foo")
+    w = TaurusValueComboBox()
+    w.addValueNames([("A", "foobarbaz"), ("B", "FOOBAR"), ("C", "foobar")])
+    w.setModel(model)
+    assert (w.currentText() == "")
+    w.setModel(None)


### PR DESCRIPTION
When a TaurusValueComboBox widget is initialized it does not show
the set value.

The setValue method does not find the given value <s>since it saves
internally as string. Fix it doing a cast.</s>

Update by @cpascual : It is more likely related to [this](https://stackoverflow.com/questions/12837701/pyqt-how-do-i-find-tuples-using-qcomboboxfinddata) 