### PR TITLE
Add cache to TaurusAttribute isScalar and isSpectrum (back. compat.)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ develop branch) won't be reflected in this file.
 - Py3 exception in `TaurusModelChooser.getListedModels()` (#1008)
 - (for py2) Improved backwards compatibility of `taurus.qt.qtgui.plot` (#1027)
 - Exception in DelayedSubscriber (#1030)
+- Compatibility issue in deprecated TangoAttribute's `isScalar()` and `isSpectrum()` (#1034)
 
 
 ## [4.6.1] - 2019-08-19

--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -1169,11 +1169,13 @@ class TangoAttribute(TaurusAttribute):
         return self.isWritable(cache)
 
     @taurus4_deprecation(alt='self.data_format')
-    def isScalar(self):
+    def isScalar(self, cache=True):
+        # cache is ignored, it is only for back. compat.
         return self.data_format == DataFormat._0D
 
     @taurus4_deprecation(alt='self.data_format')
-    def isSpectrum(self):
+    def isSpectrum(self, cache=True):
+        # cache is ignored, it is only for back. compat.
         return self.data_format == DataFormat._1D
 
     @taurus4_deprecation(alt='self.data_format')


### PR DESCRIPTION
This methods implemented in Taurus 3 on the configuration class level
and exposed on the attribute level with __getattr__ used to have
cache argument. Add a dummy argument to maintain the backwards compat.