### PR TITLE
[CI] Pin tango-test docker version to 9.3.3-rc1

### DIFF
--- a/ci/tango_docker-compose.yml
+++ b/ci/tango_docker-compose.yml
@@ -21,7 +21,7 @@ services:
     depends_on:
      - tango-db
   tango-test:
-    image: tangocs/tango-test:latest
+    image: tangocs/tango-test:9.3.3-rc1
     environment:
      - TANGO_HOST=tango-cs:10000
     links:


### PR DESCRIPTION
Many tests that depend on the TangoTest service provided by the tangocs/tango-test docker image started to fail at about the time when the tangocs/tango-test:latest was updated to point to tangocs/tango-test:2.1 (december 2019). Previously it pointed to tangocs/tango-test:9.3.3-rc1 and tests were ok. 
A manual check confirms that using tangocs/tango-test:latest (=2.1) causes the TangoTest service not being available (the container exits immediately).

Fix by pinning the version of the docker image to tangocs/tango-test:9.3.3-rc1

IMPORTANT: even with this fix applied, many travis runs still fail randomly. There are further issues that need to be fixed.