### PR TITLE
Don't store classid config TaurusValue unless it is a string

### DIFF
--- a/lib/taurus/core/tauruspollingtimer.py
+++ b/lib/taurus/core/tauruspollingtimer.py
@@ -128,7 +128,7 @@ class TaurusPollingTimer(Logger):
             if not attr_dict:
                 del self.dev_dict[dev]
             if not self.dev_dict:
-                self.stop(sync=False)
+                self.stop(sync=True)
 
     def _pollAttributes(self):
         """Polls the registered attributes. This method is called by the timer

--- a/lib/taurus/core/tauruspollingtimer.py
+++ b/lib/taurus/core/tauruspollingtimer.py
@@ -128,7 +128,7 @@ class TaurusPollingTimer(Logger):
             if not attr_dict:
                 del self.dev_dict[dev]
             if not self.dev_dict:
-                self.stop(sync=True)
+                self.stop(sync=False)
 
     def _pollAttributes(self):
         """Polls the registered attributes. This method is called by the timer

--- a/lib/taurus/qt/qtgui/panel/taurusvalue.py
+++ b/lib/taurus/qt/qtgui/panel/taurusvalue.py
@@ -1165,13 +1165,14 @@ class TaurusValue(Qt.QWidget, TaurusBaseWidget):
                     or allowUnpickable):
                 #configdict[key] = classID
                 configdict[key] = {'classid': classID}
-                widget = getattr(self, key[0].lower() + key[1:])()
-                if isinstance(widget, BaseConfigurableClass):
-                    configdict[key]['delegate'] = widget.createConfig()
             else:
-                self.info('createConfig: %s not saved because it is not Pickable (%s)' % (
+                self.debug('createConfig: classid of %s not saved because it is not Pickable (%s)' % (
                     key, str(classID)))
-
+            widget = getattr(self, key[0].lower() + key[1:])()
+            if isinstance(widget, BaseConfigurableClass):
+                widget_configdict = configdict.get(key, {})
+                widget_configdict['delegate'] = widget.createConfig()
+                configdict[key] = widget_configdict
         return configdict
 
     def applyConfig(self, configdict, **kwargs):
@@ -1187,8 +1188,9 @@ class TaurusValue(Qt.QWidget, TaurusBaseWidget):
         for key in ('LabelWidget', 'ReadWidget', 'WriteWidget', 'UnitsWidget', 'CustomWidget', 'ExtraWidget'):
             if key in configdict:
                 widget_configdict = configdict[key]
-                getattr(self, 'set%sClass' % key)(
-                    widget_configdict.get('classid', None))
+                classid = widget_configdict.get('classid', None)
+                if classid:
+                    getattr(self, 'set%sClass' % key)(classid)
                 if 'delegate' in widget_configdict:
                     widget = getattr(self, key[0].lower() + key[1:])()
                     if isinstance(widget, BaseConfigurableClass):


### PR DESCRIPTION
TaurusValue refuses to store configs that have items without classID. This PR modifies the code to save those items leaving a debug message that tells the classID wasn't stored.
This PR fixes #840 which was actually a taurus issue, not a Sardana issue as indicated.
So also fixes https://github.com/sardana-org/sardana/issues/1164