### PR TITLE
Avoid deadlock between push_event and poll

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
     - env: TOXENV=py37-qt5-docs
   allow_failures:
     - env: TOXENV=flake8
-    - env: TOXENV=py27-qt4
+    - env: TOXENV=py27-qt5
 
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ matrix:
     - env: TOXENV=py37-qt5-docs
   allow_failures:
     - env: TOXENV=flake8
+    - env: TOXENV=py27-qt4
 
 
 before_install:

--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -831,7 +831,7 @@ class TangoAttribute(TaurusAttribute):
         # it must be managed out of the critical region to avoid deadlock
         if self.__deactivate_polling:
             self.__deactivate_polling = False
-            self.disablePolling()
+            self._deactivatePolling()
 
     def _pushAttrEvent(self, event):
         """Handler of (non-configuration) events from the PyTango layer.

--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -295,6 +295,7 @@ class TangoAttribute(TaurusAttribute):
         self.__already_warned_unit = None
 
         self.call__init__(TaurusAttribute, name, parent, **kwargs)
+        self.__deactivate_polling = False
 
         attr_info = None
         if parent:
@@ -485,6 +486,7 @@ class TangoAttribute(TaurusAttribute):
                     value = self.decode(value)
                     self.__attr_err = error
                     if self.__attr_err:
+
                         raise self.__attr_err
                     # Avoid "valid-but-outdated" notifications
                     # if FILTER_OLD_TANGO_EVENTS is enabled
@@ -727,7 +729,7 @@ class TangoAttribute(TaurusAttribute):
                 else:
                     self.debug("Failed: %s", df.args[0].desc)
                     self.trace(str(df))
-        self._deactivatePolling()
+        self.disablePolling()
         self.__subscription_state = SubscriptionState.Unsubscribed
 
     def _subscribeConfEvents(self):
@@ -803,6 +805,7 @@ class TangoAttribute(TaurusAttribute):
         specific handlers for different event types.
         """
         with self.__read_lock:
+
             # if it is a configuration event
             if isinstance(event, PyTango.AttrConfEventData):
                 etype, evalue = self._pushConfEvent(event)
@@ -823,6 +826,12 @@ class TangoAttribute(TaurusAttribute):
                 manager.enqueueJob(job, job_args=(etype, evalue),
                                    job_kwargs={'listeners': listeners},
                                    serialization_mode=sm)
+
+        # Deactivate polling in case of PyTango.DevFailed
+        # it must be managed out of the critical region to avoid deadlock
+        if self.__deactivate_polling:
+            self.__deactivate_polling = False
+            self.disablePolling()
 
     def _pushAttrEvent(self, event):
         """Handler of (non-configuration) events from the PyTango layer.
@@ -856,7 +865,7 @@ class TangoAttribute(TaurusAttribute):
             self.__subscription_state = SubscriptionState.Subscribed
             self.__subscription_event.set()
             if not self.isPollingForced():
-                self._deactivatePolling()
+                self.disablePolling()
             return TaurusEventType.Change, self.__attr_value
 
         elif event.errors[0].reason in EVENT_TO_POLLING_EXCEPTIONS:
@@ -872,7 +881,7 @@ class TangoAttribute(TaurusAttribute):
                 *event.errors)
             self.__subscription_state = SubscriptionState.Subscribed
             self.__subscription_event.set()
-            self._deactivatePolling()
+            self.__deactivate_polling = True
             return TaurusEventType.Error, self.__attr_err
 
     def _pushConfEvent(self, event):

--- a/lib/taurus/core/taurusfactory.py
+++ b/lib/taurus/core/taurusfactory.py
@@ -359,7 +359,7 @@ class TaurusFactory(object):
         timers = dict(self.polling_timers)
         for period, timer in timers.items():
             timer.removeAttribute(attribute)
-            if not timer.dev_dict:
+            if not timer.dev_dict and period in self.polling_timers:
                 del self.polling_timers[period]
 
     def __str__(self):


### PR DESCRIPTION
Tango attribute has a deadlock when it can not connect to
a device (e.g. device is down).

Use disablePolling instead of _deactivatePolling to update internal
variables.

Move disablePolling out of the critical region in case of
PyTango.DevFailed.