### PR TITLE
Improve v3->v4 migration API and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ develop branch) won't be reflected in this file.
 - (for py2) Improved backwards compatibility of `taurus.qt.qtgui.plot` (#1027)
 - Exception in DelayedSubscriber (#1030)
 - Compatibility issue in deprecated TangoAttribute's `isScalar()` and `isSpectrum()` (#1034)
+- Some issues in taurus v3 to v4 migration support (#1059)
 
 
 ## [4.6.1] - 2019-08-19

--- a/doc/source/devel/taurus3to4.rst
+++ b/doc/source/devel/taurus3to4.rst
@@ -154,7 +154,8 @@ This list is a best-effort to document changes, but it may not be 100% complete 
 | TangoDevice.getValueObj                       | TangoDevice.stateObj.read  *tango* or                         |
 |                                               | state  *agnostic*                                             |
 +-----------------------------------------------+---------------------------------------------------------------+
-| TangoDevice.getDisplayValue                   | TangoDevice.state().name                                      |
+| TangoDevice.getDisplayValue                   | TangoDevice.stateObj.read().rvalue.name  *tango*  or          |
+|                                               | state.name  *agnostic*                                        |
 +-----------------------------------------------+---------------------------------------------------------------+
 | TangoDevice.getHWObj                          | TangoDevice.getDeviceProxy                                    |
 +-----------------------------------------------+---------------------------------------------------------------+

--- a/doc/source/devel/taurus3to4.rst
+++ b/doc/source/devel/taurus3to4.rst
@@ -151,7 +151,7 @@ This list is a best-effort to document changes, but it may not be 100% complete 
 +-----------------------------------------------+---------------------------------------------------------------+
 | TangoDevice.getSWState                        | TangoDevice.state                                             |
 +-----------------------------------------------+---------------------------------------------------------------+
-| TangoDevice.getValueObj                       | TangoDevice.stateObj.read()  *tango* or                       |
+| TangoDevice.getValueObj                       | TangoDevice.stateObj.read  *tango* or                         |
 |                                               | .state  *agnostic*                                            |
 +-----------------------------------------------+---------------------------------------------------------------+
 | TangoDevice.getDisplayValue                   | TangoDevice.stateObj.read().rvalue.name  *tango*  or          |

--- a/doc/source/devel/taurus3to4.rst
+++ b/doc/source/devel/taurus3to4.rst
@@ -141,17 +141,18 @@ This list is a best-effort to document changes, but it may not be 100% complete 
 +-----------------------------------------------+---------------------------------------------------------------+
 +-----------------------------------------------+---------------------------------------------------------------+
 | TangoDevice.getState                          | TangoDevice.stateObj.read().rvalue *tango* or                 |
-|                                               | .state *agnostic*                                             |
+|                                               | .state  *agnostic*                                            |
 +-----------------------------------------------+---------------------------------------------------------------+
 | TangoDevice.state() *PyTango.DeviceProxy API* | TangoDevice.stateObj.read(cache=False).rvalue *tango* or      |
 |                                               | .state  *agnostic*                                            |
 +-----------------------------------------------+---------------------------------------------------------------+
 | TangoDevice.getStateObj                       | TangoDevice.stateObj  *tango* or                              |
-|                                               | .factory.getAttribute(state_full_name) *agnostic*             |
+|                                               | .factory.getAttribute(state_full_name)  *agnostic*            |
 +-----------------------------------------------+---------------------------------------------------------------+
 | TangoDevice.getSWState                        | TangoDevice.state                                             |
 +-----------------------------------------------+---------------------------------------------------------------+
-| TangoDevice.getValueObj                       | TangoDevice.state *agnostic or* stateObj.read *tango*         |
+| TangoDevice.getValueObj                       | TangoDevice.stateObj.read  *tango* or                         |
+|                                               | state  *agnostic*                                             |
 +-----------------------------------------------+---------------------------------------------------------------+
 | TangoDevice.getDisplayValue                   | TangoDevice.state().name                                      |
 +-----------------------------------------------+---------------------------------------------------------------+

--- a/doc/source/devel/taurus3to4.rst
+++ b/doc/source/devel/taurus3to4.rst
@@ -143,6 +143,9 @@ This list is a best-effort to document changes, but it may not be 100% complete 
 | TangoDevice.getState                          | TangoDevice.stateObj.read().rvalue *tango* or                 |
 |                                               | .state *agnostic*                                             |
 +-----------------------------------------------+---------------------------------------------------------------+
+| TangoDevice.state() *PyTango.DeviceProxy API* | TangoDevice.stateObj.read(cache=False).rvalue *tango* or      |
+|                                               | .state  *agnostic*                                            |
++-----------------------------------------------+---------------------------------------------------------------+
 | TangoDevice.getStateObj                       | TangoDevice.stateObj  *tango* or                              |
 |                                               | .factory.getAttribute(state_full_name) *agnostic*             |
 +-----------------------------------------------+---------------------------------------------------------------+

--- a/doc/source/devel/taurus3to4.rst
+++ b/doc/source/devel/taurus3to4.rst
@@ -151,11 +151,11 @@ This list is a best-effort to document changes, but it may not be 100% complete 
 +-----------------------------------------------+---------------------------------------------------------------+
 | TangoDevice.getSWState                        | TangoDevice.state                                             |
 +-----------------------------------------------+---------------------------------------------------------------+
-| TangoDevice.getValueObj                       | TangoDevice.stateObj.read  *tango* or                         |
-|                                               | state  *agnostic*                                             |
+| TangoDevice.getValueObj                       | TangoDevice.stateObj.read()  *tango* or                       |
+|                                               | .state  *agnostic*                                            |
 +-----------------------------------------------+---------------------------------------------------------------+
 | TangoDevice.getDisplayValue                   | TangoDevice.stateObj.read().rvalue.name  *tango*  or          |
-|                                               | state.name  *agnostic*                                        |
+|                                               | .state.name  *agnostic*                                       |
 +-----------------------------------------------+---------------------------------------------------------------+
 | TangoDevice.getHWObj                          | TangoDevice.getDeviceProxy                                    |
 +-----------------------------------------------+---------------------------------------------------------------+

--- a/lib/taurus/core/tango/tangodevice.py
+++ b/lib/taurus/core/tango/tangodevice.py
@@ -200,9 +200,9 @@ class TangoDevice(TaurusDevice):
         self._deviceObj = None
         TaurusDevice.cleanUp(self)
 
-    @taurus4_deprecation(alt='.state().name')
+    @taurus4_deprecation(alt='.state.name')
     def getDisplayValue(self, cache=True):
-        return self.state(cache).name
+        return self.stateObj.read(cache=cache).rvalue.name
 
     def _createHWObject(self):
         try:


### PR DESCRIPTION
- Fix an issue with bck-compat method `TangoDevice.getDisplayValue()`
- Improve v3->v4 migration guide regarding tango states

This PR replaces #1057 