### PR TITLE
Make sure the tooltip can be generated despite DevFail

### DIFF
--- a/lib/taurus/core/tango/tangodevice.py
+++ b/lib/taurus/core/tango/tangodevice.py
@@ -185,8 +185,11 @@ class TangoDevice(TaurusDevice):
         ret = []
         for name, value in desc_obj:
             if name.lower() == u'device state' and self.stateObj is not None:
-                tg_state = self.stateObj.read(cache).rvalue.name
-                value = u"%s (%s)" % (value, tg_state)
+                try:
+                    tg_state = self.stateObj.read(cache).rvalue.name
+                    value = u"%s (%s)" % (value, tg_state)
+                except Exception as e:
+                    value = u"cannot read state"
             ret.append((name, value))
         return ret
 


### PR DESCRIPTION
Here is a patch to allow to display tooltip for `DevFail ` attributes.

![Screenshot from 2020-03-02 17-55-58](https://user-images.githubusercontent.com/7579321/75699769-454f1980-5cb1-11ea-9c24-3f29b7263717.png)

Without catching this exception, the `TaurusLabel` devices can't start. As result.

This patch is not really nice cause the patched method have to return str (i am afraid about returning something else), then the formatting have to be done inside `getDisplayDescrObj`

This could be improved by:
- Returning the list containing `value=exception`, or an object which mimicks `str`
- The formatting could then be done inside `TaurusBaseComponent.toolTipObjToStr`
- The tooltip rendering could be then improved a lot

Closes #1086