### PR TITLE
LineEdit: enforce explicit disable

### DIFF
--- a/lib/taurus/qt/qtgui/input/tauruslineedit.py
+++ b/lib/taurus/qt/qtgui/input/tauruslineedit.py
@@ -77,6 +77,7 @@ class TaurusValueLineEdit(Qt.QLineEdit, TaurusBaseWritableWidget):
         self._enableWheelEvent = False
         self._last_value = None
         self._singleStep = 1.
+        self._allow_auto_enable = True
 
         self.setAlignment(Qt.Qt.AlignRight)
         self.setValidator(None)
@@ -146,7 +147,10 @@ class TaurusValueLineEdit(Qt.QLineEdit, TaurusBaseWritableWidget):
             except Exception as e:
                 self.info('Failed attempt to initialize value: %r', e)
 
-        self.setEnabled(evt_type != TaurusEventType.Error)
+        if self._allow_auto_enable:
+            # use QLineEdit.setEnabled in order to avoid changing
+            # _allow_auto_enable status
+            Qt.QLineEdit.setEnabled(self, evt_type != TaurusEventType.Error)
 
         if evt_type in (TaurusEventType.Change, TaurusEventType.Periodic):
             self._updateValidator(evt_value)
@@ -156,6 +160,14 @@ class TaurusValueLineEdit(Qt.QLineEdit, TaurusBaseWritableWidget):
 
         if evt_type == TaurusEventType.Error:
             self.updateStyle()
+
+    def setEnabled(self, enabled):
+        """Reimplement from :class:`QLineEdit` to avoid autoenabling if the
+        widget is explicitly disabled (but allow auto-disabling if the
+        widget is explicitly enabled)
+        """
+        self._allow_auto_enable = enabled
+        return Qt.QLineEdit.setEnabled(self, enabled)
 
     def isTextValid(self):
         """


### PR DESCRIPTION
TaurusValueLineEdit auto enables/disables itself based based on events. This precludes the user
from explicitly disable it. Fix by avoiding reenabling if setEnabled(False) is called. Note that auto-disabling on errors is still allowed even if setEnabled(True) is called, since the widget
is not usable in case of error.

To test this you can use the following snippet (without this PR, the second widget will start disabled but will be autoenabled on the first change event, while with this PR it will stay disabled even if changes are forced with the first widget):

```python
from taurus.qt.qtgui.application import TaurusApplication
from taurus.qt.qtgui.input import TaurusValueLineEdit
from taurus.external.qt import Qt


if __name__ == "__main__":
    import sys
    app = TaurusApplication(cmd_line_parser=None)

    w = Qt.QWidget()
    ly = Qt.QVBoxLayout()
    w.setLayout(ly)
    model = "sys/tg_test/1/short_scalar"

    e1 = TaurusValueLineEdit()
    e1.setModel(model)
    ly.addWidget(e1)

    e2 = TaurusValueLineEdit()
    e2.setModel(model)
    ly.addWidget(e2)
    e2.setEnabled(False)

    w.show()

    sys.exit(app.exec_())
```