### PR TITLE
Ensure that (internal) files are closed in {save,load}ConfigFile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,9 @@ matrix:
     - env: TOXENV=py35-qt5
     - env: TOXENV=py36-qt5
     - env: TOXENV=py37-qt5
+    - env: TOXENV=py38-qt5
     - env: TOXENV=py37-ps2
-    - env: TOXENV=py37-qt5-docs
+    - env: TOXENV=py38-qt5-docs
   allow_failures:
     #- env: TOXENV=flake8
     #- env: TOXENV=py27-qt4
@@ -54,7 +55,7 @@ script:
 
 after_success:
   # Deploy docs to taurus-org/taurus-doc
-  - if [[ "$TOXENV" == "py37-qt5-docs" && "$TRAVIS_REPO_SLUG" == "taurus-org/taurus" ]]; then
+  - if [[ "$TOXENV" == "py38-qt5-docs" && "$TRAVIS_REPO_SLUG" == "taurus-org/taurus" ]]; then
       pip install doctr ;
       touch build/sphinx/html/.nojekyll;
       if [[ "${TRAVIS_BRANCH}" == "develop" ]]; then

--- a/lib/taurus/qt/qtcore/configuration/configuration.py
+++ b/lib/taurus/qt/qtcore/configuration/configuration.py
@@ -444,11 +444,13 @@ class BaseConfigurableClass(object):
             )
             if not ofile:
                 return
-        if isinstance(ofile, string_types):
-            ofile = open(ofile, 'wb')
-        configdict = self.createConfig(allowUnpickable=False)
         self.info("Saving current settings in '%s'" % ofile.name)
-        pickle.dump(configdict, ofile)
+        configdict = self.createConfig(allowUnpickable=False)
+        if isinstance(ofile, string_types):
+            with open(ofile, 'wb') as ofile:
+                pickle.dump(configdict, ofile)
+        else:
+            pickle.dump(configdict, ofile)
         return ofile.name
 
     def loadConfigFile(self, ifile=None):
@@ -466,8 +468,9 @@ class BaseConfigurableClass(object):
             if not ifile:
                 return
         if isinstance(ifile, string_types):
-            ifile = open(ifile, 'rb')
-
-        configdict = pickle.load(ifile)
+            with open(ifile, 'rb') as ifile:
+                configdict = pickle.load(ifile)
+        else:
+            configdict = pickle.load(ifile)
         self.applyConfig(configdict)
         return ifile.name

--- a/lib/taurus/qt/qtgui/table/qlogtable.py
+++ b/lib/taurus/qt/qtgui/table/qlogtable.py
@@ -156,7 +156,7 @@ class QLoggingTableModel(Qt.QAbstractTableModel, logging.Handler):
         self._records = []
         self._accumulated_records = []
         Logger.addRootLogHandler(self)
-        self.startTimer(freq * 1000)
+        self.startTimer(int(freq * 1000))
 
     # ---------------------------------
     # Qt.QAbstractTableModel overwrite

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
     py27-qt4
     py{27,35,36,37}-qt5
     py37-ps2
-    py37-qt5-docs
+    py38-qt5-docs
     flake8
 
 [testenv]
@@ -25,6 +25,7 @@ conda_deps=
     py35: cython
     py36: guiqwt
     py37: guiqwt
+    py38: guiqwt
     lxml
     future
     pillow
@@ -52,7 +53,7 @@ deps=
 commands=
     python -m pytest lib/taurus
 
-[testenv:py37-qt5-docs]
+[testenv:py38-qt5-docs]
 commands=
     sphinx-build -qW doc/source/ build/sphinx/html
 


### PR DESCRIPTION
The {save,load}ConfigFile methods accept either a file name or a file object
as their argument. If a name is passed, a file object is internally created
and opened, but it is not closed. This may cause trouble. Make sure the
file is closed if it was internally created.
Note that, in order to maintain backwards compatibility, the file
won't be closed if it was passed already as a file object (the
responsibility for closing lies in the opener)