### PR TITLE
Fix buffer option in taurus trend cli

### DIFF
--- a/lib/taurus/cli/alt.py
+++ b/lib/taurus/cli/alt.py
@@ -328,7 +328,7 @@ def trend_cmd(
                 epname,
                 e,
             )
-        sys.exit(1)
+            sys.exit(1)
 
     # set models
     if models:

--- a/lib/taurus/cli/alt.py
+++ b/lib/taurus/cli/alt.py
@@ -318,6 +318,14 @@ def trend_cmd(
             )
             sys.exit(1)
 
+    # set models
+    if models:
+        w.setModel(list(models))
+
+    # period option
+    if forced_read_period > 0:
+        w.setForcedReadingPeriod(forced_read_period)
+        
     # max buffer size option
     if max_buffer_size is not None:
         try:
@@ -329,14 +337,6 @@ def trend_cmd(
                 e,
             )
             sys.exit(1)
-
-    # set models
-    if models:
-        w.setModel(list(models))
-
-    # period option
-    if forced_read_period > 0:
-        w.setForcedReadingPeriod(forced_read_period)
 
     w.show()
     sys.exit(app.exec_())


### PR DESCRIPTION
An indentation mistake provokes a premature exit when using the --buffer option in the taurus trend CLI (even on success)
Fix it so that it only exits in case of error.

Also move the call to setting the buffers in the CLI command after the models have been set, in order to affect them 
