### PR TITLE
Allow any case in CLI --log option

### DIFF
--- a/lib/taurus/cli/common.py
+++ b/lib/taurus/cli/common.py
@@ -85,11 +85,16 @@ script::
 import click
 
 
+__levels = ['Critical', 'Error', 'Warning', 'Info', 'Debug', 'Trace']
+try:
+    __log_choice = click.Choice(__levels, case_sensitive=False)
+except TypeError:  # click v< 7 does not allow case_sensitive option
+    __log_choice = click.Choice(__levels)
+
+
 log_level = click.option(
     '--log-level', 'log_level',
-    type=click.Choice(['Critical', 'Error', 'Warning', 'Info',
-                       'Debug', 'Trace'], case_sensitive=False),
-    default='Info', show_default=True,
+    type=__log_choice, default='Info', show_default=True,
     help='Show only logs with priority LEVEL or above',
 )
 

--- a/lib/taurus/cli/common.py
+++ b/lib/taurus/cli/common.py
@@ -88,7 +88,7 @@ import click
 log_level = click.option(
     '--log-level', 'log_level',
     type=click.Choice(['Critical', 'Error', 'Warning', 'Info',
-                       'Debug', 'Trace']),
+                       'Debug', 'Trace'], case_sensitive=False),
     default='Info', show_default=True,
     help='Show only logs with priority LEVEL or above',
 )


### PR DESCRIPTION
The l--taurus-log-level option of old CLI scripts was replaced by the 
--log option to the taurus script (#856). The old one was case-insensitive, while the new one is not.. Make the new one insensitive. For example, allow :
```
# only this is valid before this PR
taurus --log-level=Debug form

# this should be also valid now
taurus --log-level=debug form
```
