### PR TITLE
WIP: Usubscribe from events on the next subscription (PyTango#292)

### DIFF
--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -36,6 +36,7 @@ import weakref
 import PyTango
 import numpy
 from functools import partial
+from queue import Queue
 
 from taurus import Manager
 from taurus.core.units import Quantity, UR
@@ -48,7 +49,7 @@ from taurus.core.taurusbasetypes import (TaurusEventType,
                                          DataFormat, DataType)
 from taurus.core.taurusoperation import WriteAttrOperation
 from taurus.core.util.event import EventListener, _BoundMethodWeakrefWithCall
-from taurus.core.util.log import (debug, taurus4_deprecation,
+from taurus.core.util.log import (debug, taurus4_deprecation, trace,
                                   deprecation_decorator)
 
 from taurus.core.tango.enums import (EVENT_TO_POLLING_EXCEPTIONS,
@@ -66,6 +67,28 @@ from .util.tango_taurus import (description_from_tango,
 __all__ = ["TangoAttribute", "TangoAttributeEventListener", "TangoAttrValue"]
 
 __docformat__ = "restructuredtext"
+
+
+def _unsubscribe_event(dev_proxy, event_id):
+    try:
+        dev_proxy.unsubscribe_event(event_id)
+    except PyTango.DevFailed as df:
+        if len(df.args) and df.args[0].reason == 'API_EventNotFound':
+            # probably tango shutdown has been initiated before and
+            # it unsubscribed from events itself
+            pass
+        else:
+            debug("Error trying to unsubscribe events")
+            trace(str(df))
+
+
+_unsub_queue = Queue()
+
+
+def _empty_unsub_queue():
+    while not _unsub_queue.empty:
+        unsubscribe_event = _unsub_queue.get()
+        unsubscribe_event()
 
 
 class TangoAttrValue(TaurusAttrValue):
@@ -271,6 +294,7 @@ class TangoAttribute(TaurusAttribute):
     _description = 'A Tango Attribute'
 
     def __init__(self, name='', parent=None, **kwargs):
+        self._zombie = False
         # the last attribute value
         self.__attr_value = None
 
@@ -322,13 +346,17 @@ class TangoAttribute(TaurusAttribute):
         if self.factory().is_tango_subscribe_enabled():
             self._subscribeConfEvents()
 
+    def setZombie(self, zombie=True):
+        self._zombie = zombie
+
     def __del__(self):
+        self._zombie = True
         self.cleanUp()
 
     def cleanUp(self):
         self.trace("[TangoAttribute] cleanUp")
-        self._unsubscribeConfEvents()
-        self._unsubscribeChangeEvents()
+        self._finalUnsubscribeConfEvents()
+        self._finalUnsubscribeChangeEvents()
         TaurusAttribute.cleanUp(self)
         self.__dev_hw_obj = None
         self._pytango_attrinfoex = None
@@ -655,7 +683,7 @@ class TangoAttribute(TaurusAttribute):
         return self.__subscription_state == SubscriptionState.Subscribed
     
     def getSubscriptionState(self):
-        return self.__subscription_state    
+        return self.__subscription_state
 
     def _process_event_exception(self, ex):
         pass
@@ -663,7 +691,8 @@ class TangoAttribute(TaurusAttribute):
     def _subscribeChangeEvents(self):
         """ Enable subscription to the attribute events. If change events are
             not supported polling is activated """
-            
+        _empty_unsub_queue()
+
         if self.__chg_evt_id is not None:
             self.warning("chg events already subscribed (id=%s)"
                        %self.__chg_evt_id)
@@ -712,10 +741,6 @@ class TangoAttribute(TaurusAttribute):
         return self.__chg_evt_id
                 
     def _unsubscribeChangeEvents(self):
-        # Careful in this method: This is intended to be executed in the cleanUp
-        # so we should not access external objects from the factory, like the
-        # parent object
-        
         if self.__dev_hw_obj is not None and self.__chg_evt_id is not None:
             self.trace("Unsubscribing to change events (ID=%d)",
                        self.__chg_evt_id)
@@ -733,10 +758,26 @@ class TangoAttribute(TaurusAttribute):
         self.disablePolling()
         self.__subscription_state = SubscriptionState.Unsubscribed
 
+    def _finalUnsubscribeChangeEvents(self):
+        # Careful in this method: This is intended to be executed in the cleanUp
+        # so we should not access external objects from the factory, like the
+        # parent object
+
+        if self.__dev_hw_obj is not None and self.__chg_evt_id is not None:
+            self.trace("Postponing unsubscribe to change events (ID=%d)",
+                       self.__chg_evt_id)
+            unsubscribe_event = partial(_unsubscribe_event,
+                                        self.__dev_hw_obj,
+                                        self.__chg_evt_id)
+            _unsub_queue.put(unsubscribe_event)
+            self.__subscription_state = SubscriptionState.PostponedUnsubscribe
+            self.__chg_evt_id = None
+        # self.disablePolling()  # TODO: why it is here?
+
     def _subscribeConfEvents(self):
         """ Enable subscription to the attribute configuration events."""
+        _empty_unsub_queue()
         self.trace("Subscribing to configuration events...")
-
         if self.__cfg_evt_id is not None:
             self.warning("cfg events already subscribed (id=%s)"
                        %self.__cfg_evt_id)
@@ -778,10 +819,6 @@ class TangoAttribute(TaurusAttribute):
                 self.traceback()
                 
     def _unsubscribeConfEvents(self):
-        # Careful in this method: This is intended to be executed in the cleanUp
-        # so we should not access external objects from the factory, like the
-        # parent object
-        
         if self.__cfg_evt_id is not None and self.__dev_hw_obj is not None:
             self.trace("Unsubscribing to configuration events (ID=%s)",
                        str(self.__cfg_evt_id))
@@ -791,7 +828,22 @@ class TangoAttribute(TaurusAttribute):
             except PyTango.DevFailed as e:
                 self.debug("Error trying to unsubscribe configuration events")
                 self.trace(str(e))
-                
+
+    def _finalUnsubscribeConfEvents(self):
+        # Careful in this method: This is intended to be executed in the cleanUp
+        # so we should not access external objects from the factory, like the
+        # parent object
+
+        if self.__cfg_evt_id is not None and self.__dev_hw_obj is not None:
+            self.trace("Postponing unsubscribe to configuration events (ID=%s)",
+                       str(self.__cfg_evt_id))
+            unsubscribe_event = partial(_unsubscribe_event,
+                                       self.__dev_hw_obj,
+                                       self.__cfg_evt_id)
+            _unsub_queue.put(unsubscribe_event)
+            self.__subscription_cfg_state = SubscriptionState.PostponedUnsubscribe
+            self.__cfg_evt_id = None
+
     def subscribePendingEvents(self):
         """ Execute delayed event subscription
         """                
@@ -806,6 +858,9 @@ class TangoAttribute(TaurusAttribute):
         It propagates the event to listeners and delegates other tasks to
         specific handlers for different event types.
         """
+        if self._zombie == True:
+            return
+
         with self.__read_lock:
 
             # if it is a configuration event

--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -287,6 +287,7 @@ class TangoAttribute(TaurusAttribute):
         # current event subscription state
         self.__subscription_state = SubscriptionState.Unsubscribed
         self.__subscription_event = threading.Event()
+        self.__subscription_cfg_state = SubscriptionState.Unsubscribed
 
         # the parent's HW object (the PyTango Device obj)
         self.__dev_hw_obj = None
@@ -756,6 +757,7 @@ class TangoAttribute(TaurusAttribute):
             # connects to self.push_event callback
             # TODO: _BoundMethodWeakrefWithCall is used as workaround for
             # PyTango #185 issue
+            self.__subscription_cfg_state = SubscriptionState.Subscribing
             self.__cfg_evt_id = self.__dev_hw_obj.subscribe_event(
                 attr_name,
                 PyTango.EventType.ATTR_CONF_EVENT,
@@ -895,6 +897,7 @@ class TangoAttribute(TaurusAttribute):
                  evt_value is a TaurusValue, an Exception, or None.
         """
         if not event.err:
+            self.__subscription_cfg_state = SubscriptionState.Subscribed
             # update conf-related attributes
             self._decodeAttrInfoEx(event.attr_conf)
             # make sure that there is a self.__attr_value

--- a/lib/taurus/core/tango/tangodevice.py
+++ b/lib/taurus/core/tango/tangodevice.py
@@ -70,6 +70,7 @@ class TangoDevice(TaurusDevice):
         self._deviceStateObj = None
         # TODO reimplement using the new codification
         self._deviceState = TaurusDevState.Undefined
+        self._zombie = False
 
     # Export the DeviceProxy interface into this object.
     # This way we can call for example read_attribute on an object of this
@@ -103,6 +104,12 @@ class TangoDevice(TaurusDevice):
         on the device"""
         attr = self.getAttribute(key)
         return attr.write(value)
+
+    def setZombie(self, zombie=True):
+        self._zombie = zombie
+        if self._deviceStateObj is None:
+            return
+        self._deviceStateObj.setZombie(zombie)
 
     def getAttribute(self, attrname):
         """Returns the attribute object given its name"""

--- a/lib/taurus/core/tango/tangofactory.py
+++ b/lib/taurus/core/tango/tangofactory.py
@@ -332,7 +332,7 @@ class TangoFactory(Singleton, TaurusFactory, Logger):
         d = self.tango_devs.get(dev_name)
         if d is None:
             d = self.tango_alias_devs.get(dev_name)
-        if d is not None:
+        if d is not None and not d._zombie:
             return d
 
         validator = _Device.getNameValidator()

--- a/lib/taurus/core/tango/tangofactory.py
+++ b/lib/taurus/core/tango/tangofactory.py
@@ -51,7 +51,7 @@ from taurus.core.util.singleton import Singleton
 from taurus.core.util.containers import CaselessWeakValueDict, CaselessDict
 
 from .tangodatabase import TangoAuthority
-from .tangoattribute import TangoAttribute
+from .tangoattribute import TangoAttribute, _empty_unsub_queue
 from .tangodevice import TangoDevice
 
 _Authority = TangoAuthority
@@ -149,6 +149,7 @@ class TangoFactory(Singleton, TaurusFactory, Logger):
             v.cleanUp()
         for k, v in self.tango_db.items():
             v.cleanUp()
+        _empty_unsub_queue()
         self.reInit()
 
     def getExistingAttributes(self):
@@ -381,7 +382,7 @@ class TangoFactory(Singleton, TaurusFactory, Logger):
                    alias is invalid.
         """
         attr = self.tango_attrs.get(attr_name)
-        if attr is not None:
+        if attr is not None and not attr._zombie:
             return attr
 
         # Simple approach did not work. Lets build a proper device name

--- a/lib/taurus/core/taurusbasetypes.py
+++ b/lib/taurus/core/taurusbasetypes.py
@@ -169,7 +169,8 @@ SubscriptionState = Enumeration(
         "Unsubscribed",
         "Subscribing",
         "Subscribed",
-        "PendingSubscribe"
+        "PendingSubscribe",
+        "PostponedUnsubscribe"
     ))
 
 


### PR DESCRIPTION
Similarly to #1091 and #1093, this PR tries to workaround https://github.com/tango-controls/pytango/issues/292.

I tried this PR with [sardana-org/sardana#1312](https://github.com/sardana-org/sardana/pull/1312) ( which reverts the Sardana workaround and use zombie concept in tests) and it works corrrectly for the sardanatestsuite and for the stress macro posted in https://github.com/taurus-org/taurus/pull/1093#issuecomment-602042643. So, IMO it is a satisfactory workaround.

Note that it has one side effect - it keeps garbage collected attributes subscribed until some new attribute is subscribed. To mitigate this effect attributes are marked as zombies - their push event return immediately. Also this should happen only for the configuration events - the change events should be unsubscribed with the last `TaurusModel.removeListener` call. Also if one wants to increase the frequency of unsubscribes the `tangoattribute._empty_unsub_queue()` could be called more frequently.
