### PR TITLE
WIP: Usubscribe from events in worker thread (PyTango#292)

### DIFF
--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -82,7 +82,7 @@ def _unsubscribe_event(dev_proxy, event_id):
             # it unsubscribed from events itself
             pass
         else:
-            debug("Error trying to unsubscribe configuration events")
+            debug("Error trying to unsubscribe events")
             trace(str(df))
 
 

--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -314,6 +314,7 @@ class TangoAttribute(TaurusAttribute):
         # current event subscription state
         self.__subscription_state = SubscriptionState.Unsubscribed
         self.__subscription_event = threading.Event()
+        self.__subscription_cfg_state = SubscriptionState.Unsubscribed
 
         # the parent's HW object (the PyTango Device obj)
         self.__dev_hw_obj = None
@@ -783,6 +784,7 @@ class TangoAttribute(TaurusAttribute):
             # connects to self.push_event callback
             # TODO: _BoundMethodWeakrefWithCall is used as workaround for
             # PyTango #185 issue
+            self.__subscription_cfg_state = SubscriptionState.Subscribing
             self.__cfg_evt_id = self.__dev_hw_obj.subscribe_event(
                 attr_name,
                 PyTango.EventType.ATTR_CONF_EVENT,
@@ -922,6 +924,7 @@ class TangoAttribute(TaurusAttribute):
                  evt_value is a TaurusValue, an Exception, or None.
         """
         if not event.err:
+            self.__subscription_cfg_state = SubscriptionState.Subscribed
             # update conf-related attributes
             self._decodeAttrInfoEx(event.attr_conf)
             # make sure that there is a self.__attr_value

--- a/lib/taurus/core/tango/tangodevice.py
+++ b/lib/taurus/core/tango/tangodevice.py
@@ -70,6 +70,7 @@ class TangoDevice(TaurusDevice):
         self._deviceStateObj = None
         # TODO reimplement using the new codification
         self._deviceState = TaurusDevState.Undefined
+        self._zombie = False
 
     # Export the DeviceProxy interface into this object.
     # This way we can call for example read_attribute on an object of this
@@ -103,6 +104,12 @@ class TangoDevice(TaurusDevice):
         on the device"""
         attr = self.getAttribute(key)
         return attr.write(value)
+
+    def setZombie(self, zombie=True):
+        self._zombie = zombie
+        if self._deviceStateObj is None:
+            return
+        self._deviceStateObj.setZombie(zombie)
 
     def getAttribute(self, attrname):
         """Returns the attribute object given its name"""

--- a/lib/taurus/core/tango/tangofactory.py
+++ b/lib/taurus/core/tango/tangofactory.py
@@ -332,7 +332,7 @@ class TangoFactory(Singleton, TaurusFactory, Logger):
         d = self.tango_devs.get(dev_name)
         if d is None:
             d = self.tango_alias_devs.get(dev_name)
-        if d is not None:
+        if d is not None and not d._zombie:
             return d
 
         validator = _Device.getNameValidator()
@@ -382,7 +382,7 @@ class TangoFactory(Singleton, TaurusFactory, Logger):
                    alias is invalid.
         """
         attr = self.tango_attrs.get(attr_name)
-        if attr is not None:
+        if attr is not None and not attr._zombie:
             return attr
 
         # Simple approach did not work. Lets build a proper device name

--- a/lib/taurus/core/tango/tangofactory.py
+++ b/lib/taurus/core/tango/tangofactory.py
@@ -51,7 +51,7 @@ from taurus.core.util.singleton import Singleton
 from taurus.core.util.containers import CaselessWeakValueDict, CaselessDict
 
 from .tangodatabase import TangoAuthority
-from .tangoattribute import TangoAttribute
+from .tangoattribute import TangoAttribute, get_thread_pool
 from .tangodevice import TangoDevice
 
 _Authority = TangoAuthority
@@ -149,6 +149,7 @@ class TangoFactory(Singleton, TaurusFactory, Logger):
             v.cleanUp()
         for k, v in self.tango_db.items():
             v.cleanUp()
+        get_thread_pool().join()
         self.reInit()
 
     def getExistingAttributes(self):

--- a/lib/taurus/core/taurusbasetypes.py
+++ b/lib/taurus/core/taurusbasetypes.py
@@ -169,7 +169,8 @@ SubscriptionState = Enumeration(
         "Unsubscribed",
         "Subscribing",
         "Subscribed",
-        "PendingSubscribe"
+        "PendingSubscribe",
+        "PostponedUnsubscribe"
     ))
 
 


### PR DESCRIPTION
Similarly to https://github.com/taurus-org/taurus/pull/1091, this PR tries to workaround PyTango#292. 
This one implements the 3.b option proposed by @schooft in https://github.com/tango-controls/pytango/issues/292#issuecomment-585652804. Thanks!

I tried this PR with https://github.com/sardana-org/sardana/pull/1312 ( which reverts the Sardana workaround and use _zombie_ concept in tests) and it worked for 7 testsuite executions already. Note that the usage of zombie API in tests most probably won't be need if we implement https://github.com/taurus-org/taurus/issues/1092.