### PR TITLE
Avoid warning on strings with replacement fields

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,9 @@ matrix:
     - env: TOXENV=py35-qt5
     - env: TOXENV=py36-qt5
     - env: TOXENV=py37-qt5
+    - env: TOXENV=py38-qt5
     - env: TOXENV=py37-ps2
-    - env: TOXENV=py37-qt5-docs
+    - env: TOXENV=py38-qt5-docs
   allow_failures:
     #- env: TOXENV=flake8
     #- env: TOXENV=py27-qt4
@@ -54,7 +55,7 @@ script:
 
 after_success:
   # Deploy docs to taurus-org/taurus-doc
-  - if [[ "$TOXENV" == "py37-qt5-docs" && "$TRAVIS_REPO_SLUG" == "taurus-org/taurus" ]]; then
+  - if [[ "$TOXENV" == "py38-qt5-docs" && "$TRAVIS_REPO_SLUG" == "taurus-org/taurus" ]]; then
       pip install doctr ;
       touch build/sphinx/html/.nojekyll;
       if [[ "${TRAVIS_BRANCH}" == "develop" ]]; then

--- a/lib/taurus/qt/qtgui/table/qlogtable.py
+++ b/lib/taurus/qt/qtgui/table/qlogtable.py
@@ -156,7 +156,7 @@ class QLoggingTableModel(Qt.QAbstractTableModel, logging.Handler):
         self._records = []
         self._accumulated_records = []
         Logger.addRootLogHandler(self)
-        self.startTimer(freq * 1000)
+        self.startTimer(int(freq * 1000))
 
     # ---------------------------------
     # Qt.QAbstractTableModel overwrite

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
     py27-qt4
     py{27,35,36,37}-qt5
     py37-ps2
-    py37-qt5-docs
+    py38-qt5-docs
     flake8
 
 [testenv]
@@ -25,6 +25,7 @@ conda_deps=
     py35: cython
     py36: guiqwt
     py37: guiqwt
+    py38: guiqwt
     lxml
     future
     pillow
@@ -52,7 +53,7 @@ deps=
 commands=
     python -m pytest lib/taurus
 
-[testenv:py37-qt5-docs]
+[testenv:py38-qt5-docs]
 commands=
     sphinx-build -qW doc/source/ build/sphinx/html
 


### PR DESCRIPTION
TaurusLabel.displayValue fails when displaying a string attribute
whose value contains a replacement field, and falls back to the
default representation with a warning.
Avoid this by using a custom string formatter that ignores
missing keys when formatting a string.
Thanks to @vallsv for the proposed solution.

Fixes #1149