### PR TITLE
Avoid using --show-capture opt for pytest in py27-qt5

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -47,6 +47,10 @@ deps=
 commands=
     python -m pytest lib/taurus --show-capture=no
 
+[testenv:py27-qt5]
+commands=
+    python -m pytest lib/taurus
+
 [testenv:py37-qt5-docs]
 commands=
     sphinx-build -qW doc/source/ build/sphinx/html


### PR DESCRIPTION
For some reason, the travis tests for the py27-qt5 target started
complaining that pytest does not recognize the --show-capture option.

Remove the option (only for py27-qt5) to allow the tests to work.
This fixes #1068