### PR TITLE
Workaround for bug #1077

### DIFF
--- a/lib/taurus/qt/qtgui/graphic/jdraw/jdraw.py
+++ b/lib/taurus/qt/qtgui/graphic/jdraw/jdraw.py
@@ -151,6 +151,15 @@ class TaurusJDrawGraphicsFactory(Singleton, TaurusBaseGraphicsFactory, Logger):
 
         return item
 
+    def getBarObj(self, params):
+        # TODO: properly implement JDBar support
+        # As a workaround, use a filled rectangle as a substitute of a JDBar
+        self.warning('JDBar not yet supported. Using a JDRectangle instead')
+        if 'fillStyle' not in params:
+            params['fillStyle'] = 1
+
+        return self.getRectangleObj(params)
+
     def getRoundRectangleObj(self, params):
         item = self.getGraphicsItem('RoundRectangle', params)
         x1, y1, x2, y2 = params.get('summit')

--- a/lib/taurus/qt/qtgui/graphic/jdraw/test/res/bug1077.jdw
+++ b/lib/taurus/qt/qtgui/graphic/jdraw/test/res/bug1077.jdw
@@ -1,0 +1,9 @@
+JDFile v11 {
+  Global {
+  }
+  JDBar {
+    summit:385,70,422,105
+    origin:437,57
+    name:"tango:sys/tg_test/1/state"
+  }
+}

--- a/lib/taurus/qt/qtgui/graphic/jdraw/test/test_jdraw_parser.py
+++ b/lib/taurus/qt/qtgui/graphic/jdraw/test/test_jdraw_parser.py
@@ -1,0 +1,24 @@
+import os
+from taurus.qt.qtgui.application import TaurusApplication
+from taurus.qt.qtgui.graphic.jdraw import (
+    TaurusJDrawGraphicsFactory,
+    jdraw_parser
+)
+from taurus.qt.qtgui.graphic import TaurusGraphicsScene
+
+
+app = TaurusApplication.instance()
+if app is None:
+    app = TaurusApplication([], cmd_line_parser=None)
+
+
+def test_jdraw_parser():
+    """Check that jdraw_parser does not break with JDBar elements"""
+    fname = os.path.join(os.path.dirname(__file__), "res", "bug1077.jdw")
+    factory = TaurusJDrawGraphicsFactory(None)
+    p = jdraw_parser.parse(fname, factory)
+    assert isinstance(p, TaurusGraphicsScene)
+
+
+if __name__ == '__main__':
+    test_jdraw_parser()

--- a/lib/taurus/qt/qtgui/graphic/taurusgraphic.py
+++ b/lib/taurus/qt/qtgui/graphic/taurusgraphic.py
@@ -1208,10 +1208,10 @@ class TaurusGraphicsStateItem(TaurusGraphicsItem):
                 bg_brush, fg_brush = None, None
                 if self.getModelObj().getType() == DataType.DevState:
                     bg_brush, fg_brush = QT_DEVICE_STATE_PALETTE.qbrush(
-                        v.value)
+                        v.rvalue)
                 elif self.getModelObj().getType() == DataType.Boolean:
                     bg_brush, fg_brush = QT_DEVICE_STATE_PALETTE.qbrush(
-                        (DevState.FAULT, DevState.ON)[v.value])
+                        (DevState.FAULT, DevState.ON)[v.rvalue])
                 elif self.getShowQuality():
                     bg_brush, fg_brush = QT_ATTRIBUTE_QUALITY_PALETTE.qbrush(
                         v.quality)


### PR DESCRIPTION
This PR fixes the exception reported in #1077: the Taurus JDraw viewer 
gets an exception if JDBar item is used in the jdw file because TaurusJDrawGraphicsFactory does not support it. Work around this by implementing a dummy support for JDBar. 

Note that this is not proper support, but just a workaround to allow parsing (a filled JDRectangle is displayed instead of a bar).

