### PR TITLE
Catch RuntimeError in tauruscombobox postDetach

### DIFF
--- a/lib/taurus/qt/qtgui/input/tauruscombobox.py
+++ b/lib/taurus/qt/qtgui/input/tauruscombobox.py
@@ -79,7 +79,8 @@ class TaurusValueComboBox(Qt.QComboBox, TaurusBaseWritableWidget):
             self.currentIndexChanged.disconnect(self.writeIndexValue)
         except (RuntimeError, TypeError):
             # In new style-signal if a signal is disconnected without
-            # previously was connected it, it raises a TypeError
+            # previously was connected it, it raises a TypeError (PyQt)
+            # or RuntimeError (PySide)
             pass
 
     #-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-

--- a/lib/taurus/qt/qtgui/input/tauruscombobox.py
+++ b/lib/taurus/qt/qtgui/input/tauruscombobox.py
@@ -77,7 +77,7 @@ class TaurusValueComboBox(Qt.QComboBox, TaurusBaseWritableWidget):
         TaurusBaseWritableWidget.postDetach(self)
         try:
             self.currentIndexChanged.disconnect(self.writeIndexValue)
-        except TypeError:
+        except (RuntimeError, TypeError):
             # In new style-signal if a signal is disconnected without
             # previously was connected it, it raises a TypeError
             pass


### PR DESCRIPTION
In case of disconnecting signal which was not connected before, PyQt5 raises `TypeError`, but PySide2 raises `RuntimeError`.

This is the simplest solution, I guess. I wasn't sure if I should catch only `TypeError` when PyQt5 is used and only `RuntimeError` when PySide2 is used, so I omitted this.

Fix  #1100 