### PR TITLE
(TEP13) plugins support (entry point based)

### DIFF
--- a/doc/source/devel/plugins.rst
+++ b/doc/source/devel/plugins.rst
@@ -14,26 +14,26 @@ currently supported by taurus, according to TEP13_.
 CLI subcommands
 -----------------------------------
 
-- Description: register subcommands for the `taurus` CLI command. See :mod:`taurus.cli`
-- Group: `taurus.cli.subcommands`
+- Description: register subcommands for the ``taurus`` CLI command. See :mod:`taurus.cli`
+- Group: ``taurus.cli.subcommands``
 - Expected API: :class:`click.Command`
 - Entry point name convention: None, the name is ignored. Suggestion: use the
   subcommand name
 - Loading pattern: extension (loaded when invoking the taurus command)
 - Enabling pattern: installation
-- Examples: `taurus` self-registers all its subcommands (see `setup.py`)
+- Examples: :mod:`taurus` self-registers all its subcommands (see ``setup.py``)
 
 Schemes
 -----------------------------------
 
 
 - Description: new schemes in taurus.core to support other sources of data.
-- Group: `taurus.core.schemes`
+- Group: ``taurus.core.schemes``
 - Expected API: python module implementing a Taurus scheme. It should at least
-  provide a `TaurusFactory` specialization. See more details in the Taurus Core
-  Tutorial (http://taurus-scada.org/devel/core_tutorial.html)
+  provide a :class:`taurus.core.taurusfactory.TaurusFactory` specialization.
+  See more details in the `Taurus Core Tutorial`_
 - Entry point name convention: the name must match the module name.
-  For example: `h5file = h5file`
+  For example: ``h5file = h5file``
 - Loading pattern: Driver
 - Enabling pattern: installation
 - Examples: taurus_tangoarchiving_ registers itself as a scheme
@@ -43,44 +43,45 @@ Formatters
 
 - Description: adding formatter objects for taurus widgets, as used by
   :meth:`taurus.qt.qtgui.base.TaurusBaseComponent.displayValue`
-- Group: `taurus.qt.formatters`
+- Group: ``taurus.qt.formatters``
 - Expected API: a formatter accepted by :meth:`taurus.qt.qtgui.TaurusBaseComponent.setFormat`
 - Entry point name convention: A short descriptive string of the formatter. It
   may be used by the UI when offering the user to select formatters.
 - Loading pattern: installation
 - Enabling pattern: Explicit (e.g. via a selection dialog when calling
   :meth:`taurus.qt.qtgui.TaurusBaseWidget.onSetFormatter`)
-- Examples: `taurus` self-registers several formatters (see `setup.py`)
+- Examples: :mod:`taurus` self-registers several formatters (see ``setup.py``)
 
 Model Chooser Selectors
 -----------------------------------
 
 - Description: Adding widgets to be used by :class:`taurus.qt.qtgui.panel.TaurusModelSelector`
   for supporting models from other schemes
-- Group: `taurus.model_selector.items`
+- Group: ``taurus.model_selector.items``
 - Expected API: :class:`taurus.qt.qtgui.panel.TaurusModelSelectorItem`
 - Entry point name convention: the name should be a short description of the
-  scheme or type of models supported by this item (e.g. `TangoArchiving = ...`).
+  scheme or type of models supported by this item (e.g.
+  ``TangoArchiving = ...``).
   It is used as a tab title in :class:`taurus.qt.qtgui.panel.TaurusModelSelector`
 - Loading pattern: Extension
 - Enabling pattern: installation (but it may be changed in the future to a
   explicit or self-enabled pattern)
 - Examples: taurus_tangoarchiving_ registers
-  :class:`taurus_tangoarchiving.widget.tangoarchivingmodelchooser:TangoArchivingModelSelectorItem`
+  :class:`taurus_tangoarchiving.widget.tangoarchivingmodelchooser.TangoArchivingModelSelectorItem`
   as a model selector item
 
 Plot widget Alternatives
 -----------------------------------
 
 - Description: alternative implementations of TaurusPlot.
-- Group: `taurus.plot.alts`
+- Group: ``taurus.plot.alts``
 - Expected API: *to be formally defined with an Abstract Base Class*. For now,
   informally, the API is defined by what is used in
-  meth:`taurus.cli.alt.plot_cmd`:  at minimum, a :class:`QWidget` that has a
-  `setModel` that accepts a sequence of attribute names.
+  :func:`taurus.cli.alt.plot_cmd`:  at minimum, a :class:`QWidget` that has a
+  :meth:`setModel` that accepts a sequence of attribute names.
 - Entry point name convention: a short descriptive identifier of the
-  implementation (e.g. `"qwt5"`, `"tpg"`, ...). The name is used in the UI for
-  user selection of the implementation.
+  implementation (e.g. ``"qwt5"``, ``"tpg"``, ...). The name is used in the UI
+  for user selection of the implementation.
 - Loading pattern: Extension
 - Enabling pattern: explicit
 - Examples: taurus_pyqtgraph_ registers :class:`taurus_tauruspyqtgraph.TaurusPlot`
@@ -90,14 +91,14 @@ Trend widget Alternatives
 -----------------------------------
 
 - Description: alternative implementations of TaurusTrend
-- Group: `taurus.trend.alts`
+- Group: ``taurus.trend.alts``
 - Expected API:*to be formally defined with an Abstract Base Class*. For now,
   informally, the API is defined by what is used in
-  meth:`taurus.cli.alt.trend_cmd`:  at minimum, a :class:`QWidget` that has a
-  `setModel` that accepts a sequence of attribute names.
+  :func:`taurus.cli.alt.trend_cmd`:  at minimum, a :class:`QWidget` that has a
+  :meth:`setModel` that accepts a sequence of attribute names.
 - Entry point name convention: a short descriptive identifier of the
-  implementation (e.g. `"qwt5"`, `"tpg"`, ...). The name is used in the UI for
-  user selection of the implementation.
+  implementation (e.g. ``"qwt5"``, ``"tpg"``, ...). The name is used in the UI
+  for user selection of the implementation.
 - Loading pattern: Extension
 - Enabling pattern: explicit
 - Examples: taurus_pyqtgraph_ registers :class:`taurus_tauruspyqtgraph.TaurusTrend`
@@ -107,55 +108,55 @@ Image widget Alternatives
 -----------------------------------
 
 - Description: alternative implementations of TaurusImage
-- Group: `taurus.image.alts`
+- Group: ``taurus.image.alts``
 - Expected API: *to be formally defined with an Abstract Base Class*. For now,
   informally, the API is defined by what is used in
-  meth:`taurus.cli.alt.image_cmd`:  at minimum, a :class:`QWidget` that has a
-  `setModel` that accepts a sequence of attribute names. At this moment, the
-  widget creator needs to accept the `wintitle` keyword argument (it may change
-  when the API is formalized)
+  :func:`taurus.cli.alt.image_cmd`:  at minimum, a :class:`QWidget` that has a
+  :meth:`setModel` that accepts an attribute name. At this moment, the
+  widget creator needs to accept the ``wintitle`` keyword argument (it may
+  change when the API is formalized)
 - Entry point name convention: a short descriptive identifier of the
-  implementation (e.g. `"qwt5"`, `"tpg"`, ...). The name is used in the UI for
-  user selection of the implementation.
+  implementation (e.g. ``"guiqwt"``, ``"tpg"``, ...). The name is used in the UI
+  for user selection of the implementation.
 - Loading pattern: Extension
 - Enabling pattern: explicit
-- Examples: `taurus` self-registers its
+- Examples: :mod:`taurus` self-registers its
   :class:`taurus.qt.qtgui.extra_guiqwt.TaurusImageDialog` as an image widget
-  alternative (see `setup.py`)
+  alternative (see ``setup.py``)
 
 Trend2D widget Alternatives
 -----------------------------------
 
 - Description: alternative implementations of TaurusTrend2D
-- Group: `taurus.trend2d.alts`
+- Group: ``taurus.trend2d.alts``
 - Expected API: *to be formally defined with an Abstract Base Class*. For now,
   informally, the API is defined by what is used in
-  meth:`taurus.cli.alt.trend2d_cmd`:  at minimum, a :class:`QWidget` that has a
-  `setModel` that accepts a sequence of attribute names. At this moment, the
-  widget creator needs to accept the following keyword arguments: `stackMode`,
-  `wintitle`, `buffersize`. (it may change when the API is formalized)
+  :func:`taurus.cli.alt.trend2d_cmd`:  at minimum, a :class:`QWidget` that has a
+  :meth:`setModel` that accepts an attribute name. At this moment, the
+  widget creator needs to accept the following keyword arguments: ``stackMode``,
+  ``wintitle``, ``buffersize``. (it may change when the API is formalized)
 - Entry point name convention: a short descriptive identifier of the
-  implementation (e.g. `"qwt5"`, `"tpg"`, ...). The name is used in the UI for
-  user selection of the implementation.
+  implementation (e.g. ``"guiqwt"``, ``"tpg"``, ...). The name is used in the UI
+  for user selection of the implementation.
 - Loading pattern: Extension
 - Enabling pattern: explicit
-- Examples: `taurus` self-registers its
+- Examples: :mod:`taurus` self-registers its
   :class:`taurus.qt.qtgui.extra_guiqwt.TaurusTrend2DDialog` as trend2d widget
-  alternative (see `setup.py`)
+  alternative (see ``setup.py``)
 
 Form Factories
 -----------------------------------
 
 - Description: factories for custom "taurus value" widgets to be used in taurus
   forms. See :meth:`taurus.qt.qtgui.panel.TaurusForm.setItemFactories`
-- Group: `taurus.form.item_factories`
+- Group: ``taurus.form.item_factories``
 - Expected API: a factory function that accepts a model name as its first
   argument and which returns either a :class:`taurus.qt.qtgui.panel.TaurusValue`
-  type object (or `None`)
+  type object (or ``None``)
 - Entry point name convention:
 - Loading pattern: extension
 - Enabling pattern: installation, but allowing explicit (de)selection based
-  on meth:`taurus.core.util.plugin.selectEntryPoints`.
+  on :func:`taurus.core.util.plugin.selectEntryPoints`.
 - Examples: sardana_ registers
   :func:`sardana.taurus.qt.qtgui.extra_pool.formitemfactory.pool_item_factory`
   to provide custom widgets for sardana elements in taurus forms.
@@ -167,7 +168,7 @@ qtgui submodules
           compatibility when "outsourcing" submodules).
 
 - Description: adding submodules to :mod:`taurus.qt.qtgui`.
-- Group: `taurus.qt.qtgui`
+- Group: ``taurus.qt.qtgui``
 - Expected API: python module (typically exposing :class:`QWidget` classes)
 - Entry point name convention: the name must match the module name
 - Loading pattern: Extension (for performance, we use a
@@ -179,6 +180,7 @@ qtgui submodules
 
 
 .. _TEP13: http://www.taurus-scada.org/tep?TEP13.md
+.. _`Taurus Core Tutorial`: http://taurus-scada.org/devel/core_tutorial.html
 .. _taurus_tangoarchiving: https://github.com/taurus-org/taurus_tangoarchiving
 .. _taurus_pyqtgraph: https://github.com/taurus-org/taurus_pyqtgraph
 .. _sardana: https://sardana-controls.org/

--- a/doc/source/devel/plugins.rst
+++ b/doc/source/devel/plugins.rst
@@ -4,65 +4,181 @@
 Taurus plugins
 ==============
 
-.. note:: The taurus plugins API is still experimental. Current entry point
-         group names, and expected entry point objects API may be modified or
-         removed in later versions.
+Taurus can be extended by third party modules in various ways. The TEP13_
+prescribes some generic rules in order to unify the plugins support by using
+entry point APIs.
 
-Taurus can be extended by third party modules in various ways. For example, a
-mechanism exists since before v4.0.0 to use add new schemes to the
-`taurus.core` module. But these extension mechanisms grew organically and
-independently of each other, resulting in several non-consistent plugin APIs.
-This has been long-standing pending issue as can be seen by date of the draft
-of the TEP13_
+The following subsections describe each entry point based pluggable interface
+currently supported by taurus, according to TEP13_.
 
-Since taurus v4.3 we started introducing some experimental `pkg_resources`-
-based entry points, in an effort to test their viability for being used as a
-more generic and standard mechanism for plugins. Here we describe such
-APIs which, for now and until TEP13_ is approved, should be still considered
-experimental.
+CLI subcommands
+-----------------------------------
 
+- Description: register subcommands for the `taurus` CLI command. See :mod:`taurus.cli`
+- Group: `taurus.cli.subcommands`
+- Expected API: :class:`click.Command`
+- Entry point name convention: None, the name is ignored. Suggestion: use the
+  subcommand name
+- Loading pattern: extension (loaded when invoking the taurus command)
+- Enabling pattern: installation
+- Examples: `taurus` self-registers all its subcommands (see `setup.py`)
 
-Entry point-based plugins:
---------------------------
-
-The following table lists the entry-point groups used by taurus, with links to
-the appropriate docs.
-
-+---------------------------------+----------------------------------------+-------+
-| Entry point group               | Description                            | Notes |
-+=================================+========================================+=======+
-| taurus.qt.qtgui                 | submodules of taurus.qt.qtgui          | 1     |
-+---------------------------------+----------------------------------------+-------+
-| taurus.cli.subcommands          | click subcommands for the `taurus`     | 2     |
-|                                 | command.                               |       |
-+---------------------------------+----------------------------------------+-------+
-| taurus.model_selector.items     | items for `TaurusModelSelector`        | 3     |
-+---------------------------------+----------------------------------------+-------+
-| taurus.qt.formatters            | formatter objects for taurus widgets   | 4     |
-+---------------------------------+----------------------------------------+-------+
-| - taurus.plot.alts              | Alternative implementations for        | 2     |
-| - taurus.trend.alts             | various basic widgets. To be used in   |       |
-| - taurus.trend2d.alts           | in, e.g. the `taurus plot` subcommand, |       |
-| - taurus.image.alts             | etc.                                   |       |
-+---------------------------------+----------------------------------------+-------+
-| taurus.form.item_factories      | Factories for custom "taurus value"    | 5     |
-|                                 | widgets to be used in taurus forms     |       |
-+---------------------------------+----------------------------------------+-------+
-| taurus.core.schemes             | Schemes in taurus.core                 | 6     |
-+---------------------------------+----------------------------------------+-------+
+Schemes
+-----------------------------------
 
 
-Notes:
+- Description: new schemes in taurus.core to support other sources of data.
+- Group: `taurus.core.schemes`
+- Expected API: python module implementing a Taurus scheme. It should at least
+  provide a `TaurusFactory` specialization. See more details in the Taurus Core
+  Tutorial (http://taurus-scada.org/devel/core_tutorial.html)
+- Entry point name convention: the name must match the module name.
+  For example: `h5file = h5file`
+- Loading pattern: Driver
+- Enabling pattern: installation
+- Examples: taurus_tangoarchiving_ registers itself as a scheme
 
-1. For internal use only (used backwards compatibility when "outsourcing"
-submodules).
-2. See :mod:`taurus.cli`
-3. See :class:`taurus.qt.qtgui.panel.TaurusModelSelector`
-4. See :meth:`taurus.qt.qtgui.base.TaurusBaseComponent.displayValue`
-5. See :meth:`taurus.qt.qtgui.panel.TaurusForm.setItemFactories`
+Formatters
+-----------------------------------
 
+- Description: adding formatter objects for taurus widgets, as used by
+  :meth:`taurus.qt.qtgui.base.TaurusBaseComponent.displayValue`
+- Group: `taurus.qt.formatters`
+- Expected API: a formatter accepted by :meth:`taurus.qt.qtgui.TaurusBaseComponent.setFormat`
+- Entry point name convention: A short descriptive string of the formatter. It
+  may be used by the UI when offering the user to select formatters.
+- Loading pattern: installation
+- Enabling pattern: Explicit (e.g. via a selection dialog when calling
+  :meth:`taurus.qt.qtgui.TaurusBaseWidget.onSetFormatter`)
+- Examples: `taurus` self-registers several formatters (see `setup.py`)
 
+Model Chooser Selectors
+-----------------------------------
 
+- Description: Adding widgets to be used by :class:`taurus.qt.qtgui.panel.TaurusModelSelector`
+  for supporting models from other schemes
+- Group: `taurus.model_selector.items`
+- Expected API: :class:`taurus.qt.qtgui.panel.TaurusModelSelectorItem`
+- Entry point name convention: the name should be a short description of the
+  scheme or type of models supported by this item (e.g. `TangoArchiving = ...`).
+  It is used as a tab title in :class:`taurus.qt.qtgui.panel.TaurusModelSelector`
+- Loading pattern: Extension
+- Enabling pattern: installation (but it may be changed in the future to a
+  explicit or self-enabled pattern)
+- Examples: taurus_tangoarchiving_ registers
+  :class:`taurus_tangoarchiving.widget.tangoarchivingmodelchooser:TangoArchivingModelSelectorItem`
+  as a model selector item
+
+Plot widget Alternatives
+-----------------------------------
+
+- Description: alternative implementations of TaurusPlot.
+- Group: `taurus.plot.alts`
+- Expected API: *to be formally defined with an Abstract Base Class*. For now,
+  informally, the API is defined by what is used in
+  meth:`taurus.cli.alt.plot_cmd`:  at minimum, a :class:`QWidget` that has a
+  `setModel` that accepts a sequence of attribute names.
+- Entry point name convention: a short descriptive identifier of the
+  implementation (e.g. `"qwt5"`, `"tpg"`, ...). The name is used in the UI for
+  user selection of the implementation.
+- Loading pattern: Extension
+- Enabling pattern: explicit
+- Examples: taurus_pyqtgraph_ registers :class:`taurus_tauruspyqtgraph.TaurusPlot`
+  as a plot alternative
+
+Trend widget Alternatives
+-----------------------------------
+
+- Description: alternative implementations of TaurusTrend
+- Group: `taurus.trend.alts`
+- Expected API:*to be formally defined with an Abstract Base Class*. For now,
+  informally, the API is defined by what is used in
+  meth:`taurus.cli.alt.trend_cmd`:  at minimum, a :class:`QWidget` that has a
+  `setModel` that accepts a sequence of attribute names.
+- Entry point name convention: a short descriptive identifier of the
+  implementation (e.g. `"qwt5"`, `"tpg"`, ...). The name is used in the UI for
+  user selection of the implementation.
+- Loading pattern: Extension
+- Enabling pattern: explicit
+- Examples: taurus_pyqtgraph_ registers :class:`taurus_tauruspyqtgraph.TaurusTrend`
+  as a trend alternative
+
+Image widget Alternatives
+-----------------------------------
+
+- Description: alternative implementations of TaurusImage
+- Group: `taurus.image.alts`
+- Expected API: *to be formally defined with an Abstract Base Class*. For now,
+  informally, the API is defined by what is used in
+  meth:`taurus.cli.alt.image_cmd`:  at minimum, a :class:`QWidget` that has a
+  `setModel` that accepts a sequence of attribute names. At this moment, the
+  widget creator needs to accept the `wintitle` keyword argument (it may change
+  when the API is formalized)
+- Entry point name convention: a short descriptive identifier of the
+  implementation (e.g. `"qwt5"`, `"tpg"`, ...). The name is used in the UI for
+  user selection of the implementation.
+- Loading pattern: Extension
+- Enabling pattern: explicit
+- Examples: `taurus` self-registers its
+  :class:`taurus.qt.qtgui.extra_guiqwt.TaurusImageDialog` as an image widget
+  alternative (see `setup.py`)
+
+Trend2D widget Alternatives
+-----------------------------------
+
+- Description: alternative implementations of TaurusTrend2D
+- Group: `taurus.trend2d.alts`
+- Expected API: *to be formally defined with an Abstract Base Class*. For now,
+  informally, the API is defined by what is used in
+  meth:`taurus.cli.alt.trend2d_cmd`:  at minimum, a :class:`QWidget` that has a
+  `setModel` that accepts a sequence of attribute names. At this moment, the
+  widget creator needs to accept the following keyword arguments: `stackMode`,
+  `wintitle`, `buffersize`. (it may change when the API is formalized)
+- Entry point name convention: a short descriptive identifier of the
+  implementation (e.g. `"qwt5"`, `"tpg"`, ...). The name is used in the UI for
+  user selection of the implementation.
+- Loading pattern: Extension
+- Enabling pattern: explicit
+- Examples: `taurus` self-registers its
+  :class:`taurus.qt.qtgui.extra_guiqwt.TaurusTrend2DDialog` as trend2d widget
+  alternative (see `setup.py`)
+
+Form Factories
+-----------------------------------
+
+- Description: factories for custom "taurus value" widgets to be used in taurus
+  forms. See :meth:`taurus.qt.qtgui.panel.TaurusForm.setItemFactories`
+- Group: `taurus.form.item_factories`
+- Expected API: a factory function that accepts a model name as its first
+  argument and which returns either a :class:`taurus.qt.qtgui.panel.TaurusValue`
+  type object (or `None`)
+- Entry point name convention:
+- Loading pattern: extension
+- Enabling pattern: installation, but allowing explicit (de)selection based
+  on meth:`taurus.core.util.plugin.selectEntryPoints`.
+- Examples: sardana_ registers
+  :func:`sardana.taurus.qt.qtgui.extra_pool.formitemfactory.pool_item_factory`
+  to provide custom widgets for sardana elements in taurus forms.
+
+qtgui submodules
+-----------------------------------
+
+.. note:: This entry point is for internal use only (to be used for backwards
+          compatibility when "outsourcing" submodules).
+
+- Description: adding submodules to :mod:`taurus.qt.qtgui`.
+- Group: `taurus.qt.qtgui`
+- Expected API: python module (typically exposing :class:`QWidget` classes)
+- Entry point name convention: the name must match the module name
+- Loading pattern: Extension (for performance, we use a
+  :class:`taurus.core.util.lazymodule.LazyModule` to delay the actual import
+  of the module until one of its members is actually used).
+- Enabling pattern: installation
+- Examples: taurus_pyqtgraph_ registers itself to be exported as
+  :mod:`taurus.qt.qtgui.tpg`
 
 
 .. _TEP13: http://www.taurus-scada.org/tep?TEP13.md
+.. _taurus_tangoarchiving: https://github.com/taurus-org/taurus_tangoarchiving
+.. _taurus_pyqtgraph: https://github.com/taurus-org/taurus_pyqtgraph
+.. _sardana: https://sardana-controls.org/

--- a/doc/source/tep/TEP13.md
+++ b/doc/source/tep/TEP13.md
@@ -1,6 +1,6 @@
     Title: plugins support 
     TEP: 13
-    State: CANDIDATE
+    State: ACCEPTED
     Date: 2015-03-25
     Drivers: Carlos Pascual-Izarra <cpascual@cells.es>
     URL: http://www.taurus-scada.org/tep?TEP13.md
@@ -335,6 +335,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 - 2016-11-16: [mrosanes][] Adapt TEP format and URL according TEP16
 - 2020-12-11: [cpascual][] Full re-writing of the DRAFT and promotion to 
   CANDIDATE state
+- 2021-03-08: [cpascual][] Promoted from CANDIDATE to ACCEPTED state
   
 [stevedore docs]: https://docs.openstack.org/stevedore/latest/
 [stevedore]: https://pypi.python.org/pypi/stevedore

--- a/doc/source/tep/TEP13.md
+++ b/doc/source/tep/TEP13.md
@@ -41,7 +41,7 @@ The expected benefits are:
 ## Considered implementation options
 
 During the many years since we first discussed this TEP, we studied several 
-alternatives ([yapsy][], pyutilib, [Marty Alchin's 6-line plugin framework][], 
+alternatives (yapsy, pyutilib, Marty Alchin's 6-line plugin framework, 
 ...) but we ended up deciding among using [stevedore][] or using [setuptools][] 
 entry points directly.
 
@@ -338,7 +338,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
   
 [stevedore docs]: https://docs.openstack.org/stevedore/latest/
 [stevedore]: https://pypi.python.org/pypi/stevedore
-[yapsy]: https://pypi.python.org/pypi/Yapsy
+[setuptools]: https://setuptools.readthedocs.io/
 [SEP19]: https://github.com/reszelaz/sardana/blob/sep19/doc/source/sep/SEP19.md
 [pkg_resources]: https://setuptools.readthedocs.io/en/latest/pkg_resources.html
 [ep_spec]: https://packaging.python.org/specifications/entry-points/

--- a/doc/source/tep/TEP13.md
+++ b/doc/source/tep/TEP13.md
@@ -1,345 +1,310 @@
     Title: plugins support 
     TEP: 13
-    State: DRAFT
+    State: CANDIDATE
     Date: 2015-03-25
     Drivers: Carlos Pascual-Izarra <cpascual@cells.es>
     URL: http://www.taurus-scada.org/tep?TEP13.md
     License: http://www.jclark.com/xml/copying.txt
     Abstract:
-     Implement support for managing third-party code 
-     (plugins) to extends Taurus. Identify, document,
-     unify and systematise the various existing 
-     approaches to plugins already found in Taurus, 
-     and provide conventions and tools for creating more
-     entry points in the future.
+     Define the generic rules and APIs for how taurus allows other code 
+     (plugins) to extends Taurus. Describe a single approach that can be used
+     to unify and systematise the various existing plugin mechanisms found 
+     today in Taurus, as well as to create more entry points in the future.
+     Provide a guide for how the pluggable components should be documented
     
 
-IMPORTANT
-=========
 
-This is still in pre-draft stage. For now we are using this this wiki page to collect various preparatory notes in order to write the proper drafts for TEP13
+# Introduction
 
+Over the history of Taurus different mechanisms to support extensions were 
+implemented in various subsystems of Taurus (see APPENDIX I). Most of these 
+mechanisms, being ad-hoc implementations, are quite specific and present 
+limitations such as requiring the plugin to have privileged access to Taurus 
+installation directories, or not having a well defined interface, or not 
+allowing to define dependencies/incompatibilities among plugins.
 
-Introduction
-============
-
-At this moment, different mechanisms to support extensions are already implemented in various subsystems of Taurus (see APPENDIX IV). Most of these mechanisms, being ad-hoc implementations, are quite specific and present limitations such as requiring the plugin to have privileged access to Taurus installation directories, or not having a well defined interface, or not allowing to define dependencies/incompatibilities among plugins.
-
-This situation can be improved by adopting a generic extension mechanism (e.g., [stevedore][] or [yapsy][]) and using it throughout the whole Taurus library.
+This situation can be improved by adopting a generic extension mechanism and 
+using it throughout the whole Taurus library.
 
 The expected benefits are:
 
-- facilitate the maintainability of the code (removing multiple different implementations and APIs)
-- Increase Taurus modularity (since many subpackages that are currently monolithic could be reimplemented as a collection of optional extensions to be loaded on-demand).
-- Sardana would also benefit from an "official" extension API in Taurus (first, by formally registering itself as a taurus extension and second, by using the same API internally for its own plugins.
+- facilitate the maintainability of the code (unifying the current
+  implementations of plugins support in taurus)
+- Increase Taurus modularity (since many subpackages that are currently 
+  monolithic could be reimplemented as a collection of optional extensions to 
+  be loaded on-demand). For example, all tango-centric code in taurus could be 
+  moved to a separate "taurus_tango" plugin project.
+- Sardana would also benefit from an "official" extension API in Taurus (first, 
+  by formally registering itself as a taurus extension and second, by using the 
+  same API internally for its own plugins.
+  
+## Considered implementation options
+
+During the many years since we first discussed this TEP, we studied several 
+alternatives ([yapsy][], pyutilib, [Marty Alchin's 6-line plugin framework][], 
+...) but we ended up deciding among using [stevedore][] or using [setuptools][] 
+entry points directly.
+
+Stevedore is appealing because it provides a well defined formal framework, but
+it introduces a dependency to the `stevedore` module  which is not used by a 
+large number of projects. In contrast, with setuptools having become the 
+de-facto standard for python distribution, its entry-point mechanism is more  
+accessible to the potential plugin developers. In fact, all the recent 
+plugins created for Taurus are already using setuptools entry points directly 
+and hence the decision has been made to use that for this TEP.
+  
+## Note on terminology
+
+Even if we decided not commit to use [stevedore][], we find that the analysis 
+and naming conventions used in its docs are quite useful for describing the 
+various aspects to consider of a plugin system.
+
+We will therefore be using concepts such as "Driver", "Hook", "Extension", 
+"Loading pattern", "Enabling pattern", etc. as defined in the 
+[stevedore docs][].
+
+Also, we will use the term "taurus pluggable component" to refer to a part of 
+the taurus code that is or may be implemented with plugin support. 
+
+## Scope of this TEP
+
+This TEP focuses on providing a generalised solution and convention for 
+supporting the various components of taurus that can be implemented as plugins.
+
+What it is **not** in the scope of this TEP is the implementation of each and 
+all of the possible pluggable interfaces. This is to be treated as future work.
+
+The initial draft of this TEP covered Sardana plugins as well, but this 
+has been now moved out of the scope of this TEP and will be treated by Sardana's 
+[SEP19][]. See also [this comment](https://github.com/sardana-org/sardana/pull/1328#issuecomment-741907800)
+
+# Rules for TEP13-compliant plugins
+
+This proposal covers the following aspects of the plugin support:
+- The plugin interface definition and documentation: how taurus should define 
+and document its pluggable components  
+- The advertising mechanism: how 3rd party code (or taurus itself) can "plug" 
+to a given pluggable interface
+- The internal taurus loading and enabling mechanisms: how taurus should 
+implement the discovery/loading/enabling of the available plugged code
+
+These three aspects are based on [python entry points][ep_spec].
+
+## Plugin interface definition and documentation
+
+For each pluggable component, taurus should define and document the following:
+
+- a description of the component
+- the *entry point group* associated with this pluggable component
+- the API that is expected from the objects to be loaded in this group 
+- the name convention applying to the *entry point names* in this group 
+- the *loading pattern* that will be used
+- the *enabling pattern* that will be used
+
+This information can be documented where it is more appropriate attending to 
+the context (e.g the taurus subcommands entry point mechanism can be 
+documented in the docs of the `taurus.cli` submodule), but it should also be 
+**referenced in a dedicated part of the docs that enumerates and centralizes all 
+the existing extension points provided by taurus** (as of now, this is the 
+[taurus plugins][plugins] page).
+
+The following subsections provide some more details on each required 
+documentation item. 
+
+### Description
+
+A human-readable description of the pluggable component. Can contain links to 
+docs, examples, etc.
+
+### Entry point group
+
+The entry point group is a string that identifies the particular pluggable 
+component in taurus and which follows the syntax rules from the
+[entry_points API][pkg_resources]. To avoid group name collisions, all taurus 
+groups should start with `"taurus."` and then be followed by a preferably short 
+string that identifies the component, and which may use dots for grouping 
+related components.
+
+Some recommendations:
+
+- While the group names may totally or partially match a submodule name, it 
+is not necessarily the case. Descriptive and reasonably short and unambiguous 
+names are preferred over long submodule-matching names. e.g:
+`taurus.form.item_factories` and not `taurus.qt.qtgui.panel.taurusform.item_factories`
+
+- The last part of the name will in general be a plural name, reflecting the
+fact that this is a group of entry points
+
+- For consistency, all-lowercase group names are preferred, but this may be 
+ignored if there is a strong reason against it (e.g. specific context 
+consistency)  
+
+### Expected API
+
+This describes which is the object type /  API that taurus expects from objects 
+loaded in this group. This can be done by referring to a concrete type, or by 
+describing the minimal required object API, but it is probably a good idea to
+formalize the description by providing an [Abstract Base Class][abc].
+
+### Name convention
+
+When a distribution advertises an object of a given group, it must provide a 
+name. This name may be used by taurus while loading or enabling the plugin, 
+and therefore taurus may impose or recommend some rules for that name. 
+
+For example: the alternative implementations for TaurusPlot (`taurus.plot.alts`
+group) can be listed and selected by the user using the advertised name, and 
+therefore taurus expects the name to be a short string identifying the 
+specific implementation.
+
+### Loading pattern
+
+This describes how will the registered object be loaded by taurus.
+It can typically be one of "Driver", "Hook", or "Extension", as described in:
+https://docs.openstack.org/stevedore/latest/user/patterns_loading.html
+
+For example: the schemes in taurus core (`taurus.core.schemes` group) are 
+loaded using the *Drivers* pattern, while the taurus CLI subcommands 
+( `taurus.cli.subcommands` group) are loaded with the *Extensions* pattern
+
+### Enabling pattern
+
+This describes the mechanism by which the registered object will be enabled 
+(or not) in taurus. In other words, a package may advertise objects 
+for a given taurus group, but taurus may or may not make use of those objects.
+
+It can typically be one of "Installation", "Explicit", or "Self-enabled", as
+described in: 
+https://docs.openstack.org/stevedore/latest/user/patterns_enabling.html
+
+It may also provide more details such as which mechanisms are used in the case 
+of the *explicit* or *self-enabled* patterns
+
+For example: the schemes in taurus core (`taurus.core.schemes` group) are 
+enabled by installation, whereas the formatters (`taurus.qt.formatters`) are
+enabled explicitly (e.g. by the user or programmer setting them with 
+`TaurusBaseComponent.setFormatter()`)
+
+## Advertising
+
+Any python module (or more strictly speaking, any python *distribution*) may
+advertise objects for entry point groups defined by Taurus.
+
+In general, this can be done by any means allowed by the [entry points 
+specification][ep_spec], and is typically done with the `entry_points` 
+argument for `setuptools.setup()` (or by defining them in `setup.cfg`), with the
+following syntax: 
+
+`name = some.module:some.attr`
+ 
+where:
+
+- `name` is the entry point name
+- `some.module:some.attr` refers to the object (`:some.attr` may be omitted if 
+referring to a module)
+ 
+Note that a given distribution can advertise objects for more than one group.
+For example, the [taurus_tangoarchiving][] package, which provides support 
+for Tango archiving models, advertises the module itself as a taurus scheme 
+(`taurus.core.schemes` group) and also a model chooser extension widget 
+(`taurus.model_selector.items` group) 
+
+## Implementation of taurus loading and enabling mechanisms
+
+Taurus should use the setuptools' [`pkg-resources` API][pkg_resources] or 
+the [`importlib.metadata`][metadata] equivalent to discover and load the 
+advertised objects.
+
+The specific implementation will depend on each case, but the following general 
+considerations apply:
+
+- performance: since taurus won't have control over 3rd-party code that may 
+advertise its objects, strategies to minimize potential performance hits 
+should be considered (e.g. delay entry point loading until needed, provide 
+mechanisms for selecting available plugins, consider parallelization when 
+loading, etc)
+
+- robustness: since we do not have control over plugin quality, the 
+loading of advertised objects should be protected and allow taurus to fail 
+gracefully if an advertised object fails to load. 
+
+## Full Example
+
+The documentation for "taurus subcommands plugin" is:
+
+- Description: register subcommands for the `taurus` CLI command.
+- Group: `taurus.cli.subcommands`
+- Expected API: [`click.Command`](https://click.palletsprojects.com/en/7.x/api/#click.Command) 
+- Entry point name convention: None, the name is ignored. Suggestion: use the subcommand name 
+- Loading pattern: extension
+- Enabling pattern: installation
+
+Now, if a module called `foo_mod` implements a `click`-based command as 
+the `foo_mod.cli.foo` object and wants it exposed by Taurus as a subcommand of 
+the `taurus` command, it can achieve it by using the following code in its 
+`setup.py`:
+
+```
+import setuptools
+
+entry_points = {}
+...
+entry_points["taurus.cli.subcommands"] = ["foo = foo_mod.cli:foo"]
+
+setuptools.setup(
+    entry_points=entry_points,
+    ...
+)
+```
+
+The implementation in this case is done by the `taurus.cli.` module, which 
+iterates over the advertised entry points for the `taurus.cli.subcommands` group
+and safely loads them only when the `taurus` command is executed in the CLI.
 
 
-Goals and constraints
-=====================
+# Existing TEP13-compliant plugins
 
-(To be written)
+At the moment of writing, taurus already supports the following pluggable 
+components that comply to this TEP rules (for details, check the 
+[taurus plugins documentation][plugins])
 
-APPENDIX I: Notes on terms and concepts used
-============================================
-
-Regardless of which solution we end up proposing in the draft, we find that the analysis and naming conventions used in the [stevedore docs][] are quite useful for analising the various aspects to consider of a plugin system.
-
-We will therefore be using concepts such as "Driver", "Hook", "Extension", "Loading pattern", "Enabling pattern", etc. as defined in the [stevedore docs][].
-
-More specifically, you should read the following parts of stevedore docs:
-
-First an overview of what was out there in 2013:
-
-- [discovery](http://docs.openstack.org/developer/stevedore/essays/pycon2013.html#discovery)
-- [enabling](http://docs.openstack.org/developer/stevedore/essays/pycon2013.html#enabling)
-- [importing](http://docs.openstack.org/developer/stevedore/essays/pycon2013.html#importing)
-- [integration](http://docs.openstack.org/developer/stevedore/essays/pycon2013.html#application-plugin-integration)
-- [api-enforcement](http://docs.openstack.org/developer/stevedore/essays/pycon2013.html#api-enforcement)
-- [invocation](http://docs.openstack.org/developer/stevedore/essays/pycon2013.html#invocation)
-
-And then some more formal description of patterns:
-
-- [Loading Pattern](http://docs.openstack.org/developer/stevedore/patterns_loading.html)
-- [Enabling Pattern](http://docs.openstack.org/developer/stevedore/patterns_enabling.html)
-
-APPENDIX II: Notes on basic considerations when evaluating a solution
-=====================================================================
-
-What we look for in a plugin system:
-
-- able to handle all existing and foreseen entry points in Taurus and Sardana
-- not adding dependencies (as yapsy), ... or embedable... or as a worst case, adding light well-known, well supported deps (e.g. setuptools in the case of stevedore)
-- well supported (if it is external) or simple enough to self-support
-- must allow 3rd parties to provide plugins that can be installed, discovered, enabled, etc. without assuming direct coordination between the 3rd party and the sardana/Taurus authors
-
-APPENDIX III: Possible candidates being explored
-=================================================
-
-- [stevedore][]
-- [yapsy][]
-- PCA (pyutilib component architecture) from [pyutilib](https://software.sandia.gov/trac/pyutilib)
-- [Marty Alchin's 6-line plugin framework](http://martyalchin.com/2008/jan/10/simple-plugin-framework/)
-- Custom implementation
-
-APPENDIX IV: List of (potential) plugin systems in Taurus and Sardana
-=====================================================================
-
-The following is a list of Taurus & Sardana subsistems or APIs which are already implemented as plugins or which may benefit from being implemented as plugins.
-
-Each system/API is described according to the following template:
-
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-<System/API name>
-------------------
-- **Description:** <what does it provide?>
-- **Pointer**: <Path(s)/entry point(s) in current code where it is implemented>
-- **Existing plugins**: <which plugins are already available for this system?>
-- **Foreseen plugins**: <which plugins would we want to be implemented for this system?>
-- **Current discovery method**: <explicit VS scanned? ... File Path VS Py Object Name?>
-- **Current activation method**: <explicit VS installation VS self-enabled>
-- **Proposed Loading Patterns**: <Driver VS Hook VS Extension>
-- **Proposed Enabling Patterns**: <explicit VS installation VS self-enabled>
-- **Priority**: <MoSCoW-style priotization for this system to be adapted to sep13>
-- **Notes**: <anything worth mentioning and not covered above>
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Schemes
--------
-- **Description**: access abstraction to data sources via data models
-- **Pointer**: taurus.core (taurus factory, helper, etc. Refer to [SEP3](https://sourceforge.net/p/sardana/wiki/SEP3/))
-- **Existing plugins**: Tango, Eval, Epics, Spec, Simulation
-- **Foreseen plugins**: Hdf5, Ascii tables, xls/ods files, SQL, archiving, ...
-- **Current discovery method**: Path based. Uses both scanning and explicit (via tauruscustomsettings.SCHEMES)
-- **Current activation method**: self-enabled (based on availability of 3rd party modules)
-- **Proposed Loading Patterns**: Drivers 
-- **Proposed Enabling Patterns**: installation (maybe with the possibility of explicitly disabling them to save resources?)
-- **Priority**: Should
-
-Codecs
-------
-- **Description:** Codecs for the DEV_ENCODED data type
-- **Pointer**: taurus.core.util.codecs
-- **Existing plugins**: Null, Zip, BZ2, Pickle, Json, VideoImage (Lima),...
-- **Foreseen plugins**: ?
-- **Current discovery method**: scan import reference (functions defined in taurus.core.util.codecs)
-- **Current activation method**: install
-- **Proposed Loading Patterns**: Driver
-- **Proposed Enabling Patterns**: installation
-- **Priority**: Would
-
-widgets
--------
-- **Description:** adding new widgets, e.g. sardana's TaurusMacroExecutor
-- **Pointer**: subdirs of taurus.qt.qtgui (except those that do not define QWidget-derived classes, such as base, test, ui,...)
-- **Existing plugins**: all submodules of taurus.qt.qtgui which define classes that inherit from QWidget could be considered as plugins of this type. Still some widgets can be considered more "core" than others (e.g. those in the extra_XXXX subdirs are already considered "optional"). Also, sardana already defines several plugins of this type in its sardana.taurus.qt.qtgui module.
-- **Foreseen plugins**: any taurus widget of sufficient general interest that someone may want to share
-- **Current discovery method**: scan import reference 
-- **Current activation method**: installation and in some cases self-enabled (based on availability of 3rd party modules)
-- **Proposed Loading Patterns**: Extension
-- **Proposed Enabling Patterns**: self-enabled
-- **Priority**: Should
-
-external modules
-------------------
-- **Description:** modules that unify APIs from 3rd party modules (e.g. provide a common access to PySide and PyQt, or to unittest across the various supported versions of Python, etc)
-- **Pointer**: taurus.external
-- **Existing plugins**: argparse, enum, ordereddict, pint, qt, unittest
-- **Foreseen plugins**: any dependency that requires backporting for some version of Python supported by Taurus
-- **Current discovery method**: scan import reference
-- **Current activation method**: installation
-- **Proposed Loading Patterns**: Extension
-- **Proposed Enabling Patterns**: installation
-- **Priority**: would
-
-Tango FactoryExtension API
---------------------------
-- **Description:** API for (un)registering custom classes to be returned by the factory when a Device or Attribute is requested. These are based on the Tango Device Class name and the tango attribute.
-- **Pointer**: TangoFactory.{un,}register{Device,Attribute}Class methods (note, previous to SEP3, this was implemented at the TaurusFactory level, but it is moved to tango scheme folder by SEP3). 
-- **Existing plugins**: 
-    - those registered by spock: SpockMacroServer, QSpockDoor, SpockDoor
-    - those registered by
-      sardana.taurus.core.tango.sardana.macroserver.registerExtensions():  
-      MacroServer, Door,...
-    - those registered by sardana.taurus.core.tango.sardana.pool.registerExtensions():
-      Pool, Controller, ComChannel, Motor,...
-    - those registered by taurus.core.tango.img.registerExtensions(): PyImageViewer,
-      ImgGrabber, Falcon,...
-- **Foreseen plugins**: ?
-- **Current discovery method**: explicit import reference
-- **Current activation method**: self-enabled
-- **Proposed Loading Patterns**: Driver
-- **Proposed Enabling Patterns**: explicit
-- **Priority**: could
-- **Notes**: the {un,}registerAttributeClass methods are implemented but they do not seem to be used at all yet (only the {un,}registerDeviceClass are)
-
-The TaurusModelChooser widget (support for non-tango schemes)
--------------------------------------------------------------
-- **Description:** The ModelChooser uses a TaurusDbTreeWidget which is, 
-  nowadays, Tango-centric. Other schemes may define alternative 
-  widgets to interact with their models (e.g. the eval scheme may provide
-  an eval attribute editor)
-- **Pointer**: .../qtgui/panel/taurusmodelchooser.py (see also
-  taurus.qt.qtgui.panel.QRawDataWidget which is used in plots together with
-  TaurusModelChooser)
-- **Existing plugins**: TaurusDbTreeWidget (and its associated QModel), 
-- **Foreseen plugins**: Evaluation Attribute editor
-- **Current discovery method**: N/A
-- **Current activation method**: N/A
-- **Proposed Loading Patterns**: Extension
-- **Proposed Enabling Patterns**: installation (with scheme)
-- **Priority**: Could
-- **Notes**: Apart from allowing certain schemes to provide an extension for 
-  the ModelChooser, it would be wise to implement a scheme-agnostic Tree View Widget
-
-Icons
--------
-- **Description**: adding icons for the standard Taurus icon catalog
-- **Pointer**: implemented in taurus.qt.qtgui.resource. Also "build_resources" command from setup.py
-- **Existing plugins**: tango-icons, rrze-icons, external, extra-icons, large
-- **Foreseen plugins**: icon folders added by other plugins (e.g. sardana-icons)
-- **Current discovery method**: Path based. Scanning (at install time) the subdirs of...gtgui/resource/ to generate qrc and rcc files that are later used used by the methods in taurus.qt.qtgui.resource.taurus_resource_utils
-- **Current activation method**: install
-- **Proposed Loading Patterns**: Extension 
-- **Proposed Enabling Patterns**: installation
-- **Priority**: Could
-- **Notes**: There have been informal talks about implementing direct load of icons instead of using qrc/rcc files. This may affect the design of this plugin system.
-
-Loggers
--------
-- **Description**: Set the Taurus logger system (multiples loggers could be registered). 
-- **Pointer**:  taurus.core.util.log, taurus.core, taurus.qt (refer to [TEP8](http://www.taurus-scada.org/tep?TEP8.md))
-- **Existing plugins**:  Taurus logger only
-- **Foreseen plugins**: loggers from external applications using Taurus, custom loggers, ...
-- **Current discovery method**: Not discovered. Hardcoded in  taurus.core.util.log
-- **Current activation method**: Not activated. TEP8 implementation proposes explicit mechanism, via tauruscustomsetting variable (ENABLE_TAURUS_LOGGER)
-- **Proposed Loading Patterns**: Hook 
-- **Proposed Enabling Patterns**: Explicit
-- **Priority**: Could
-- **Notes**:  The Taurus models use the Factory pattern, which creates Mementos for logged events, so the use of a Logger is a requirement.
-
-TestSuite
--------
-- **Description:** The unit test infrastructure (Implemented in [SEP5](https://sourceforge.net/p/sardana/wiki/SEP5/)). New tests for features or modules can be added. Particular tests may be (de)activated dynamically.
-- **Pointer**:  taurus.test and test submodules of taurus modules.
-- **Existing plugins**: all "test" submodules taurus modules
-- **Foreseen plugins**: New tests.
-- **Current discovery method**: unittest discovery (started from test suite in taurus.test)
-- **Current activation method**: installation, explicit defined via variable in taurus custom settings, and in some cases self-enabled (based on availability of resources, or execution conditions. e.g.  Taurus Qt tests (widgets) are not executed if the X is not exported.
-- **Proposed Loading Patterns**: Extension
-- **Proposed Enabling Patterns**: self-enabled (e.g. based on the activation of other plugins or availability of resources), explicit (white/black lists could be used to deactivate certain tests).
-- **Priority**: Could
-- **Notes**:  The tests could be grouped by feature/module. e.g. taurus.core.test, taurus.core.tango, taurus.qt.qtgui.panel, etc. (maybe using particular test suites)
-
-Macros
-------------------
-- **Description:** adding new macros to the MacroServer 
-- **Pointer**: Paths set in MacroPath property of the MacroServer Device. (Class MacroManager: msmacromanager.py )
-- **Existing plugins**: specific macros
-- **Foreseen plugins**: all macros which are not provided by Sardana
-- **Current discovery method**: Path based. Scanning the directories listed in the MacroPath property of the MacroServer
-- **Current activation method**: Explicit (when the macro is executed).
-- **Proposed Loading Patterns**: Drivers
-- **Proposed Enabling Patterns**: Explicit
-- **Priority**: Should
-- **Notes**: 
+- `taurus.cli.subcommands` (click subcommands for the taurus command)
+- `taurus.core.schemes` (new schemes in taurus.core to support other sources of data)
+- `taurus.qt.qtgui` (adding submodules to taurus.qt.qtgui)
+- `taurus.qt.formatters` (formatter objects for taurus widgets)
+- `taurus.model_selector.items` (items for `TaurusModelSelector`)
+- `taurus.plot.alts` (alternative implementations of `TaurusPlot`)
+- `taurus.trend.alts` (alternative implementations of `TaurusTrend`)
+- `taurus.trend2d.alts` (alternative implementations of `TaurusTrend2D`) 
+- `taurus.image.alts`  (alternative implementations of `TaurusImage`)
+- `taurus.form.item_factories` (factories for custom "taurus value" widgets to 
+be used in taurus forms)
 
 
-Controllers
-------------------
-- **Description:** adding new controller libraries to the Pool.  
-- **Pointer**: Paths set in PoolPath property of the Pool Device  (Class ControllerManager: poolcontrollermanager.py)
-- **Existing plugins**: specific controllers which are not distributed by default. 
-- **Foreseen plugins**: all controllers which are not provided by Sardana.
-- **Current discovery method**: Path based. Scanning the directories listed in the PoolPath property of the PoolDevice
-- **Current activation method**: Explicit (when an instance is created)
-- **Proposed Loading Patterns**: Drivers
-- **Proposed Enabling Patterns**: Explicit
-- **Priority**: Should
-- **Notes**: 
+# Future work
+
+The following is non-exhaustive list of taurus components that may benefit from 
+being refactored according to this TEP. Some are currently plugabble using an 
+ad-hoc (non TEP13-compliant) mechanism while others are not yet pluggable at 
+all. The proposed "group name" is only tentative, and subject to change on 
+implementation: 
+
+- adding new codecs as those in `taurus.core.util.codecs`
+- extending `taurus.core.util.eventfilter`
+- refactoring the `TaurusFactory.registerDeviceClass` (and related) mechanisms
+- adding entries to the panel catalog in a TaurusGUI
+- adding pages to the the `AppSettingsWizard` (e.g. the sardana-related page 
+should be provided by `sardana`)
+- adding icons for the standard Taurus icon catalog
+- ...
 
 
-Recorders
-------------------
-- **Description:** adding new recorders to the MacroServer.  
-- **Pointer**: Paths set in RecorderPath property of the MacroServer Device (**TODO**: point to relevant modules involved in the implementation)
-- **Existing plugins**: Spec, Json, NXscan, NXsax, FIO, output, SharedMemory, ... 
-- **Foreseen plugins**: Other specific recorders which are not provided by default. 
-- **Current discovery method**: Path based. Scanning the folder (no the subdirs)
-- **Current activation method**: Explicit (The output recorder is active by default)
-- **Proposed Loading Patterns**: Extension 
-- **Proposed Enabling Patterns**: Explicit
-- **Priority**: Should
-- **Notes**:  More information ticket: https://sourceforge.net/p/sardana/tickets/380/
+# Links to more details and discussions
+
+The implementation and discussion is done in the PR associated to this TEP
 
 
-
-
-
-(APIs/Sytems to be expanded with the above template)
-----------------------------------------------------
-- <s>schemes (adding new taurus.core schemes)</s>
-- <s>codecs (extend taurus.core.util.codecs)</s>
-- <s>widgets (adding new widgets, e.g. sardana's TaurusMacroExecutor)</s>
-- <s>external modules (unifying interfaces e.g. taurus.external.unittest, or taurus.external.qt)</s>
-- <s>Tango FactoryExtension API (API of TaurusFactory, used e.g. in sardana.taurus.core.tango.sardana.pool)</s>
-- Extendable Taurus widgets: some Taurus widgets may provide entry
-  points to be extended:
-    - <s>The ModelBrowser widget (each scheme may provide an extension to support
-       browsing/selection of its models)</s>
-    - The entries in the panel catalog (when selecting "new panel" in a TaurusGUI)
-    - The pages of the new-gui wizard (e.g. the sardana-related page should be 
-      provided by sardana)
-    - TaurusForm's Custom Widget Map (see tauruscustomsettings.T_FORM_CUSTOM_WIDGET_MAP)
-    - Choice of alternative subwidgets in TaurusValue (see mechanism from 
-      TaurusValue.getDefaultXXXXWidgetClass())
-    - ...
-- <s>Icons (adding icons for the standard Taurus icon catalog)</s>
-- EventFilters (extend taurus.core.util.eventfilter)
-- <s>Loggers (consider this in relation to [SEP8](https://sourceforge.net/p/sardana/wiki/SEP8/))</s>
-- <s>testsuite (may be interesting for enabling/disabling certain tests in the testsuite... </s>
-  (e.g for substituting the lib.taurus.test.skip mechanism)
-- Qt Designer Pluggins (see https://sourceforge.net/p/tauruslib/tickets/144/)
-- Synoptic extensions (e.g., jdraw allows to declare custom extensions...)
-- Plot mechanisms (maybe too ambitious... but plugins could be used to provide the 
-  plotting... like PyMca5 does when abstracting access to switch from pyqtgraph and
-  matplotlib backends)
-- The mechanism for loading/installing specific TaurusGUI (using `taurusgui <modulename>`)
-  could based on plugins (maybe only if the plugin system is coupled with the installation
-  system as in stevedore)
-- widgets backend (e.g. taurus.qt VS taurus.web VS taurus.gtk,...) 
-  Ideally, we could define a set of basic Taurus building blocks such as TaurusForm, 
-  Taurus Label, TaurusPlot, TaurusGui,...etc and make them "back-end agnostic" so 
-  that  a Taurus GUI app could be defined transparently and be ported to any 
-  of those back-ends. This sounds nice but it means a huge refactoring and may meet 
-  many practical issues, so for the moment it is not to be considered.
-
-Sardana:
-
-- <s>macros (discovering 3rd party macros)</s>
-- <s>controllers (discovering 3rd party controllers)</s>
-- <s>recorders (registering recorders. see gscan's  of DataHandler.addRecorder() )</s>
-- custom macro executor widgets (see 
-  sardana.taurus.qt.qtgui.extra_macroexecutor.macroparameterseditor.customeditors)
-- hook API for macros? (maybe it makes sense defining the hookpoints of macros as 
-  internal entry points)
-- macro execution clients (does it make sense to define an entry point for the 
-  macro execution clients (e.g. spock vs TaurusMacroExecutor))
-- spock support for diffferent versions of ipython (i.e. the code forks in the 
-  genutils submodule).
-- spock's InputHandler support/selection (see sardanacustomsettings.SPOCK_INPUT_HANDLER)
-
-
-
-
-Links to more details and discussions
-=====================================
-
-The main discussions for this SEP take place in the [sardana-devel mailing list](https://sourceforge.net/p/sardana/mailman/).
-
-This SEP uses concepts and nomenclature from the [stevedore docs](http://docs.openstack.org/developer/stevedore/index.html)
-
-License
-=======
+# License
 
 Copyright (c) 2015  Carlos Pascual-Izarra
 
@@ -362,13 +327,25 @@ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-Changes
-=======
-* 2015-10-15: [cpascual](https://sourceforge.net/u/cpascual/) Moved pre-draft notes from [sardana:wiki:SEP13]
-* 2015-01-27: [cpascual](https://sourceforge.net/u/cpascual/) 
+# Changes
+
+- 2015-10-15: [cpascual][] Moved pre-draft notes from [sardana:wiki:SEP13]
+- 2015-01-27: [cpascual][] 
   Initial pre-draft notes collection started
-* 2016-11-16: [mrosanes](https://github.com/sagiss/) Adapt TEP format and URL according TEP16
+- 2016-11-16: [mrosanes][] Adapt TEP format and URL according TEP16
+- 2020-12-11: [cpascual][] Full re-writing of the DRAFT and promotion to 
+  CANDIDATE state
   
-[stevedore docs]: http://docs.openstack.org/developer/stevedore/index.html
+[stevedore docs]: https://docs.openstack.org/stevedore/latest/
 [stevedore]: https://pypi.python.org/pypi/stevedore
 [yapsy]: https://pypi.python.org/pypi/Yapsy
+[SEP19]: https://github.com/reszelaz/sardana/blob/sep19/doc/source/sep/SEP19.md
+[pkg_resources]: https://setuptools.readthedocs.io/en/latest/pkg_resources.html
+[ep_spec]: https://packaging.python.org/specifications/entry-points/
+[metadata]: https://docs.python.org/3/library/importlib.metadata.html
+[plugins]: http://taurus-scada.org/devel/plugins.html
+[abc]: https://docs.python.org/3/library/abc.html
+[taurus_tangoarchiving]: https://github.com/taurus-org/taurus_tangoarchiving
+[cpascual]: https://github.com/cpascual/
+[mrosanes]: https://github.com/sagiss/
+


### PR DESCRIPTION
This PR provides a CANDIDATE version of TEP13 (plugins support), including a complete re-writing of the TEP itself based on the existing "pre-draft" version and a full documentation of existing entry-point based plugins in the taurus docs, consistent with the prescriptions of the TEP13.

Please @taurus-org/integrators , can you have a look at it and cast a vote on passing this to ACCEPTED state?
