### PR TITLE
Fix missing precision initialization

### DIFF
--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -1078,7 +1078,7 @@ class TangoAttribute(TaurusAttribute):
         match = re.search("[^\.]*\.(?P<precision>[0-9]+)[eEfFgG%]", fmt)
         if match:
             self.precision = int(match.group(1))
-        elif re.match("%[0-9]*d", '%d'):
+        elif re.match("%[0-9]*d", fmt):
             self.precision = 0
         # self._units and self._display_format is to be used by
         # TangoAttrValue for performance reasons. Do not rely on it in other

--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -1078,6 +1078,8 @@ class TangoAttribute(TaurusAttribute):
         match = re.search("[^\.]*\.(?P<precision>[0-9]+)[eEfFgG%]", fmt)
         if match:
             self.precision = int(match.group(1))
+        elif re.match("%[0-9]*d", '%d'):
+            self.precision = 0
         # self._units and self._display_format is to be used by
         # TangoAttrValue for performance reasons. Do not rely on it in other
         # code


### PR DESCRIPTION
Some widgets report 'Invalid format' warning messages for
TangoAttributes URIS of Type.Integer.

The precision attribute is not initialized right for integer types.

Fix it.

You can reproduce it with : `taurus --log-level=Debug form sys/tg_test/1/long_scalar`
