### PR TITLE
Maintain old widget for 0D and PseudoCounters in TaurusValue

### DIFF
--- a/lib/taurus/tauruscustomsettings.py
+++ b/lib/taurus/tauruscustomsettings.py
@@ -38,9 +38,9 @@ T_FORM_CUSTOM_WIDGET_MAP = \
     {'SimuMotor': ('sardana.taurus.qt.qtgui.extra_pool.PoolMotorTV', (), {}),
      'Motor': ('sardana.taurus.qt.qtgui.extra_pool.PoolMotorTV', (), {}),
      'PseudoMotor': ('sardana.taurus.qt.qtgui.extra_pool.PoolMotorTV', (), {}),
-     'PseudoCounter': ('sardana.taurus.qt.qtgui.extra_pool.PoolChannelTV', (), {}),
+     'PseudoCounter': ('sardana.taurus.qt.qtgui.extra_pool._PoolChannelTV', (), {}),
      'CTExpChannel': ('sardana.taurus.qt.qtgui.extra_pool.PoolChannelTV', (), {}),
-     'ZeroDExpChannel': ('sardana.taurus.qt.qtgui.extra_pool.PoolChannelTV', (), {}),
+     'ZeroDExpChannel': ('sardana.taurus.qt.qtgui.extra_pool._PoolChannelTV', (), {}),
      'OneDExpChannel': ('sardana.taurus.qt.qtgui.extra_pool.PoolChannelTV', (), {}),
      'TwoDExpChannel': ('sardana.taurus.qt.qtgui.extra_pool.PoolChannelTV', (), {}),
      'IORegister': ('sardana.taurus.qt.qtgui.extra_pool.PoolIORegisterTV', (), {})


### PR DESCRIPTION
[sardana-org/sardana#1203](https://github.com/sardana-org/sardana/pull/1203) introduces new widget for experimental channels which allows acquisition. Since 0D and PseudoCounters do not allow experimental channel acquisition still use the old widget for them.