### PR TITLE
Allow to customize Worker for ThreadPool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ develop branch) won't be reflected in this file.
 - check-deps subcommand (#988)
 - `taurus.cli.register_subcommands()` and `taurus.cli.taurus_cmd()` (#991)
 - Support for spyder v4 in `taurus.qt.qtgui.editor` (#1038)
+- New `worker_cls` argument for `taurus.core.util.ThreadPool` costructor (#1081)
 
 ### Removed
 ### Changed

--- a/lib/taurus/core/util/threadpool.py
+++ b/lib/taurus/core/util/threadpool.py
@@ -50,8 +50,13 @@ class ThreadPool(Logger):
 
     NoJob = 6 * (None,)
 
-    def __init__(self, name=None, parent=None, Psize=20, Qsize=20, daemons=True):
+    def __init__(self, name=None, parent=None, Psize=20, Qsize=20,
+                 daemons=True, worker_cls=None):
         Logger.__init__(self, name, parent)
+        if worker_cls is None:
+            self._worker_cls = Worker
+        else:
+            self._worker_cls = worker_cls
         self._daemons = daemons
         self.localThreadId = 0
         self.workers = []
@@ -70,7 +75,7 @@ class ThreadPool(Logger):
             for i in range(newSize - nb_workers):
                 self.localThreadId += 1
                 name = "%s.W%03i" % (self.log_name, self.localThreadId)
-                new = Worker(self, name, self._daemons)
+                new = self._worker_cls(self, name, self._daemons)
                 self.workers.append(new)
                 self.debug("Starting %s" % name)
                 new.start()


### PR DESCRIPTION
Tango is not thread safe when using threading.Thread. One must use
omni threads instead. This was confirmed for parallel event subscriptions
in https://github.com/tango-controls/pytango/issues/307.

For example, in the case of Sardana, the custom Worker will be protected
by the EnsureOmniThread context manager intoroduced in https://github.com/tango-controls/pytango/pull/327.