### PR TITLE
Allow to skip  tango attr auto-subscription to conf events

### DIFF
--- a/lib/taurus/core/tango/tangoattribute.py
+++ b/lib/taurus/core/tango/tangoattribute.py
@@ -317,8 +317,11 @@ class TangoAttribute(TaurusAttribute):
         self._decodeAttrInfoEx(attr_info)
 
         # subscribe to configuration events (unsubscription done at cleanup)
+        auto_subscribe_conf = getattr(
+            tauruscustomsettings, "TANGO_AUTOSUBSCRIBE_CONF", True
+        )
         self.__cfg_evt_id = None
-        if self.factory().is_tango_subscribe_enabled():
+        if auto_subscribe_conf and self.factory().is_tango_subscribe_enabled():
             self._subscribeConfEvents()
 
     def __del__(self):

--- a/lib/taurus/tauruscustomsettings.py
+++ b/lib/taurus/tauruscustomsettings.py
@@ -85,6 +85,14 @@ EXTRA_SCHEME_MODULES = []
 #: 'Serial', 'Concurrent', or 'TangoSerial' (default)
 TANGO_SERIALIZATION_MODE = 'TangoSerial'
 
+#: Whether TangoAttribute is subscribed to configuration events by default.
+#: Setting to True (or not setting it) makes the TangoAttribute auto-subscribe
+#: Setting to False avoids this subscription, which prevents issues such as
+#: https://github.com/taurus-org/taurus/issues/1118
+#: but it also prevents clients to be notified when configurations (e.g.,
+#: units, format) change.
+TANGO_AUTOSUBSCRIBE_CONF = True
+
 #: PLY (lex/yacc) optimization: 1=Active (default) , 0=disabled.
 #: Set PLY_OPTIMIZE = 0 if you are getting yacc exceptions while loading
 #: synoptics


### PR DESCRIPTION
TangoAttribute subscribes to configuration events automatically. This sometimes may not be wanted/needed(see https://github.com/taurus-org/taurus/issues/1118 ).
Add an entry in tauruscustomsettings, allowing to disable this autosubscrition (but maintain the current behaviour by default).

This can be used (among other things) as a workaround to fix #1118 until  #tango-controls/pytango#371 is fixed