### PR TITLE
Add len support to taurus enumeration

### DIFF
--- a/lib/taurus/core/util/enumeration.py
+++ b/lib/taurus/core/util/enumeration.py
@@ -137,6 +137,9 @@ class Enumeration(object):
         # Enumeration member.
         return self.lookup[self.whatis(i)]
 
+    def __len__(self):
+        return len(self.lookup)
+
     def _generateUniqueId(self):
         if self._flaggable:
             n = 2 ** self._uniqueId


### PR DESCRIPTION
taurus.core.util.enumeration.Enumeration stopped supporting
len() operations at some point (probably since it was adapted
for py3).
This triggered a regression in taurusgui (see #1106).
Add explicit len support.

Fixes #1106