### PR TITLE
Lazy plugin import

### DIFF
--- a/lib/taurus/core/util/lazymodule.py
+++ b/lib/taurus/core/util/lazymodule.py
@@ -1,0 +1,56 @@
+#############################################################################
+##
+# This file is part of Taurus
+##
+# http://taurus-scada.org
+##
+# Copyright 2011 CELLS / ALBA Synchrotron, Bellaterra, Spain
+##
+# Taurus is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+##
+# Taurus is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+##
+# You should have received a copy of the GNU Lesser General Public License
+# along with Taurus.  If not, see <http://www.gnu.org/licenses/>.
+##
+#############################################################################
+
+"""
+This module provides LazyModule for loading plugins in lazy way -
+only when members of actual plugin are requested.
+"""
+
+__all__ = ["LazyModule"]
+
+from types import ModuleType
+import sys
+
+from taurus import warning
+
+
+class LazyModule(ModuleType):
+
+    def __init__(self, name, package, entry_point):
+        super(LazyModule, self).__init__(name)
+        self.__package__ = package
+        self.ep = entry_point
+
+    def __getattr__(self, member):
+
+        try:
+            mod = self.ep.load()
+            # Replace lazy module with actual module for package
+            setattr(sys.modules[self.__package__], self.__name__, mod)
+            # Replace lazy module with actual module in sys.modules
+            modname = "%s.%s" % (self.__package__, self.__name__)
+            sys.modules[modname] = mod
+            return getattr(mod, member)
+        except Exception as e:
+            warning('Could not load plugin "%s". Reason: %s', self.ep.name, e)
+            return None

--- a/lib/taurus/qt/qtgui/__init__.py
+++ b/lib/taurus/qt/qtgui/__init__.py
@@ -63,12 +63,14 @@ class LazyModule(ModuleType):
         self.ep = entry_point
 
     def __getattr__(self, member):
+        import sys as __sys
         mod = self.ep.load()
         # Replace lazy module with actual module for package
-        setattr(sys.modules[self.__package__], self.__name__, mod)
+        setattr(__sys.modules[self.__package__], self.__name__, mod)
         # Replace lazy module with actual module in sys.modules
         modname = "%s.%s" % (self.__package__, self.__name__)
-        sys.modules[modname] = mod
+        __sys.modules[modname] = mod
+        del __sys
         return getattr(mod, member)
 
 # Discover the taurus.qt.qtgui plugins

--- a/lib/taurus/qt/qtgui/__init__.py
+++ b/lib/taurus/qt/qtgui/__init__.py
@@ -35,9 +35,10 @@ import os
 import sys
 import glob
 import pkg_resources
-from types import ModuleType
+
 from taurus import tauruscustomsettings as __S
 from taurus import info as __info
+from taurus.core.util.lazymodule import LazyModule
 
 
 __docformat__ = 'restructuredtext'
@@ -53,33 +54,6 @@ __icon.registerTheme(name=getattr(__S, 'QT_THEME_NAME', 'Tango'),
 # ------------------------------------------------------------------------
 # Note: this is an experimental feature introduced in v 4.3.0a
 # It may be removed or changed in future releases
-
-class LazyModule(ModuleType):
-
-    def __init__(self, name, package, entry_point):
-        super(LazyModule, self).__init__(name)
-        self.__package__ = package
-        self.ep = entry_point
-
-    def __getattr__(self, member):
-        import sys as __sys
-
-        from taurus import warning as __warning
-
-        try:
-            mod = self.ep.load()
-            # Replace lazy module with actual module for package
-            setattr(__sys.modules[self.__package__], self.__name__, mod)
-            # Replace lazy module with actual module in sys.modules
-            modname = "%s.%s" % (self.__package__, self.__name__)
-            __sys.modules[modname] = mod
-            return getattr(mod, member)
-        except Exception as e:
-            __warning('Could not load plugin "%s". Reason: %s', __p.module_name, e)
-            return None
-        finally:
-            del __sys, __warning
-
 
 # Discover the taurus.qt.qtgui plugins
 __mod = __modname = None

--- a/lib/taurus/qt/qtgui/__init__.py
+++ b/lib/taurus/qt/qtgui/__init__.py
@@ -69,7 +69,7 @@ class LazyModule(ModuleType):
         # Replace lazy module with actual module in sys.modules
         modname = "%s.%s" % (self.__package__, self.__name__)
         sys.modules[modname] = mod
-        return getattr(mod, memeber)
+        return getattr(mod, member)
 
 # Discover the taurus.qt.qtgui plugins
 __mod = __modname = None

--- a/lib/taurus/qt/qtgui/__init__.py
+++ b/lib/taurus/qt/qtgui/__init__.py
@@ -64,7 +64,7 @@ for __p in pkg_resources.iter_entry_points('taurus.qt.qtgui'):
     setattr(sys.modules[__name__], __p.name, __lazy_mod)
     # Add it to sys.modules
     sys.modules[__modname] = __lazy_mod
-    __info('Plugin "%s" loaded as "%s"', __p.module_name, __modname)
+    __info('Plugin "%s" lazy-loaded as "%s"', __p.module_name, __modname)
 
 # ------------------------------------------------------------------------
     


### PR DESCRIPTION
Hi Taurus Community

This should close #944 

How does it work:
During import, fake `LazyModule` object is created and put into `sys.modules` with proper name (of the actual plugin module) and reference to entry point. When attribute not present in this fake module is requested, `__getattr__` is invoked. It then loads actual module and replaces fake module with actual one in `sys.modules`. It is done that way to avoid problems that may or may not occur. This tricks just has to work once for each plugin module.
After that, attribute from plugin module is returned. That way actual module is present in `sys.modules` even if requested attribute name is wrong or attribute is not present.

Tested with `taurus_pyqtgraph` under Python 2.7