### PR TITLE
Add debugging info on model handling exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ develop branch) won't be reflected in this file.
 - Qt theme no longer set to TangoIcons by default (for coherence with docs) (#1012)
 - (for developers) Support of tox and change to pytest. More platforms
   being now automatically tested by travis (#994)
+- TaurusForm provides more debugging info when failing to handle a model (#1049)
 
 ### Deprecated
 ### Fixed

--- a/lib/taurus/qt/qtgui/panel/taurusform.py
+++ b/lib/taurus/qt/qtgui/panel/taurusform.py
@@ -331,9 +331,10 @@ class TaurusForm(TaurusWidget):
         except:
             try:
                 obj = taurus.Device(model)
-            except:
+            except Exception as e:
                 self.warning(
-                    'Cannot handle model "%s". Using default widget.' % (model))
+                    'Cannot handle model "%s". Using default widget.', model)
+                self.debug('Model error: %s', e)
                 return self._defaultFormWidget, (), {}
             try:
                 key = obj.getDeviceProxy().info().dev_class  # TODO: Tango-centric


### PR DESCRIPTION
Log the exception message (with level=debug) if getting an exception
while loading a model in TaurusForm.

Fixes #1046