### PR TITLE
Fix #1113 (TangoAttribute not reenabling polling)

### DIFF
--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -746,7 +746,7 @@ class TangoAttribute(TaurusAttribute):
                 else:
                     self.debug("Failed: %s", df.args[0].desc)
                     self.trace(str(df))
-        self.disablePolling()
+        self._deactivatePolling()
         self.__subscription_state = SubscriptionState.Unsubscribed
 
     def _subscribeConfEvents(self):


### PR DESCRIPTION
TangoAttribute calls `.disablePolling()` when
unsubscribing from Change events (this happens automatically
e.g. when removing its last listener). This is problematic
because it permanently disables the polling (e.g. it
won't e re-activated if a listener is lately added to the
same attribute). Prevent this by "deactivating" instead of
"disabling" the polling.

Fixes #1113